### PR TITLE
Support old Pi update fallback

### DIFF
--- a/.tickets/tlht-qcce.md
+++ b/.tickets/tlht-qcce.md
@@ -1,0 +1,22 @@
+---
+id: tlht-qcce
+status: closed
+deps: []
+links: []
+created: 2026-05-19T14:23:30Z
+type: bug
+priority: 1
+assignee: Diego Petrucci
+---
+# Support old Pi update CLI in default extension refresh
+
+Make the TLH installer refresh bundled default extensions without requiring users to upgrade an already-installed older Pi runtime. Keep the modern settings-wide refresh path when available, but ensure fallback per-source refreshes use the positional update form supported by older Pi.
+
+## Design
+
+The observed old Pi rejects 'pi update --extensions' and 'pi update --extension <source>' but accepts 'pi update [source]'. The installer already treats the settings-wide '--extensions' refresh as best-effort; use the positional source form for per-source fallback because newer Pi documents that form too.
+
+## Acceptance Criteria
+
+Installer commands always set PI_CODING_AGENT_DIR for the isolated profile. If 'pi update --extensions' is unsupported, the installer retries non-critical bundled defaults with 'pi update <source>' and can complete without requiring a Pi upgrade. Existing modern batch behavior remains covered. Tests cover the old-CLI fallback and expected command shapes.
+

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -790,7 +790,7 @@ function installCriticalDefaultExtension(config, source) {
 function updateDefaultExtensionSourceBestEffort(config, source) {
 	verboseLog(config, `Installing bundled default extension package: ${source}`);
 	try {
-		runIsolatedPi(config, ["pi", "update", "--extension", source]);
+		runIsolatedPi(config, ["pi", "update", source]);
 		return true;
 	} catch {
 		warn(`default extension package update failed; continuing: ${source}`);

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -253,7 +253,7 @@ test("stage-1 batches non-critical default extension updates", (t) => {
 	assertPiCommands(piLog, agentDir, ["update --extensions"]);
 });
 
-test("stage-1 falls back to best-effort per-source non-critical updates when batch update fails", (t) => {
+test("stage-1 falls back to old-CLI positional per-source non-critical updates when batch update fails", (t) => {
 	const criticalSource = "git:github.com/example/critical";
 	const defaults = [
 		{ id: "critical", critical: true, source: criticalSource },
@@ -269,11 +269,15 @@ test("stage-1 falls back to best-effort per-source non-critical updates when bat
 			"\tprintf 'batch failed\\n' >&2",
 			"\texit 42",
 			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" && \"${3:-}\" == \"npm:helper-a\" ]]; then",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" ]]; then",
+			"\tprintf 'old pi does not support --extension\\n' >&2",
+			"\texit 98",
+			"fi",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-a\" ]]; then",
 			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-a.done\"",
 			"\texit 0",
 			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" && \"${3:-}\" == \"npm:helper-b\" ]]; then",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-b\" ]]; then",
 			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-b.attempted\"",
 			"\tprintf 'helper-b failed\\n' >&2",
 			"\texit 43",
@@ -289,8 +293,8 @@ test("stage-1 falls back to best-effort per-source non-critical updates when bat
 
 	assertPiCommands(piLog, agentDir, [
 		"update --extensions",
-		"update --extension npm:helper-a",
-		"update --extension npm:helper-b",
+		"update npm:helper-a",
+		"update npm:helper-b",
 		"install git:github.com/example/critical",
 	]);
 	assert.match(stderr, /warning: settings-wide extension refresh from merged settings failed; falling back to per-source updates for only 2 non-critical bundled default source\(s\)/);


### PR DESCRIPTION
## Summary
- use positional `pi update <source>` for bundled default-extension fallback so older Pi installs can continue
- keep the modern settings-wide `pi update --extensions` refresh path
- add installer tests covering old-CLI fallback command shapes

## Validation
- `node --test tests/install-stage1.test.mjs`
- developer also ran: `node --check scripts/tlh-install.mjs`, `bash -n install.sh`, `bash scripts/check-installer-smoke.sh`, `node scripts/merge-settings.mjs --dry-run`, `npm pack --dry-run`, `git diff --check`

Ticket: `tlht-qcce`