### PR TITLE
Add session learnings backlog tickets

### DIFF
--- a/.tickets/tlhf-2yiy.md
+++ b/.tickets/tlhf-2yiy.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-2yiy
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: bug
+priority: 0
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Prevent subagent output=false from creating repo-root false
+
+Investigate and fix the TLH/pi-subagents output handling path where boolean output: false can be treated as the string path false, creating an unintended repository-root file named false. Scope includes the local integration/wrapper surface needed for TLH sessions.
+
+## Design
+
+Start by reproducing with the narrowest subagent invocation that uses output: false. The fix should preserve intentional file outputs and file-only outputs while ensuring boolean false disables artifact writing.
+
+## Acceptance Criteria
+
+No subagent invocation with output: false writes a file named false in the cwd or repo root; a regression test or smoke check covers the failure; existing intentional output path behavior still works; final status shows no root false artifact.
+

--- a/.tickets/tlhf-ewii.md
+++ b/.tickets/tlhf-ewii.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-ewii
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: bug
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Codify critical default-extension invariants
+
+Strengthen tests/docs around critical default extensions such as subagents and intercom so installer/settings/defaults changes cannot silently remove architect delegation or escalation support.
+
+## Acceptance Criteria
+
+Tests document that critical defaults cannot be disabled silently by package filters or opt-out state; critical sources remain validated after settings-wide refresh/fallback paths; docs state the invariant and intended user-facing failure behavior.
+

--- a/.tickets/tlhf-ffn9.md
+++ b/.tickets/tlhf-ffn9.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-ffn9
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: task
+priority: 3
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Add high-risk design escalation guidance
+
+Update TLH workflow guidance so filesystem/PATH/temp-file/security-sensitive changes get an explicit design checkpoint before implementation, preferably using oracle only when the user agrees.
+
+## Acceptance Criteria
+
+Guidance identifies high-risk triggers such as symlink/TOCTOU, PATH resolution, installer profile isolation, and temp file writes; it asks for a short design review before implementation; it preserves the rule that oracle is only used with user consent.
+

--- a/.tickets/tlhf-fkxm.md
+++ b/.tickets/tlhf-fkxm.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-fkxm
+status: open
+deps: [tlhf-2yiy]
+links: []
+created: 2026-05-19T20:37:35Z
+type: feature
+priority: 2
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Improve subagent and intercom report UX defaults
+
+Reduce session noise from giant subagent/intercom cards and verbose report artifacts by improving default rendering/report behavior while preserving access to full details.
+
+## Acceptance Criteria
+
+Incoming subagent/intercom reports are compact or collapsed by default where supported; full content remains accessible; output-file guidance avoids accidental repo artifacts; tests or docs cover the expected compact behavior.
+

--- a/.tickets/tlhf-hkxd.md
+++ b/.tickets/tlhf-hkxd.md
@@ -1,0 +1,18 @@
+---
+id: tlhf-hkxd
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: epic
+priority: 1
+assignee: Diego Petrucci
+---
+# Session learnings improvement backlog
+
+Backlog created from reviewing the last 10 days of TLH sessions for this repository. Tracks recurring failures/stumbles and improvement work without implementing the fixes on this ticket-only branch.
+
+## Acceptance Criteria
+
+Child tickets exist for each identified improvement area; this branch contains ticket metadata only; implementation happens in separate focused branches.
+

--- a/.tickets/tlhf-oxht.md
+++ b/.tickets/tlhf-oxht.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-oxht
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Centralize safe TLH profile file writes
+
+Reduce repeated TOCTOU/symlink/temp-path mistakes by designing and adopting one shared helper for safety-critical writes inside the isolated TLH profile. Candidate call sites include settings, keybindings/state, managed tk, managed Gnosis, backups, and installer support/state files.
+
+## Design
+
+The helper should validate against the intended isolated agent root, reject normal ~/.pi/agent, avoid predictable temp paths, avoid following symlinks, validate parent/final identities as far as Node allows, and clean up only paths proven to be helper-owned.
+
+## Acceptance Criteria
+
+A shared helper or clearly documented pattern exists; at least the highest-risk existing write paths use it or have follow-up tickets; adversarial tests cover symlinked parents, swapped parents where practical, predictable temp path pre-creation, cleanup safety, and normal Pi no-mutation.
+

--- a/.tickets/tlhf-wkp5.md
+++ b/.tickets/tlhf-wkp5.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-wkp5
+status: open
+deps: []
+links: []
+created: 2026-05-19T20:37:35Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Add mandatory final hygiene checklist
+
+Update TLH agent/reviewer/developer guidance so final handoff checks consistently catch recurring process mistakes: untracked files, missing support files, root false artifacts, package manifests, and pack/smoke drift.
+
+## Acceptance Criteria
+
+Relevant AGENTS/agent prompt/docs guidance requires git status --short --untracked-files=all; checks for no root false artifact; confirms required new files are tracked and included in installer/package manifests when applicable; keeps guidance concise and non-invasive.
+


### PR DESCRIPTION
## Summary\n- Add a ticket-only backlog from the last 10 days of TLH session review\n- Track recurring issues around output=false artifacts, safe profile writes, final hygiene, critical defaults, high-risk design review, and report UX\n- Leave implementation for separate focused branches\n\n## Validation\n- tk show tlhf-hkxd\n- git status --short --untracked-files=all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal ticket documentation for tracking planned bug fixes, features, and process improvements across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->