### PR TITLE
Update subagents pin for false output fix

### DIFF
--- a/.tickets/tlhf-2yiy.md
+++ b/.tickets/tlhf-2yiy.md
@@ -1,6 +1,6 @@
 ---
 id: tlhf-2yiy
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-05-19T20:37:35Z

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -82,7 +82,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.24.2-5",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.24.2-6",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {


### PR DESCRIPTION
## Summary
- Update bundled `pi-subagents` default pin to `tlh-v0.24.2-6`, which treats `output: false` and `"false"` as disabled output instead of `<cwd>/false`
- Close `tlhf-2yiy` after implementation/review

## Dependencies
- Builds on merged PR #9, which introduced `tlhf-2yiy`
- External fix PR: https://github.com/diegopetrucci/pi-subagents/pull/1
- Remote tag exists: `diegopetrucci/pi-subagents@tlh-v0.24.2-6` -> `4018a63`

## Validation
Developer ran:
- `node --experimental-strip-types --import ./test/support/clear-profile-env.mjs --test test/unit/single-output.test.ts` in `pi-subagents`
- `npm run test:unit` in `pi-subagents`
- `/opt/homebrew/opt/node@22/bin/node --experimental-transform-types --import ./test/support/clear-profile-env.mjs --import ./test/support/register-loader.mjs --test test/integration/fork-context-execution.test.ts` in `pi-subagents`
- `npm test`
- `npm run lint`
- `node scripts/merge-settings.mjs --dry-run`
- `bash scripts/check-installer-smoke.sh`
- `npm pack --dry-run`
- `git status --short --untracked-files=all && test ! -e false`

Reviewer confirmed no remaining issues.
