### PR TITLE
Centralize TLH profile safe writes

### DIFF
--- a/.tickets/tlhf-etnw.md
+++ b/.tickets/tlhf-etnw.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-etnw
+status: closed
+deps: []
+links: []
+created: 2026-05-19T21:26:47Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Add script-side TLH profile safe-write helper
+
+Add or extend a shared helper in scripts/lib/tlh-install-paths.mjs for writes inside the isolated TLH agent profile. Prefer root-relative profile targets while preserving needed legacy absolute settings paths.
+
+## Design
+
+Use best-effort portable Node hardening: reject normal ~/.pi/agent; reject symlinked parent components and final symlinks; use mkdtemp under the target parent plus exclusive temp/backup creation; revalidate parent/final identity before rename; only clean up helper-owned temp dirs/files. Document residual TOCTOU risk where Node cannot provide openat/renameat-style anchoring.
+
+## Acceptance Criteria
+
+Helper supports top-level profile files and existing support-file targets; intentional dry-run/read-only flows remain unaffected; normal ~/.pi/agent is rejected; adversarial helper tests cover symlinked parent/final file, predictable temp pre-creation, backup collision/symlink, cleanup ownership, failed-write preservation, and residual-risk documentation/commenting.
+

--- a/.tickets/tlhf-geay.md
+++ b/.tickets/tlhf-geay.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-geay
+status: closed
+deps: [tlhf-gsew]
+links: []
+created: 2026-05-19T21:26:47Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Validate narrowed safe-write migration
+
+Add/adjust integration coverage and run project validation for the narrowed tlhf-oxht implementation.
+
+## Design
+
+Prefer existing test files for CLI flows and one focused helper test file if useful. Include the deferred-scope follow-up ticket tlhf-gqbg in final reporting rather than implementing deferred work.
+
+## Acceptance Criteria
+
+Tests cover rejected ~/.pi/agent, symlinked parents/final settings file, predictable temp path pre-creation, backup collision/symlink safety, failed write preservation, dry-run creates nothing, and support-copy cleanup ownership where practical; existing installer smoke/lint/merge dry-run/npm pack validations pass; root false artifact remains absent; tlhf-oxht can be closed.
+

--- a/.tickets/tlhf-gqbg.md
+++ b/.tickets/tlhf-gqbg.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-gqbg
+status: open
+deps: [tlhf-oxht]
+links: []
+created: 2026-05-19T21:25:52Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlhf-hkxd
+---
+# Evaluate remaining TLH profile write hardening
+
+Follow up on safe-write coverage deferred from tlhf-oxht. Consider whether to harden runtime TS extension writes, managed Gnosis binary install, wrapper/bin writes, tlh-update flows, and any future managed tk profile writes. Decide which deserve implementation tickets versus documentation/no-op.
+
+## Design
+
+Do not bundle this with the first script-side safe-write helper. Treat wrapper/bin writes as a separate managed-file problem outside the TLH profile. Runtime extension writes need their own compatibility review.
+
+## Acceptance Criteria
+
+Deferred write categories are audited; concrete follow-up tickets are created for any high-value remaining hardening; decisions to defer/no-op are documented; no source implementation is included in this ticket.
+

--- a/.tickets/tlhf-gsew.md
+++ b/.tickets/tlhf-gsew.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-gsew
+status: closed
+deps: [tlhf-etnw]
+links: []
+created: 2026-05-19T21:26:47Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Migrate high-risk script profile writes to helper
+
+Adopt the shared profile write helper for the first-scope script-side writes: merge-settings, merge-keybindings, tlh-defaults, tlh-gnosis settings writes only, tlh-install-state, tlh-install settings pre-install backup, and copySafeProfileFile support copies.
+
+## Design
+
+Do not change merge semantics, opt-out behavior, Gnosis binary install behavior, wrapper/bin writes, or runtime extension writes. Ensure installed helper scripts can import any shared lib they need from the isolated profile.
+
+## Acceptance Criteria
+
+Listed scripts use the helper or have an explicit in-code reason they do not; existing backups remain conservative/non-overwriting; support manifest/package install includes required helper lib files; direct CLI use such as --settings remains compatible or fails closed with a clear error; no normal ~/.pi/agent mutation path is introduced.
+

--- a/.tickets/tlhf-oxht.md
+++ b/.tickets/tlhf-oxht.md
@@ -1,6 +1,6 @@
 ---
 id: tlhf-oxht
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-05-19T20:37:35Z

--- a/scripts/lib/tlh-install-paths.mjs
+++ b/scripts/lib/tlh-install-paths.mjs
@@ -1,15 +1,20 @@
 import {
-	copyFileSync,
+	closeSync,
+	constants,
 	existsSync,
+	fstatSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	openSync,
+	readFileSync,
 	realpathSync,
 	renameSync,
 	rmSync,
+	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 export const DEFAULT_VALID_UPDATE_TRACKS = Object.freeze(["latest-release", "pinned-tag", "ref", "custom"]);
 
@@ -65,17 +70,97 @@ export function validateInstallerTargets(config, { homeDir = homedir(), validUpd
 	}
 }
 
+function isMissingPath(error) {
+	return error?.code === "ENOENT";
+}
+
+function noFollowOpenFlag() {
+	return typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+}
+
+function fileIdentity(stats) {
+	return { dev: stats.dev, ino: stats.ino };
+}
+
+function fileMode(stats) {
+	return stats.mode & 0o777;
+}
+
+function sameFileIdentity(stats, identity) {
+	return stats.dev === identity.dev && stats.ino === identity.ino;
+}
+
+function lstatIdentity(path) {
+	return fileIdentity(lstatSync(path));
+}
+
+function removeOwnedFile(path, identity) {
+	if (!identity) return false;
+	try {
+		const stats = lstatSync(path);
+		if (!stats.isFile() || !sameFileIdentity(stats, identity)) return false;
+		rmSync(path, { force: true });
+		return true;
+	} catch (error) {
+		if (isMissingPath(error)) return false;
+		throw error;
+	}
+}
+
+function removeOwnedTempDir(path, identity) {
+	if (!identity) return false;
+	try {
+		const stats = lstatSync(path);
+		if (!stats.isDirectory() || !sameFileIdentity(stats, identity)) return false;
+		rmSync(path, { recursive: true, force: true });
+		return true;
+	} catch (error) {
+		if (isMissingPath(error)) return false;
+		throw error;
+	}
+}
+
+function openExclusiveFile(path, label, mode = 0o666) {
+	try {
+		const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowOpenFlag(), mode);
+		return { fd, identity: fileIdentity(fstatSync(fd)) };
+	} catch (error) {
+		if (error?.code === "EEXIST" || error?.code === "ELOOP") {
+			throw new Error(`refusing to overwrite existing ${label}: ${path}`);
+		}
+		throw error;
+	}
+}
+
+function writeExclusiveFile(path, data, label, mode = 0o666) {
+	let fd;
+	let identity;
+	try {
+		const opened = openExclusiveFile(path, label, mode);
+		fd = opened.fd;
+		identity = opened.identity;
+		writeFileSync(fd, data);
+		closeSync(fd);
+		fd = undefined;
+		return identity;
+	} catch (error) {
+		if (fd !== undefined) closeSync(fd);
+		removeOwnedFile(path, identity);
+		throw error;
+	}
+}
+
 export function isSymlink(path) {
 	try {
 		return lstatSync(path).isSymbolicLink();
 	} catch (error) {
-		if (error?.code === "ENOENT") return false;
+		if (isMissingPath(error)) return false;
 		throw error;
 	}
 }
 
 export function validateProfileRelativePath(relativePath, label = "TLH profile path") {
-	if (!relativePath || relativePath.startsWith("/") || relativePath.endsWith("/")) {
+	if (!relativePath || relativePath.startsWith("/") || relativePath.endsWith("/") || relativePath.includes("\\")) {
 		throw new Error(`refusing unsafe ${label}: ${relativePath}`);
 	}
 	for (const component of relativePath.split("/")) {
@@ -96,14 +181,32 @@ export function assertProfilePathWithinAgent(config, path, label = "TLH profile 
 	}
 }
 
-export function ensureSafeProfileDir(config, relativePath, label = "TLH profile directory", options = {}) {
-	validateProfileRelativePath(relativePath, label);
+function ensureSafeProfileRoot(config, label = "TLH profile root", options = {}) {
+	const { createParents = true, homeDir = homedir() } = options;
 	const root = realpathForCompare(config.agentDir);
-	assertProfilePathWithinAgent(config, root, label, options);
+	if (pathIsProtectedPiConfig(root, { homeDir, alreadyNormalized: true })) {
+		throw new Error(`refusing to write ${label} under normal Pi config root: ${config.agentDir}`);
+	}
+	if (isSymlink(config.agentDir)) {
+		throw new Error(`refusing to write ${label} through symlinked TLH profile root: ${config.agentDir}`);
+	}
 	if (existsSync(root) && !lstatSync(root).isDirectory()) {
 		throw new Error(`refusing to use non-directory TLH profile root for ${label}: ${config.agentDir}`);
 	}
-	if (!existsSync(root)) mkdirSync(root, { recursive: true });
+	if (!existsSync(root) && createParents) mkdirSync(root, { recursive: true });
+	if (isSymlink(config.agentDir)) {
+		throw new Error(`refusing to write ${label} through symlinked TLH profile root: ${config.agentDir}`);
+	}
+	if (existsSync(root) && !lstatSync(root).isDirectory()) {
+		throw new Error(`refusing to use non-directory TLH profile root for ${label}: ${config.agentDir}`);
+	}
+	return root;
+}
+
+export function ensureSafeProfileDir(config, relativePath, label = "TLH profile directory", options = {}) {
+	validateProfileRelativePath(relativePath, label);
+	const root = ensureSafeProfileRoot(config, label, options);
+	const { createParents = true } = options;
 
 	let cursor = root;
 	for (const component of relativePath.split("/")) {
@@ -114,21 +217,98 @@ export function ensureSafeProfileDir(config, relativePath, label = "TLH profile 
 		if (existsSync(cursor) && !lstatSync(cursor).isDirectory()) {
 			throw new Error(`refusing to use non-directory TLH profile path for ${label}: ${cursor}`);
 		}
-		if (!existsSync(cursor)) mkdirSync(cursor);
+		if (!existsSync(cursor) && createParents) mkdirSync(cursor);
+		if (isSymlink(cursor)) {
+			throw new Error(`refusing to write ${label} through symlinked TLH profile path: ${cursor}`);
+		}
+		if (existsSync(cursor) && !lstatSync(cursor).isDirectory()) {
+			throw new Error(`refusing to use non-directory TLH profile path for ${label}: ${cursor}`);
+		}
 		assertProfilePathWithinAgent(config, cursor, label, options);
 	}
 	return cursor;
 }
 
-export function safeProfileFileTarget(config, relativePath, label = "TLH profile file", options = {}) {
-	validateProfileRelativePath(relativePath, label);
-	const parentSeparatorIndex = relativePath.lastIndexOf("/");
-	if (parentSeparatorIndex < 1 || parentSeparatorIndex === relativePath.length - 1) {
-		throw new Error(`refusing unsafe ${label}: ${relativePath}`);
+function validateExistingProfileFile(path, label) {
+	try {
+		const stats = lstatSync(path);
+		if (stats.isSymbolicLink()) {
+			throw new Error(`refusing to replace symlinked ${label}: ${path}`);
+		}
+		if (!stats.isFile()) {
+			throw new Error(`refusing to replace non-file ${label}: ${path}`);
+		}
+	} catch (error) {
+		if (isMissingPath(error)) return;
+		throw error;
 	}
-	const parentRelative = relativePath.slice(0, parentSeparatorIndex);
-	const base = basename(relativePath);
-	const parent = ensureSafeProfileDir(config, parentRelative, `${label} parent directory`, options);
+}
+
+function validateRawProfileParentComponents(profileRoot, relativePath, label) {
+	const parentSeparatorIndex = relativePath.lastIndexOf("/");
+	if (parentSeparatorIndex === -1) return;
+
+	let cursor = profileRoot;
+	for (const component of relativePath.slice(0, parentSeparatorIndex).split("/")) {
+		cursor = join(cursor, component);
+		try {
+			const stats = lstatSync(cursor);
+			if (stats.isSymbolicLink()) {
+				throw new Error(`refusing to write ${label} parent directory through symlinked TLH profile path: ${cursor}`);
+			}
+			if (!stats.isDirectory()) {
+				throw new Error(`refusing to use non-directory TLH profile path for ${label} parent directory: ${cursor}`);
+			}
+		} catch (error) {
+			if (isMissingPath(error)) return;
+			throw error;
+		}
+	}
+}
+
+function rawAbsoluteProfileRelativePath(config, rawPath, label) {
+	const rawTarget = stripTrailingSlashes(resolve(rawPath));
+	validateExistingProfileFile(rawTarget, label);
+
+	const rawAgent = stripTrailingSlashes(resolve(config.agentDir));
+	const normalizedAgent = stripTrailingSlashes(realpathForCompare(config.agentDir));
+	const profileRoot = pathWithinOrEqual(rawAgent, rawTarget)
+		? rawAgent
+		: (pathWithinOrEqual(normalizedAgent, rawTarget) ? normalizedAgent : "");
+	if (!profileRoot) {
+		throw new Error(`refusing to write ${label} outside the isolated TLH profile: ${rawPath}`);
+	}
+
+	const relativePath = relative(profileRoot, rawTarget).split(sep).join("/");
+	validateProfileRelativePath(relativePath, label);
+	validateRawProfileParentComponents(profileRoot, relativePath, label);
+	return relativePath;
+}
+
+function profileRelativeFilePath(config, profilePath, label, options) {
+	const rawPath = String(profilePath);
+	if (!isAbsolute(rawPath)) {
+		validateProfileRelativePath(rawPath, label);
+		return rawPath;
+	}
+
+	const allowedAbsoluteBasenames = new Set(options.allowLegacyAbsoluteSettingsPath ? ["settings.json"] : []);
+	for (const allowedName of options.allowLegacyAbsoluteProfileBasenames ?? []) allowedAbsoluteBasenames.add(allowedName);
+	if (!allowedAbsoluteBasenames.has(basename(rawPath))) {
+		throw new Error(`refusing absolute ${label}; use a TLH profile-relative path: ${profilePath}`);
+	}
+
+	return rawAbsoluteProfileRelativePath(config, rawPath, label);
+}
+
+function safeProfileFileTargetInfo(config, profilePath, label = "TLH profile file", options = {}) {
+	const relativePath = profileRelativeFilePath(config, profilePath, label, options);
+	const parentSeparatorIndex = relativePath.lastIndexOf("/");
+	const parentRelative = parentSeparatorIndex === -1 ? "" : relativePath.slice(0, parentSeparatorIndex);
+	const base = parentSeparatorIndex === -1 ? relativePath : basename(relativePath);
+	const parent = parentRelative
+		? ensureSafeProfileDir(config, parentRelative, `${label} parent directory`, options)
+		: ensureSafeProfileRoot(config, `${label} parent directory`, options);
 	const target = join(parent, base);
 	if (isSymlink(target)) {
 		throw new Error(`refusing to replace symlinked ${label}: ${target}`);
@@ -137,22 +317,158 @@ export function safeProfileFileTarget(config, relativePath, label = "TLH profile
 		throw new Error(`refusing to replace non-file ${label}: ${target}`);
 	}
 	assertProfilePathWithinAgent(config, target, label, options);
-	return target;
+	return { target, parent, base };
+}
+
+export function safeProfileFileTarget(config, profilePath, label = "TLH profile file", options = {}) {
+	return safeProfileFileTargetInfo(config, profilePath, label, options).target;
+}
+
+function currentTargetIdentity(target, label, options = {}) {
+	try {
+		const stats = lstatSync(target);
+		if (stats.isSymbolicLink()) {
+			throw new Error(`refusing to replace symlinked ${label}: ${target}`);
+		}
+		if (!stats.isFile()) {
+			throw new Error(`refusing to replace non-file ${label}: ${target}`);
+		}
+		if (options.exclusive) {
+			throw new Error(`refusing to overwrite existing ${label}: ${target}`);
+		}
+		return { ...fileIdentity(stats), mode: fileMode(stats) };
+	} catch (error) {
+		if (isMissingPath(error)) return undefined;
+		throw error;
+	}
+}
+
+function revalidateProfileWriteTarget({ parent, parentIdentity, target, targetIdentity, label }) {
+	const parentStats = lstatSync(parent);
+	if (!parentStats.isDirectory() || !sameFileIdentity(parentStats, parentIdentity)) {
+		throw new Error(`refusing to replace ${label}; parent directory changed before rename: ${parent}`);
+	}
+
+	try {
+		const targetStats = lstatSync(target);
+		if (targetStats.isSymbolicLink()) {
+			throw new Error(`refusing to replace symlinked ${label}: ${target}`);
+		}
+		if (!targetStats.isFile()) {
+			throw new Error(`refusing to replace non-file ${label}: ${target}`);
+		}
+		if (!targetIdentity) {
+			throw new Error(`refusing to replace ${label}; target appeared before rename: ${target}`);
+		}
+		if (!sameFileIdentity(targetStats, targetIdentity)) {
+			throw new Error(`refusing to replace ${label}; target changed before rename: ${target}`);
+		}
+	} catch (error) {
+		if (!isMissingPath(error)) throw error;
+		if (targetIdentity) {
+			throw new Error(`refusing to replace ${label}; target disappeared before rename: ${target}`);
+		}
+	}
+}
+
+function revalidateTempWriteTarget(tempTarget, tempFileIdentity, label) {
+	try {
+		const stats = lstatSync(tempTarget);
+		if (stats.isSymbolicLink()) {
+			throw new Error(`refusing to replace ${label}; temp file changed to symlink before rename: ${tempTarget}`);
+		}
+		if (!stats.isFile()) {
+			throw new Error(`refusing to replace ${label}; temp file is not a regular file before rename: ${tempTarget}`);
+		}
+		if (!sameFileIdentity(stats, tempFileIdentity)) {
+			throw new Error(`refusing to replace ${label}; temp file changed before rename: ${tempTarget}`);
+		}
+	} catch (error) {
+		if (isMissingPath(error)) {
+			throw new Error(`refusing to replace ${label}; temp file disappeared before rename: ${tempTarget}`);
+		}
+		throw error;
+	}
+}
+
+function backupPathForTarget(config, target, parent, label, options) {
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const backupPath = realpathForCompare(options.backupPath || `${target}.backup-${stamp}`);
+	if (dirname(backupPath) !== parent) {
+		throw new Error(`refusing to write ${label} backup outside the target directory: ${backupPath}`);
+	}
+	assertProfilePathWithinAgent(config, backupPath, `${label} backup`, options);
+	if (isSymlink(backupPath) || existsSync(backupPath)) {
+		throw new Error(`refusing to overwrite existing ${label} backup: ${backupPath}`);
+	}
+	return backupPath;
+}
+
+function createTargetBackup(config, writeTarget, targetIdentity, options) {
+	if (!options.backup || !targetIdentity) return undefined;
+	const { parent, target, label } = writeTarget;
+	const backupPath = backupPathForTarget(config, target, parent, label, options);
+	revalidateProfileWriteTarget({ ...writeTarget, targetIdentity });
+	writeExclusiveFile(backupPath, readFileSync(target), `${label} backup`, options.backupMode ?? targetIdentity.mode ?? 0o666);
+	return backupPath;
+}
+
+// Best-effort portable safe replacement for files inside the isolated TLH profile.
+// Node does not expose fd-anchored openat(2)/renameat(2) primitives, so a residual TOCTOU
+// window remains between path identity revalidation and renameSync.
+export function replaceSafeProfileFile(config, profilePath, writeTempFile, label = "TLH profile file", options = {}) {
+	if (typeof writeTempFile !== "function") throw new TypeError("writeTempFile must be a function");
+	if (options.dryRun) {
+		const { target } = safeProfileFileTargetInfo(config, profilePath, label, { ...options, createParents: false });
+		return { target, backupPath: undefined, dryRun: true };
+	}
+
+	const { target, parent, base } = safeProfileFileTargetInfo(config, profilePath, label, options);
+	const parentIdentity = lstatIdentity(parent);
+	const targetIdentity = currentTargetIdentity(target, label, options);
+	const replacementMode = options.mode ?? targetIdentity?.mode ?? options.defaultMode ?? 0o666;
+	const writeTarget = { parent, parentIdentity, target, label };
+	const tempDir = mkdtempSync(join(parent, `.${base}.tmp.`));
+	const tempDirIdentity = lstatIdentity(tempDir);
+	const tempTarget = join(tempDir, base);
+	let tempFd;
+	let tempFileIdentity;
+
+	try {
+		const opened = openExclusiveFile(tempTarget, `${label} temp file`, replacementMode);
+		tempFd = opened.fd;
+		tempFileIdentity = opened.identity;
+		writeTempFile({ fd: tempFd, tempPath: tempTarget, tempDir, target });
+		closeSync(tempFd);
+		tempFd = undefined;
+		revalidateTempWriteTarget(tempTarget, tempFileIdentity, label);
+
+		revalidateProfileWriteTarget({ ...writeTarget, targetIdentity });
+		const backupPath = createTargetBackup(config, writeTarget, targetIdentity, options);
+		revalidateProfileWriteTarget({ ...writeTarget, targetIdentity });
+		revalidateTempWriteTarget(tempTarget, tempFileIdentity, label);
+		renameSync(tempTarget, target);
+		tempFileIdentity = undefined;
+		return { target, backupPath };
+	} catch (error) {
+		if (tempFd !== undefined) closeSync(tempFd);
+		removeOwnedFile(tempTarget, tempFileIdentity);
+		throw error;
+	} finally {
+		removeOwnedTempDir(tempDir, tempDirIdentity);
+	}
+}
+
+export function writeSafeProfileFile(config, profilePath, data, label = "TLH profile file", options = {}) {
+	return replaceSafeProfileFile(config, profilePath, ({ fd }) => writeFileSync(fd, data), label, options);
 }
 
 export function copySafeProfileFile(config, source, relativePath, label = "TLH profile file", options = {}) {
-	const target = safeProfileFileTarget(config, relativePath, label, options);
-	const tempDir = mkdtempSync(join(dirname(target), `.${basename(target)}.tmp.`));
-	const tempTarget = join(tempDir, basename(target));
-	try {
-		copyFileSync(source, tempTarget);
-		renameSync(tempTarget, target);
-	} catch (error) {
-		rmSync(tempTarget, { force: true });
-		throw error;
-	} finally {
-		rmSync(tempDir, { recursive: true, force: true });
-	}
+	const sourceStats = lstatSync(source);
+	return writeSafeProfileFile(config, relativePath, readFileSync(source), label, {
+		...options,
+		defaultMode: fileMode(sourceStats),
+	});
 }
 
 export function fileLinkCount(path) {

--- a/scripts/lib/tlh-install-support-manifest.mjs
+++ b/scripts/lib/tlh-install-support-manifest.mjs
@@ -28,7 +28,7 @@ const BASE_SUPPORT_FILES = Object.freeze([
 		requirement: REQUIRED,
 		relativePath: "scripts/lib/tlh-install-paths.mjs",
 		tempPath: "lib/tlh-install-paths.mjs",
-		installName: "",
+		installName: "lib/tlh-install-paths.mjs",
 	},
 	{
 		variable: "TLH_INSTALL_GIT_LIB",

--- a/scripts/merge-keybindings.mjs
+++ b/scripts/merge-keybindings.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
-import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
+
+import { safeProfileFileTarget, writeSafeProfileFile } from "./lib/tlh-install-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -146,12 +148,12 @@ function backupPathFor(keybindingsPath) {
 	return `${keybindingsPath}.backup-${stamp}`;
 }
 
-function realpathForCompare(path) {
-	const resolved = resolve(path);
-	if (existsSync(resolved)) return realpathSync(resolved);
-	const parent = dirname(resolved);
-	if (parent === resolved) return resolved;
-	return join(realpathForCompare(parent), basename(resolved));
+function profileFileReference(filePath) {
+	const absolutePath = resolve(filePath);
+	return {
+		config: { agentDir: dirname(absolutePath) },
+		profilePath: basename(absolutePath),
+	};
 }
 
 function assertKeybindingsTarget(keybindingsPath) {
@@ -159,28 +161,20 @@ function assertKeybindingsTarget(keybindingsPath) {
 		throw new Error(`Refusing to modify non-keybindings file: ${keybindingsPath}`);
 	}
 
-	const normalPiRoot = realpathForCompare(join(homedir(), ".pi"));
-	const resolvedKeybindingsPath = realpathForCompare(keybindingsPath);
-	if (resolvedKeybindingsPath === normalPiRoot || resolvedKeybindingsPath.startsWith(`${normalPiRoot}${sep}`)) {
-		throw new Error(`Refusing to modify normal Pi config from The Last Harness installer: ${keybindingsPath}`);
-	}
+	const target = profileFileReference(keybindingsPath);
+	safeProfileFileTarget(target.config, target.profilePath, "keybindings file", { createParents: false });
 }
 
-function writeKeybindings(keybindingsPath, value, { dryRun, existed }) {
+function writeKeybindings(keybindingsPath, value, { dryRun }) {
 	const formatted = `${JSON.stringify(value, null, 2)}\n`;
 	if (dryRun) return undefined;
 
-	mkdirSync(dirname(keybindingsPath), { recursive: true });
-	let backupPath;
-	if (existed) {
-		backupPath = backupPathFor(keybindingsPath);
-		copyFileSync(keybindingsPath, backupPath);
-	}
-
-	const tempPath = `${keybindingsPath}.tmp-${process.pid}`;
-	writeFileSync(tempPath, formatted, "utf8");
-	renameSync(tempPath, keybindingsPath);
-	return backupPath;
+	const target = profileFileReference(keybindingsPath);
+	const result = writeSafeProfileFile(target.config, target.profilePath, formatted, "keybindings file", {
+		backup: true,
+		backupPath: backupPathFor(keybindingsPath),
+	});
+	return result.backupPath;
 }
 
 function log(args, message) {
@@ -218,7 +212,7 @@ function main() {
 		return;
 	}
 
-	const backupPath = writeKeybindings(keybindingsPath, next, { dryRun: args.dryRun, existed });
+	const backupPath = writeKeybindings(keybindingsPath, next, { dryRun: args.dryRun });
 	if (backupPath) log(args, `Backed up previous keybindings to: ${backupPath}`);
 	log(args, "Keybindings updated.");
 }

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
-import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join, normalize, parse, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
+
+import { safeProfileFileTarget, writeSafeProfileFile } from "./lib/tlh-install-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -577,37 +579,29 @@ function backupPathFor(settingsPath) {
 	return `${settingsPath}.backup-${stamp}`;
 }
 
-function realpathForCompare(path) {
-	const resolved = resolve(path);
-	if (existsSync(resolved)) return realpathSync(resolved);
-	const parent = dirname(resolved);
-	if (parent === resolved) return resolved;
-	return join(realpathForCompare(parent), basename(resolved));
+function profileFileReference(filePath) {
+	const absolutePath = resolve(filePath);
+	return {
+		config: { agentDir: dirname(absolutePath) },
+		profilePath: basename(absolutePath),
+	};
 }
 
-function assertNotNormalPiSettings(settingsPath) {
-	const normalPiRoot = realpathForCompare(join(homedir(), ".pi"));
-	const resolvedSettingsPath = realpathForCompare(settingsPath);
-	if (resolvedSettingsPath === normalPiRoot || resolvedSettingsPath.startsWith(`${normalPiRoot}${sep}`)) {
-		throw new Error(`Refusing to modify normal Pi config from The Last Harness installer: ${settingsPath}`);
-	}
+function assertSafeSettingsTarget(settingsPath) {
+	const target = profileFileReference(settingsPath);
+	safeProfileFileTarget(target.config, target.profilePath, "settings file", { createParents: false });
 }
 
-function writeSettings(settingsPath, value, { dryRun, existed }) {
+function writeSettings(settingsPath, value, { dryRun }) {
 	const formatted = `${JSON.stringify(value, null, 2)}\n`;
 	if (dryRun) return undefined;
 
-	mkdirSync(dirname(settingsPath), { recursive: true });
-	let backupPath;
-	if (existed) {
-		backupPath = backupPathFor(settingsPath);
-		copyFileSync(settingsPath, backupPath);
-	}
-
-	const tempPath = `${settingsPath}.tmp-${process.pid}`;
-	writeFileSync(tempPath, formatted, "utf8");
-	renameSync(tempPath, settingsPath);
-	return backupPath;
+	const target = profileFileReference(settingsPath);
+	const result = writeSafeProfileFile(target.config, target.profilePath, formatted, "settings file", {
+		backup: true,
+		backupPath: backupPathFor(settingsPath),
+	});
+	return result.backupPath;
 }
 
 function log(args, message) {
@@ -624,7 +618,7 @@ function main() {
 	const defaultsPath = resolve(args.defaultsPath || defaultDefaultsPath());
 	const defaultExtensionsPath = resolve(args.defaultExtensionsPath || defaultDefaultExtensionsPath());
 	const settingsPath = resolve(args.settingsPath || defaultSettingsPath());
-	assertNotNormalPiSettings(settingsPath);
+	assertSafeSettingsTarget(settingsPath);
 	const existed = existsSync(settingsPath);
 	const existing = readJson(settingsPath, { missingValue: {} });
 	const rawDefaults = readJson(defaultsPath);
@@ -654,7 +648,7 @@ function main() {
 		return;
 	}
 
-	const backupPath = writeSettings(settingsPath, next, { dryRun: args.dryRun, existed });
+	const backupPath = writeSettings(settingsPath, next, { dryRun: args.dryRun });
 	if (backupPath) log(args, `Backed up previous settings to: ${backupPath}`);
 	log(args, "Settings updated.");
 }

--- a/scripts/tlh-defaults.mjs
+++ b/scripts/tlh-defaults.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
-import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
+
+import { safeProfileFileTarget, writeSafeProfileFile } from "./lib/tlh-install-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -419,37 +421,29 @@ function backupPathFor(settingsPath) {
 	return `${settingsPath}.backup-tlh-defaults-${stamp}`;
 }
 
-function realpathForCompare(path) {
-	const resolved = resolve(path);
-	if (existsSync(resolved)) return realpathSync(resolved);
-	const parent = dirname(resolved);
-	if (parent === resolved) return resolved;
-	return join(realpathForCompare(parent), basename(resolved));
+function profileFileReference(filePath) {
+	const absolutePath = resolve(filePath);
+	return {
+		config: { agentDir: dirname(absolutePath) },
+		profilePath: basename(absolutePath),
+	};
 }
 
-function assertNotNormalPiSettings(settingsPath) {
-	const normalPiRoot = realpathForCompare(join(homedir(), ".pi"));
-	const resolvedSettingsPath = realpathForCompare(settingsPath);
-	if (resolvedSettingsPath === normalPiRoot || resolvedSettingsPath.startsWith(`${normalPiRoot}${sep}`)) {
-		throw new Error(`Refusing to modify normal Pi config from The Last Harness defaults command: ${settingsPath}`);
-	}
+function assertSafeSettingsTarget(settingsPath) {
+	const target = profileFileReference(settingsPath);
+	safeProfileFileTarget(target.config, target.profilePath, "settings file", { createParents: false });
 }
 
 function writeSettings(settingsPath, value, previousRaw) {
 	const formatted = `${JSON.stringify(value, null, 2)}\n`;
 	if (formatted === previousRaw) return undefined;
 
-	mkdirSync(dirname(settingsPath), { recursive: true });
-	let backupPath;
-	if (existsSync(settingsPath)) {
-		backupPath = backupPathFor(settingsPath);
-		copyFileSync(settingsPath, backupPath);
-	}
-
-	const tempPath = `${settingsPath}.tmp-${process.pid}`;
-	writeFileSync(tempPath, formatted, "utf8");
-	renameSync(tempPath, settingsPath);
-	return backupPath;
+	const target = profileFileReference(settingsPath);
+	const result = writeSafeProfileFile(target.config, target.profilePath, formatted, "settings file", {
+		backup: true,
+		backupPath: backupPathFor(settingsPath),
+	});
+	return result.backupPath;
 }
 
 function loadSettings(settingsPath) {
@@ -515,7 +509,7 @@ function main() {
 	const settingsPath = resolve(expandHome(args.settingsPath || defaultSettingsPath()));
 	const defaultExtensionsPath = resolve(expandHome(args.defaultExtensionsPath || defaultDefaultExtensionsPath()));
 	const mutatesSettings = args.command === "disable" || args.command === "enable";
-	if (mutatesSettings) assertNotNormalPiSettings(settingsPath);
+	if (mutatesSettings) assertSafeSettingsTarget(settingsPath);
 	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath);
 	const { settings, previousRaw } = loadSettings(settingsPath);
 	validateSettings(settings);

--- a/scripts/tlh-gnosis.mjs
+++ b/scripts/tlh-gnosis.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-import { closeSync, constants, copyFileSync, existsSync, fchmodSync, lstatSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, constants, existsSync, fchmodSync, lstatSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
+
+import { safeProfileFileTarget, writeSafeProfileFile } from "./lib/tlh-install-paths.mjs";
 
 const VALIDATION_TIMEOUT_MS = 5000;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
@@ -554,10 +556,17 @@ function isUnderNormalPiConfig(path) {
 	return resolvedPath === normalPiRoot || resolvedPath.startsWith(`${normalPiRoot}${sep}`);
 }
 
+function profileFileReference(filePath) {
+	const absolutePath = resolve(filePath);
+	return {
+		config: { agentDir: dirname(absolutePath) },
+		profilePath: basename(absolutePath),
+	};
+}
+
 function assertNotNormalPiSettings(settingsPath) {
-	if (isUnderNormalPiConfig(settingsPath)) {
-		throw new Error(`Refusing to modify normal Pi config from The Last Harness gnosis command: ${settingsPath}`);
-	}
+	const target = profileFileReference(settingsPath);
+	safeProfileFileTarget(target.config, target.profilePath, "Gnosis settings file", { createParents: false });
 }
 
 function assertNotNormalPiPath(path, label) {
@@ -655,17 +664,12 @@ function writeSettings(settingsPath, value, previousRaw, { dryRun }) {
 	if (formatted === previousRaw) return "unchanged";
 	if (dryRun) return "dry-run";
 
-	mkdirSync(dirname(settingsPath), { recursive: true });
-	let backupPath;
-	if (existsSync(settingsPath)) {
-		backupPath = backupPathFor(settingsPath);
-		copyFileSync(settingsPath, backupPath);
-	}
-
-	const tempPath = `${settingsPath}.tmp-${process.pid}`;
-	writeFileSync(tempPath, formatted, "utf8");
-	renameSync(tempPath, settingsPath);
-	return backupPath || "written";
+	const target = profileFileReference(settingsPath);
+	const result = writeSafeProfileFile(target.config, target.profilePath, formatted, "Gnosis settings file", {
+		backup: true,
+		backupPath: backupPathFor(settingsPath),
+	});
+	return result.backupPath || "written";
 }
 
 function log(args, message) {

--- a/scripts/tlh-install-state.mjs
+++ b/scripts/tlh-install-state.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
-import { homedir } from "node:os";
 import process from "node:process";
+
+import {
+	pathIsProtectedPiConfig,
+	safeProfileFileTarget,
+	writeSafeProfileFile,
+} from "./lib/tlh-install-paths.mjs";
 
 function usage() {
 	return `Usage: tlh-install-state.mjs [options]
@@ -174,24 +177,26 @@ function parseBoolean(value, flag) {
 	throw new Error(`${flag} must be true or false`);
 }
 
-function realpathForCompare(path) {
-	const resolved = resolve(path);
-	if (existsSync(resolved)) return realpathSync(resolved);
-	const parent = dirname(resolved);
-	if (parent === resolved) return resolved;
-	return join(realpathForCompare(parent), basename(resolved));
-}
-
-function isUnderNormalPiConfig(path) {
-	const normalPiRoot = realpathForCompare(join(homedir(), ".pi"));
-	const resolvedPath = realpathForCompare(path);
-	return resolvedPath === normalPiRoot || resolvedPath.startsWith(`${normalPiRoot}${sep}`);
-}
-
 function assertNotNormalPiPath(path, label) {
-	if (isUnderNormalPiConfig(path)) {
+	if (pathIsProtectedPiConfig(path)) {
 		throw new Error(`refusing to modify normal Pi config from The Last Harness install-state command (${label}): ${path}`);
 	}
+}
+
+function stateFileOptions(extraOptions = {}) {
+	return {
+		allowLegacyAbsoluteProfileBasenames: ["install-state.json"],
+		...extraOptions,
+	};
+}
+
+function assertSafeStatePath(args) {
+	safeProfileFileTarget(
+		{ agentDir: args.agentDir },
+		args.statePath,
+		"tlh install-state file",
+		stateFileOptions({ createParents: false }),
+	);
 }
 
 function log(args, message) {
@@ -221,15 +226,13 @@ function writeInstallState(args) {
 	}
 
 	const state = buildState(args);
-	const tmpPath = `${args.statePath}.tmp.${process.pid}`;
-	mkdirSync(dirname(args.statePath), { recursive: true });
-	try {
-		writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
-		renameSync(tmpPath, args.statePath);
-	} catch (error) {
-		rmSync(tmpPath, { force: true });
-		throw error;
-	}
+	writeSafeProfileFile(
+		{ agentDir: args.agentDir },
+		args.statePath,
+		`${JSON.stringify(state, null, 2)}\n`,
+		"tlh install-state file",
+		stateFileOptions(),
+	);
 }
 
 function main() {
@@ -242,6 +245,7 @@ function main() {
 	assertNotNormalPiPath(args.statePath, "state path");
 	assertNotNormalPiPath(args.agentDir, "agent dir");
 	assertNotNormalPiPath(args.binDir, "wrapper install dir");
+	assertSafeStatePath(args);
 	writeInstallState(args);
 }
 

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import {
-	copyFileSync,
 	existsSync,
 	mkdirSync,
 	readFileSync,
@@ -22,7 +21,6 @@ import {
 	assertSafeSettingsTarget,
 	copySafeProfileFile,
 	ensureSafeProfileDir,
-	isSymlink,
 	validateInstallerTargets,
 } from "./lib/tlh-install-paths.mjs";
 import {
@@ -513,15 +511,13 @@ function backupExistingSettingsBeforePiInstall(config) {
 	assertSafeSettingsTarget(config);
 	if (!existsSync(config.settingsPath)) return;
 	const stamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z").replace(/:/g, "-");
-	const backupPath = `${config.settingsPath}.backup-before-install-${stamp}`;
+	const backupName = `settings.json.backup-before-install-${stamp}`;
+	const backupPath = join(config.agentDir, backupName);
 	if (config.dryRun) {
 		log(config, `Would back up existing isolated settings to: ${backupPath}`);
 		return;
 	}
-	if (existsSync(backupPath) || isSymlink(backupPath)) {
-		throw new Error(`refusing to overwrite existing settings backup: ${backupPath}`);
-	}
-	copyFileSync(config.settingsPath, backupPath);
+	copySafeProfileFile(config, config.settingsPath, backupName, "pre-install settings backup", { exclusive: true });
 	detailLog(config, `Backed up existing isolated settings to: ${backupPath}`);
 }
 

--- a/tests/install-libs.test.mjs
+++ b/tests/install-libs.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -13,10 +13,13 @@ import {
 import { assertGitSourceTargetSafe } from "../scripts/lib/tlh-install-git.mjs";
 import {
 	assertProfilePathWithinAgent,
+	copySafeProfileFile,
 	ensureSafeProfileDir,
 	pathIsProtectedPiConfig,
+	replaceSafeProfileFile,
 	safeProfileFileTarget,
 	validateInstallerTargets,
+	writeSafeProfileFile,
 } from "../scripts/lib/tlh-install-paths.mjs";
 import {
 	TLH_SUBAGENT_PROMPTS,
@@ -132,18 +135,49 @@ test("normal Pi config guards reject agent, wrapper, and profile writes under ~/
 	);
 });
 
-test("safeProfileFileTarget rejects single-segment file targets", (t) => {
+test("safe profile file helpers support top-level, support-file, dry-run, and legacy settings targets", (t) => {
 	const root = tempFixture(t);
 	const agentDir = join(root, "agent");
 	const homeDir = join(root, "home");
 	mkdirSync(homeDir, { recursive: true });
 
-	assert.throws(
-		() => safeProfileFileTarget({ agentDir }, "settings.json", "test file", { homeDir }),
-		/refusing unsafe test file: settings\.json/,
+	assert.equal(
+		safeProfileFileTarget({ agentDir }, "settings.json", "settings file", { homeDir }),
+		join(realpathSync.native(agentDir), "settings.json"),
 	);
-	assert.equal(existsSync(agentDir), false);
-	assert.equal(existsSync(join(agentDir, "settings.jso")), false);
+	assert.equal(
+		safeProfileFileTarget({ agentDir }, "tlh/default-extensions.json", "support file", { homeDir }),
+		join(realpathSync.native(agentDir), "tlh", "default-extensions.json"),
+	);
+
+	writeSafeProfileFile({ agentDir }, "keybindings.json", "{\"x\":1}\n", "keybindings file", { homeDir });
+	assert.equal(readFileSync(join(agentDir, "keybindings.json"), "utf8"), "{\"x\":1}\n");
+
+	const absoluteSettingsPath = join(agentDir, "settings.json");
+	writeSafeProfileFile(
+		{ agentDir },
+		absoluteSettingsPath,
+		"{}\n",
+		"settings file",
+		{ homeDir, allowLegacyAbsoluteSettingsPath: true },
+	);
+	assert.equal(readFileSync(absoluteSettingsPath, "utf8"), "{}\n");
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, absoluteSettingsPath, "{}\n", "settings file", { homeDir }),
+		/refusing absolute settings file; use a TLH profile-relative path/,
+	);
+
+	const dryRunAgentDir = join(root, "dry-run-agent");
+	const dryRunResult = writeSafeProfileFile(
+		{ agentDir: dryRunAgentDir },
+		"settings.json",
+		"{}\n",
+		"dry-run settings file",
+		{ homeDir, dryRun: true },
+	);
+	assert.equal(dryRunResult.dryRun, true);
+	assert.equal(dryRunResult.target, join(realpathSync.native(root), "dry-run-agent", "settings.json"));
+	assert.equal(existsSync(dryRunAgentDir), false);
 });
 
 test("ensureSafeProfileDir rejects protected profile roots before creating them", (t) => {
@@ -156,8 +190,256 @@ test("ensureSafeProfileDir rejects protected profile roots before creating them"
 		() => ensureSafeProfileDir({ agentDir: protectedAgentDir }, "tlh", "test directory", { homeDir }),
 		/refusing to write test directory under normal Pi config root/,
 	);
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir: protectedAgentDir }, "settings.json", "{}\n", "test file", { homeDir }),
+		/refusing to write test file parent directory under normal Pi config root/,
+	);
 	assert.equal(existsSync(protectedAgentDir), false);
 	assert.equal(existsSync(join(homeDir, ".pi")), false);
+});
+
+test("safe profile writes reject symlinked parent components and final files", (t) => {
+	const root = tempFixture(t);
+	const agentDir = join(root, "agent");
+	const outsideDir = join(root, "outside");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(outsideDir, { recursive: true });
+
+	symlinkSync(outsideDir, join(agentDir, "tlh"), "dir");
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, "tlh/support.txt", "support\n", "support file"),
+		/refusing to write support file parent directory through symlinked TLH profile path/,
+	);
+	assert.equal(existsSync(join(outsideDir, "support.txt")), false);
+
+	rmSync(join(agentDir, "tlh"), { force: true });
+	writeFileSync(join(outsideDir, "settings.json"), "outside\n");
+	symlinkSync(join(outsideDir, "settings.json"), join(agentDir, "settings.json"));
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, "settings.json", "inside\n", "settings file"),
+		/refusing to replace symlinked settings file/,
+	);
+	assert.equal(readFileSync(join(outsideDir, "settings.json"), "utf8"), "outside\n");
+
+	const sourceSupportFile = join(root, "source-support.mjs");
+	const outsideSupportFile = join(outsideDir, "tlh-defaults.mjs");
+	writeFileSync(sourceSupportFile, "source\n");
+	writeFileSync(outsideSupportFile, "outside-support\n");
+	mkdirSync(join(agentDir, "tlh"));
+	symlinkSync(outsideSupportFile, join(agentDir, "tlh", "tlh-defaults.mjs"));
+	assert.throws(
+		() => copySafeProfileFile(
+			{ agentDir },
+			sourceSupportFile,
+			"tlh/tlh-defaults.mjs",
+			"TLH support file tlh-defaults.mjs",
+		),
+		/refusing to replace symlinked TLH support file tlh-defaults\.mjs/,
+	);
+	assert.equal(readFileSync(outsideSupportFile, "utf8"), "outside-support\n");
+});
+
+test("legacy absolute settings paths reject raw symlink components before target resolution", (t) => {
+	const root = tempFixture(t);
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	const realTarget = join(agentDir, "actual-settings.json");
+	const absoluteSettingsPath = join(agentDir, "settings.json");
+	writeFileSync(realTarget, "actual\n");
+	symlinkSync(realTarget, absoluteSettingsPath);
+
+	assert.throws(
+		() => writeSafeProfileFile(
+			{ agentDir },
+			absoluteSettingsPath,
+			"new\n",
+			"settings file",
+			{ allowLegacyAbsoluteSettingsPath: true },
+		),
+		/refusing to replace symlinked settings file/,
+	);
+	assert.equal(lstatSync(absoluteSettingsPath).isSymbolicLink(), true);
+	assert.equal(readFileSync(realTarget, "utf8"), "actual\n");
+
+	const realDir = join(agentDir, "real-dir");
+	const symlinkedDir = join(agentDir, "settings-link");
+	const realDirSettings = join(realDir, "settings.json");
+	mkdirSync(realDir);
+	writeFileSync(realDirSettings, "nested\n");
+	symlinkSync(realDir, symlinkedDir, "dir");
+	assert.throws(
+		() => writeSafeProfileFile(
+			{ agentDir },
+			join(symlinkedDir, "settings.json"),
+			"new\n",
+			"settings file",
+			{ allowLegacyAbsoluteSettingsPath: true },
+		),
+		/refusing to write settings file parent directory through symlinked TLH profile path/,
+	);
+	assert.equal(readFileSync(realDirSettings, "utf8"), "nested\n");
+});
+
+test("safe profile writes avoid predictable temps and reject backup collisions", (t) => {
+	const root = tempFixture(t);
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	const predictableTemp = join(agentDir, `settings.json.tmp-${process.pid}`);
+	writeFileSync(predictableTemp, "attacker\n");
+
+	writeSafeProfileFile({ agentDir }, "settings.json", "current\n", "settings file");
+	assert.equal(readFileSync(join(agentDir, "settings.json"), "utf8"), "current\n");
+	assert.equal(readFileSync(predictableTemp, "utf8"), "attacker\n");
+
+	const backupPath = join(agentDir, "settings.json.backup-fixed");
+	writeFileSync(backupPath, "collision\n");
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, "settings.json", "next\n", "settings file", { backup: true, backupPath }),
+		/refusing to overwrite existing settings file backup/,
+	);
+	assert.equal(readFileSync(join(agentDir, "settings.json"), "utf8"), "current\n");
+
+	rmSync(backupPath, { force: true });
+	const outsideBackupTarget = join(root, "outside-backup");
+	writeFileSync(outsideBackupTarget, "outside\n");
+	symlinkSync(outsideBackupTarget, backupPath);
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, "settings.json", "next\n", "settings file", { backup: true, backupPath }),
+		/refusing to write settings file backup outside the target directory|refusing to overwrite existing settings file backup/,
+	);
+	assert.equal(readFileSync(join(agentDir, "settings.json"), "utf8"), "current\n");
+
+	writeSafeProfileFile({ agentDir }, "exclusive-backup.json", "first\n", "exclusive backup", { exclusive: true });
+	assert.throws(
+		() => writeSafeProfileFile({ agentDir }, "exclusive-backup.json", "second\n", "exclusive backup", { exclusive: true }),
+		/refusing to overwrite existing exclusive backup/,
+	);
+	assert.equal(readFileSync(join(agentDir, "exclusive-backup.json"), "utf8"), "first\n");
+});
+
+test("safe profile replacements and backups preserve restrictive target modes", (t) => {
+	const root = tempFixture(t);
+	const agentDir = join(root, "agent");
+	const settingsPath = join(agentDir, "settings.json");
+	const backupPath = join(agentDir, "settings.json.backup-fixed");
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(settingsPath, "old\n");
+	chmodSync(settingsPath, 0o600);
+	assert.equal(lstatSync(settingsPath).mode & 0o777, 0o600);
+
+	const result = writeSafeProfileFile({ agentDir }, "settings.json", "new\n", "settings file", {
+		backup: true,
+		backupPath,
+	});
+
+	assert.equal(result.backupPath, realpathSync.native(backupPath));
+	assert.equal(readFileSync(settingsPath, "utf8"), "new\n");
+	assert.equal(readFileSync(backupPath, "utf8"), "old\n");
+	assert.equal(lstatSync(settingsPath).mode & 0o777, 0o600);
+	assert.equal(lstatSync(backupPath).mode & 0o777, 0o600);
+});
+
+test("safe profile writes preserve failed targets and clean only owned temp dirs", (t) => {
+	const root = tempFixture(t);
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(join(agentDir, "settings.json"), "old\n");
+
+	assert.throws(
+		() => replaceSafeProfileFile(
+			{ agentDir },
+			"settings.json",
+			({ fd }) => {
+				writeFileSync(fd, "new\n");
+				throw new Error("simulated write failure");
+			},
+			"settings file",
+		),
+		/simulated write failure/,
+	);
+	assert.equal(readFileSync(join(agentDir, "settings.json"), "utf8"), "old\n");
+
+	const victimDir = join(root, "victim");
+	mkdirSync(victimDir);
+	writeFileSync(join(victimDir, "keep.txt"), "keep\n");
+	let capturedTempDir;
+	assert.throws(
+		() => replaceSafeProfileFile(
+			{ agentDir },
+			"settings.json",
+			({ tempDir }) => {
+				capturedTempDir = tempDir;
+				rmSync(tempDir, { recursive: true, force: true });
+				symlinkSync(victimDir, tempDir, "dir");
+				throw new Error("simulated cleanup race");
+			},
+			"settings file",
+		),
+		/simulated cleanup race/,
+	);
+	assert.equal(readFileSync(join(agentDir, "settings.json"), "utf8"), "old\n");
+	assert.equal(readFileSync(join(victimDir, "keep.txt"), "utf8"), "keep\n");
+	assert.equal(lstatSync(capturedTempDir).isSymbolicLink(), true);
+});
+
+test("safe profile writes reject temp replacement, removal, and symlink swaps before rename", (t) => {
+	const root = tempFixture(t);
+	const cases = [
+		{
+			name: "removed",
+			expected: /temp file disappeared before rename/,
+			tamper({ tempPath }) {
+				rmSync(tempPath, { force: true });
+			},
+		},
+		{
+			name: "replaced",
+			expected: /temp file changed before rename/,
+			tamper({ tempPath }) {
+				rmSync(tempPath, { force: true });
+				writeFileSync(tempPath, "attacker\n");
+			},
+		},
+		{
+			name: "symlinked",
+			expected: /temp file changed to symlink before rename/,
+			tamper({ tempPath, victimPath }) {
+				rmSync(tempPath, { force: true });
+				symlinkSync(victimPath, tempPath);
+			},
+		},
+	];
+
+	for (const { name, expected, tamper } of cases) {
+		const agentDir = join(root, `agent-${name}`);
+		const finalTarget = join(agentDir, "settings.json");
+		const victimPath = join(root, `victim-${name}.txt`);
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(finalTarget, "old\n");
+		writeFileSync(victimPath, "victim\n");
+
+		assert.throws(
+			() => replaceSafeProfileFile(
+				{ agentDir },
+				"settings.json",
+				({ fd, tempPath }) => {
+					writeFileSync(fd, "new\n");
+					tamper({ tempPath, victimPath });
+				},
+				"settings file",
+			),
+			expected,
+		);
+		assert.equal(lstatSync(finalTarget).isSymbolicLink(), false, `${name} must not replace final target with a symlink`);
+		assert.equal(readFileSync(finalTarget, "utf8"), "old\n");
+		assert.equal(readFileSync(victimPath, "utf8"), "victim\n");
+	}
+});
+
+test("safe profile write helper documents residual TOCTOU risk", () => {
+	const source = readFileSync(new URL("../scripts/lib/tlh-install-paths.mjs", import.meta.url), "utf8");
+	assert.match(source, /residual\s+TOCTOU/i);
+	assert.match(source, /openat\(2\)\/renameat\(2\)/);
 });
 
 test("subagent prompt discovery honors source precedence and copies prompt files safely", (t) => {
@@ -201,9 +483,11 @@ test("subagent prompt discovery honors source precedence and copies prompt files
 });
 
 test("support manifest includes stage-1 library dependencies", () => {
-	const relativePaths = supportFileManifest().map((file) => file.relativePath);
+	const manifest = supportFileManifest();
+	const relativePaths = manifest.map((file) => file.relativePath);
 	assert.ok(relativePaths.includes("scripts/lib/tlh-install-git.mjs"));
 	assert.ok(relativePaths.includes("scripts/lib/tlh-install-support-files.mjs"));
+	assert.ok(manifest.some((file) => file.relativePath === "scripts/lib/tlh-install-paths.mjs" && file.installName === "lib/tlh-install-paths.mjs"));
 });
 
 test("settings defaults declare when bundled subagent prompts are required", (t) => {

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -419,6 +419,43 @@ test("stage-1 keeps critical defaults on per-source install path while dry-run s
 	assert.doesNotMatch(stdout, /pi update --extension npm:helper/);
 });
 
+test("install-state refuses to write outside the configured isolated profile", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const outsideDir = join(root, "outside");
+	const outsideState = join(outsideDir, "install-state.json");
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	mkdirSync(outsideDir, { recursive: true });
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const result = spawnSync(process.execPath, [
+		join(repoRoot, "scripts/tlh-install-state.mjs"),
+		"--state-path", outsideState,
+		"--repo", "owner/repo",
+		"--ref", "main",
+		"--track", "ref",
+		"--package-source", "git:github.com/owner/repo@main",
+		"--package-source-is-default", "true",
+		"--raw-base", "https://example.invalid/raw",
+		"--agent-dir", agentDir,
+		"--bin-dir", binDir,
+		"--wrapper-name", "tlh",
+	], {
+		cwd: repoRoot,
+		env: scrubInstallerEnv({ HOME: homeDir }),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /outside the isolated TLH profile/);
+	assert.equal(existsSync(outsideState), false);
+});
+
 test("stage-1 canonicalizes relative target dirs before deriving wrapper and state paths", (t) => {
 	const root = makeTempDir();
 	const homeDir = join(root, "home");

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -37,6 +37,38 @@ function runMerge(fixture) {
 function readJson(path) {
 	return JSON.parse(readFileSync(path, "utf8"));
 }
+
+test("merge refuses to write a symlinked settings target", () => {
+	const dir = mkdtempSync(join(tmpdir(), "tlh-merge-settings-symlink-test-"));
+	const agentDir = join(dir, "agent");
+	const outsideDir = join(dir, "outside");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(outsideDir, { recursive: true });
+	const defaults = join(dir, "settings.defaults.json");
+	const extensions = join(dir, "default-extensions.json");
+	const settings = join(agentDir, "settings.json");
+	const outsideSettings = join(outsideDir, "settings.json");
+	writeFileSync(defaults, JSON.stringify({ packages: ["npm:new-default"] }, null, 2));
+	writeFileSync(extensions, "[]\n");
+	writeFileSync(outsideSettings, JSON.stringify({ packages: [harnessPackage] }, null, 2));
+	symlinkSync(outsideSettings, settings);
+
+	const result = spawnSync(process.execPath, [
+		mergeScript,
+		defaults,
+		"--settings", settings,
+		"--default-extensions", extensions,
+		"--quiet",
+	], {
+		cwd: repoRoot,
+		env: process.env,
+		encoding: "utf8",
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /symlinked settings file/);
+	assert.deepEqual(readJson(outsideSettings), { packages: [harnessPackage] });
+});
 
 test("merge treats normalized subagents.agentDirs paths as duplicates", () => {
 	const fixture = tempFixture(


### PR DESCRIPTION
## Summary
- Add a shared safe-write helper for script-side TLH profile files with root confinement, symlink checks, randomized temp dirs, exclusive backup/temp creation, identity revalidation, permission preservation, and owned cleanup.
- Migrate high-risk script writes for settings, keybindings, defaults, Gnosis settings, install-state, support copies, and pre-install settings backup to the helper.
- Add adversarial/helper and integration coverage for protected normal Pi config, symlinked paths, predictable temp pre-creation, backup collision/symlink safety, failed write preservation, dry-run behavior, cleanup ownership, support-copy safety, and 0600 mode preservation.
- Close `tlhf-oxht` and implementation subtasks; add deferred follow-up `tlhf-gqbg` for runtime/wrapper/Gnosis-binary/etc. hardening consideration.

## Scope intentionally deferred
- Runtime TS extension writes
- Wrapper/bin managed-file writes
- Managed Gnosis binary install refactor
- `tlh-update` audit
- Future managed `tk` profile writes

## Validation
- `npm test` — passed, 94/94
- `bash scripts/check-installer-smoke.sh` — passed
- `npm run lint` — passed
- `node scripts/merge-settings.mjs --dry-run` — passed
- `npm pack --dry-run` — passed
- `git diff --check` — passed
- `test ! -e false` — passed

Final code review found no required changes.
