### PR TITLE
Set model and thinking for all subagents

### DIFF
--- a/agents/subagents/bug-catcher.md
+++ b/agents/subagents/bug-catcher.md
@@ -2,6 +2,8 @@
 name: bug-catcher
 description: Provides an independent read-only second opinion on bug investigations.
 tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-opus-4-7
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/bug-hunter.md
+++ b/agents/subagents/bug-hunter.md
@@ -2,6 +2,8 @@
 name: bug-hunter
 description: Investigates reported bugs, identifies root causes, and recommends fixes without changing code.
 tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-opus-4-7
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -2,6 +2,8 @@
 name: code-reviewer
 description: Reviews diffs against assigned tasks for correctness, security, and maintainability.
 tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-opus-4-7
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/developer.md
+++ b/agents/subagents/developer.md
@@ -2,6 +2,8 @@
 name: developer
 description: Implements exactly one approved architect task at a time.
 tools: read, write, edit, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-sonnet-4-6
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/diff-summarizer.md
+++ b/agents/subagents/diff-summarizer.md
@@ -2,6 +2,8 @@
 name: diff-summarizer
 description: Summarizes the current VCS diff and highlights review risk hotspots.
 tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-haiku-4-5
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/librarian.md
+++ b/agents/subagents/librarian.md
@@ -2,6 +2,8 @@
 name: librarian
 description: Researches external GitHub repositories and project history using the librarian extension tool.
 tools: librarian, read, grep, find, ls, contact_supervisor
+model: anthropic/claude-haiku-4-5
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/oracle.md
+++ b/agents/subagents/oracle.md
@@ -2,6 +2,8 @@
 name: oracle
 description: Provides read-only high-reasoning second opinions using the oracle extension tool.
 tools: oracle, read, grep, find, ls, contact_supervisor, bash
+model: anthropic/claude-opus-4-7
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/agents/subagents/repo-scout.md
+++ b/agents/subagents/repo-scout.md
@@ -2,6 +2,8 @@
 name: repo-scout
 description: Scans a repository and reports stack, conventions, commands, and hotspots.
 tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-haiku-4-5
+thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false


### PR DESCRIPTION
Adds `model` and `thinking` to the two remaining subagents (oracle, librarian) so all subagents have explicit models, matching the pattern already applied to the others.

- `oracle` → `anthropic/claude-opus-4-7` + `thinking: high` (high-reasoning second opinions)
- `librarian` → `anthropic/claude-haiku-4-5` + `thinking: high` (tool-wrapping research, matches repo-scout/diff-summarizer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated subagent configurations across the system to enable enhanced reasoning modes.
  * Assigned appropriate AI models to multiple subagents (bug-catcher, bug-hunter, code-reviewer, developer, diff-summarizer, librarian, oracle, and repo-scout) to optimize their performance and analytical capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->