### PR TITLE
Extract default extension helpers

### DIFF
--- a/.tickets/tlht-632w.md
+++ b/.tickets/tlht-632w.md
@@ -1,6 +1,6 @@
 ---
 id: tlht-632w
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-05-20T19:03:26Z

--- a/scripts/lib/default-extensions.mjs
+++ b/scripts/lib/default-extensions.mjs
@@ -1,0 +1,154 @@
+import { existsSync, readFileSync } from "node:fs";
+
+function isPlainObject(value) {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readManifestJson(path, { allowMissing }) {
+	if (!existsSync(path)) {
+		if (allowMissing) return [];
+		throw new Error(`File does not exist: ${path}`);
+	}
+	const raw = readFileSync(path, "utf8").replace(/^\uFEFF/, "");
+	if (!raw.trim()) return {};
+	try {
+		return JSON.parse(raw);
+	} catch (error) {
+		throw new Error(`Invalid JSON in ${path}: ${error.message}`);
+	}
+}
+
+function readStringArrayField(entry, key, label) {
+	if (entry[key] === undefined) return [];
+	if (!Array.isArray(entry[key])) {
+		throw new Error(`Default extension ${label} field '${key}' must be an array`);
+	}
+	return entry[key]
+		.map((value) => (typeof value === "string" ? value.trim() : ""))
+		.filter((value) => value.length > 0);
+}
+
+function readBooleanField(entry, key, label) {
+	if (entry[key] === undefined) return false;
+	if (typeof entry[key] !== "boolean") {
+		throw new Error(`Default extension ${label} field '${key}' must be a boolean`);
+	}
+	return entry[key];
+}
+
+function npmIdentity(spec) {
+	const withoutPrefix = spec.slice("npm:".length).trim();
+	if (!withoutPrefix) return spec;
+	if (withoutPrefix.startsWith("@")) {
+		const secondAt = withoutPrefix.indexOf("@", 1);
+		return `npm:${secondAt === -1 ? withoutPrefix : withoutPrefix.slice(0, secondAt)}`;
+	}
+	const firstAt = withoutPrefix.indexOf("@");
+	return `npm:${firstAt === -1 ? withoutPrefix : withoutPrefix.slice(0, firstAt)}`;
+}
+
+function gitIdentity(source) {
+	let value = source.trim();
+	if (value.startsWith("git:")) value = value.slice("git:".length).trim();
+	value = value.replace(/^https?:\/\//i, "");
+	value = value.replace(/^ssh:\/\//i, "");
+	value = value.replace(/^git:\/\//i, "");
+	value = value.replace(/^git@([^:]+):/, "$1/");
+	value = value.replace(/#.*$/, "");
+	value = value.replace(/\.git$/, "");
+	value = value.replace(/\.git(?=@)/, "");
+
+	const lastSlash = value.lastIndexOf("/");
+	const refAt = lastSlash === -1 ? -1 : value.indexOf("@", lastSlash + 1);
+	if (refAt !== -1) value = value.slice(0, refAt);
+
+	return `git:${value.toLowerCase()}`;
+}
+
+export function packageSourceOf(entry) {
+	if (typeof entry === "string") return entry;
+	if (isPlainObject(entry) && typeof entry.source === "string") return entry.source;
+	return undefined;
+}
+
+export function packageIdentity(entry) {
+	const source = packageSourceOf(entry);
+	if (!source) return undefined;
+	const trimmed = source.trim();
+	if (trimmed.startsWith("npm:")) return npmIdentity(trimmed);
+	if (
+		trimmed.startsWith("git:") ||
+		/^(https?|ssh|git):\/\//i.test(trimmed) ||
+		trimmed.startsWith("git@")
+	) {
+		return gitIdentity(trimmed);
+	}
+	return `local:${trimmed}`;
+}
+
+export function readDefaultExtensions(path, { allowMissing = false } = {}) {
+	const raw = readManifestJson(path, { allowMissing });
+	if (!Array.isArray(raw)) {
+		throw new Error(`Default extension manifest must be an array: ${path}`);
+	}
+
+	const seenIds = new Set();
+	const seenSources = new Set();
+	return raw.map((entry, index) => {
+		if (!isPlainObject(entry)) {
+			throw new Error(`Default extension entry ${index + 1} must be an object`);
+		}
+		const id = typeof entry.id === "string" ? entry.id.trim() : "";
+		const source = typeof entry.source === "string" ? entry.source.trim() : "";
+		const description = typeof entry.description === "string" ? entry.description.trim() : "";
+		const aliases = readStringArrayField(entry, "aliases", id || String(index + 1));
+		const replaces = readStringArrayField(entry, "replaces", id || String(index + 1));
+		const migrateReplacements = readBooleanField(entry, "migrateReplacements", id || String(index + 1));
+		const critical = readBooleanField(entry, "critical", id || String(index + 1));
+		if (!id) throw new Error(`Default extension entry ${index + 1} is missing id`);
+		if (!source) throw new Error(`Default extension ${id} is missing source`);
+		for (const candidateId of [id, ...aliases]) {
+			if (seenIds.has(candidateId)) throw new Error(`Duplicate default extension id or alias: ${candidateId}`);
+			seenIds.add(candidateId);
+		}
+		if (seenSources.has(packageIdentity(source))) throw new Error(`Duplicate default extension source: ${source}`);
+		seenSources.add(packageIdentity(source));
+		return { id, aliases, replaces, migrateReplacements, critical, source, description };
+	});
+}
+
+function rawDisabledDefaultExtensionIds(settings) {
+	if (!isPlainObject(settings)) return new Set();
+	const values = settings.tlh?.disabledDefaultExtensions;
+	if (!Array.isArray(values)) return new Set();
+	return new Set(values.filter((value) => typeof value === "string" && value.trim()).map((value) => value.trim()));
+}
+
+export function criticalDefaultExtensionOptOutIds(defaultExtensions) {
+	const ids = new Set();
+	for (const extension of defaultExtensions) {
+		if (extension.critical !== true) continue;
+		ids.add(extension.id);
+		for (const alias of extension.aliases) ids.add(alias);
+	}
+	return ids;
+}
+
+export function disabledDefaultExtensionIds(settings, defaultExtensions = []) {
+	const ids = rawDisabledDefaultExtensionIds(settings);
+	for (const id of criticalDefaultExtensionOptOutIds(defaultExtensions)) {
+		ids.delete(id);
+	}
+	for (const extension of defaultExtensions) {
+		if (extension.critical === true) continue;
+		if ([extension.id, ...extension.aliases].some((id) => ids.has(id))) {
+			ids.add(extension.id);
+			for (const alias of extension.aliases) ids.delete(alias);
+		}
+	}
+	return ids;
+}
+
+export function defaultExtensionPackageIdentities(extension) {
+	return [extension.source, ...extension.replaces].map(packageIdentity).filter(Boolean);
+}

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -5,6 +5,15 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
+import {
+	criticalDefaultExtensionOptOutIds,
+	defaultExtensionPackageIdentities,
+	disabledDefaultExtensionIds,
+	packageIdentity,
+	packageSourceOf,
+	readDefaultExtensions,
+} from "./lib/default-extensions.mjs";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -137,141 +146,6 @@ function isPlainObject(value) {
 
 function clone(value) {
 	return JSON.parse(JSON.stringify(value));
-}
-
-function packageSourceOf(entry) {
-	if (typeof entry === "string") return entry;
-	if (isPlainObject(entry) && typeof entry.source === "string") return entry.source;
-	return undefined;
-}
-
-function npmIdentity(spec) {
-	const withoutPrefix = spec.slice("npm:".length).trim();
-	if (!withoutPrefix) return spec;
-	if (withoutPrefix.startsWith("@")) {
-		const secondAt = withoutPrefix.indexOf("@", 1);
-		return `npm:${secondAt === -1 ? withoutPrefix : withoutPrefix.slice(0, secondAt)}`;
-	}
-	const firstAt = withoutPrefix.indexOf("@");
-	return `npm:${firstAt === -1 ? withoutPrefix : withoutPrefix.slice(0, firstAt)}`;
-}
-
-function gitIdentity(source) {
-	let value = source.trim();
-	if (value.startsWith("git:")) value = value.slice("git:".length).trim();
-	value = value.replace(/^https?:\/\//i, "");
-	value = value.replace(/^ssh:\/\//i, "");
-	value = value.replace(/^git:\/\//i, "");
-	value = value.replace(/^git@([^:]+):/, "$1/");
-	value = value.replace(/#.*$/, "");
-	value = value.replace(/\.git$/, "");
-	value = value.replace(/\.git(?=@)/, "");
-
-	const lastSlash = value.lastIndexOf("/");
-	const refAt = lastSlash === -1 ? -1 : value.indexOf("@", lastSlash + 1);
-	if (refAt !== -1) value = value.slice(0, refAt);
-
-	return `git:${value.toLowerCase()}`;
-}
-
-function packageIdentity(entry) {
-	const source = packageSourceOf(entry);
-	if (!source) return undefined;
-	const trimmed = source.trim();
-	if (trimmed.startsWith("npm:")) return npmIdentity(trimmed);
-	if (
-		trimmed.startsWith("git:") ||
-		/^(https?|ssh|git):\/\//i.test(trimmed) ||
-		trimmed.startsWith("git@")
-	) {
-		return gitIdentity(trimmed);
-	}
-	return `local:${trimmed}`;
-}
-
-function readStringArrayField(entry, key, label) {
-	if (entry[key] === undefined) return [];
-	if (!Array.isArray(entry[key])) {
-		throw new Error(`Default extension ${label} field '${key}' must be an array`);
-	}
-	return entry[key]
-		.map((value) => (typeof value === "string" ? value.trim() : ""))
-		.filter((value) => value.length > 0);
-}
-
-function readBooleanField(entry, key, label) {
-	if (entry[key] === undefined) return false;
-	if (typeof entry[key] !== "boolean") {
-		throw new Error(`Default extension ${label} field '${key}' must be a boolean`);
-	}
-	return entry[key];
-}
-
-function readDefaultExtensions(path) {
-	if (!existsSync(path)) return [];
-	const raw = readJson(path);
-	if (!Array.isArray(raw)) {
-		throw new Error(`Default extension manifest must be an array: ${path}`);
-	}
-
-	const seenIds = new Set();
-	const seenSources = new Set();
-	return raw.map((entry, index) => {
-		if (!isPlainObject(entry)) {
-			throw new Error(`Default extension entry ${index + 1} must be an object`);
-		}
-		const id = typeof entry.id === "string" ? entry.id.trim() : "";
-		const source = typeof entry.source === "string" ? entry.source.trim() : "";
-		const aliases = readStringArrayField(entry, "aliases", id || String(index + 1));
-		const replaces = readStringArrayField(entry, "replaces", id || String(index + 1));
-		const migrateReplacements = readBooleanField(entry, "migrateReplacements", id || String(index + 1));
-		const critical = readBooleanField(entry, "critical", id || String(index + 1));
-		if (!id) throw new Error(`Default extension entry ${index + 1} is missing id`);
-		if (!source) throw new Error(`Default extension ${id} is missing source`);
-		for (const candidateId of [id, ...aliases]) {
-			if (seenIds.has(candidateId)) throw new Error(`Duplicate default extension id or alias: ${candidateId}`);
-			seenIds.add(candidateId);
-		}
-		if (seenSources.has(packageIdentity(source))) throw new Error(`Duplicate default extension source: ${source}`);
-		seenSources.add(packageIdentity(source));
-		return { id, aliases, replaces, migrateReplacements, critical, source };
-	});
-}
-
-function rawDisabledDefaultExtensionIds(settings) {
-	if (!isPlainObject(settings)) return new Set();
-	const values = settings.tlh?.disabledDefaultExtensions;
-	if (!Array.isArray(values)) return new Set();
-	return new Set(values.filter((value) => typeof value === "string" && value.trim()).map((value) => value.trim()));
-}
-
-function criticalDefaultExtensionOptOutIds(defaultExtensions) {
-	const ids = new Set();
-	for (const extension of defaultExtensions) {
-		if (extension.critical !== true) continue;
-		ids.add(extension.id);
-		for (const alias of extension.aliases) ids.add(alias);
-	}
-	return ids;
-}
-
-function disabledDefaultExtensionIds(settings, defaultExtensions = []) {
-	const ids = rawDisabledDefaultExtensionIds(settings);
-	for (const id of criticalDefaultExtensionOptOutIds(defaultExtensions)) {
-		ids.delete(id);
-	}
-	for (const extension of defaultExtensions) {
-		if (extension.critical === true) continue;
-		if ([extension.id, ...extension.aliases].some((id) => ids.has(id))) {
-			ids.add(extension.id);
-			for (const alias of extension.aliases) ids.delete(alias);
-		}
-	}
-	return ids;
-}
-
-function defaultExtensionPackageIdentities(extension) {
-	return [extension.source, ...extension.replaces].map(packageIdentity).filter(Boolean);
 }
 
 function packageIdentityExists(packages, identity) {
@@ -635,7 +509,7 @@ function main() {
 	const existed = existsSync(settingsPath);
 	const existing = readJson(settingsPath, { missingValue: {} });
 	const rawDefaults = readJson(defaultsPath);
-	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath);
+	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath, { allowMissing: true });
 	const disabledIds = disabledDefaultExtensionIds(existing, defaultExtensions);
 	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
 	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });

--- a/scripts/tlh-defaults.mjs
+++ b/scripts/tlh-defaults.mjs
@@ -5,6 +5,13 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
+import {
+	disabledDefaultExtensionIds as disabledIdsFromSettings,
+	packageIdentity,
+	packageSourceOf,
+	readDefaultExtensions,
+} from "./lib/default-extensions.mjs";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -115,111 +122,12 @@ function readJson(path, { missingValue } = {}) {
 	}
 }
 
-function readStringArrayField(entry, key, label) {
-	if (entry[key] === undefined) return [];
-	if (!Array.isArray(entry[key])) {
-		throw new Error(`Default extension ${label} field '${key}' must be an array`);
-	}
-	return entry[key]
-		.map((value) => (typeof value === "string" ? value.trim() : ""))
-		.filter((value) => value.length > 0);
-}
-
-function readBooleanField(entry, key, label) {
-	if (entry[key] === undefined) return false;
-	if (typeof entry[key] !== "boolean") {
-		throw new Error(`Default extension ${label} field '${key}' must be a boolean`);
-	}
-	return entry[key];
-}
-
-function readDefaultExtensions(path) {
-	const raw = readJson(path);
-	if (!Array.isArray(raw)) {
-		throw new Error(`Default extension manifest must be an array: ${path}`);
-	}
-
-	const seenIds = new Set();
-	const seenSources = new Set();
-	return raw.map((entry, index) => {
-		if (!isPlainObject(entry)) {
-			throw new Error(`Default extension entry ${index + 1} must be an object`);
-		}
-		const id = typeof entry.id === "string" ? entry.id.trim() : "";
-		const source = typeof entry.source === "string" ? entry.source.trim() : "";
-		const description = typeof entry.description === "string" ? entry.description.trim() : "";
-		const aliases = readStringArrayField(entry, "aliases", id || String(index + 1));
-		const replaces = readStringArrayField(entry, "replaces", id || String(index + 1));
-		const migrateReplacements = readBooleanField(entry, "migrateReplacements", id || String(index + 1));
-		const critical = readBooleanField(entry, "critical", id || String(index + 1));
-		if (!id) throw new Error(`Default extension entry ${index + 1} is missing id`);
-		if (!source) throw new Error(`Default extension ${id} is missing source`);
-		for (const candidateId of [id, ...aliases]) {
-			if (seenIds.has(candidateId)) throw new Error(`Duplicate default extension id or alias: ${candidateId}`);
-			seenIds.add(candidateId);
-		}
-		if (seenSources.has(packageIdentity(source))) throw new Error(`Duplicate default extension source: ${source}`);
-		seenSources.add(packageIdentity(source));
-		return { id, aliases, replaces, migrateReplacements, critical, source, description };
-	});
-}
-
 function isPlainObject(value) {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function clone(value) {
 	return JSON.parse(JSON.stringify(value));
-}
-
-function packageSourceOf(entry) {
-	if (typeof entry === "string") return entry;
-	if (isPlainObject(entry) && typeof entry.source === "string") return entry.source;
-	return undefined;
-}
-
-function npmIdentity(spec) {
-	const withoutPrefix = spec.slice("npm:".length).trim();
-	if (!withoutPrefix) return spec;
-	if (withoutPrefix.startsWith("@")) {
-		const secondAt = withoutPrefix.indexOf("@", 1);
-		return `npm:${secondAt === -1 ? withoutPrefix : withoutPrefix.slice(0, secondAt)}`;
-	}
-	const firstAt = withoutPrefix.indexOf("@");
-	return `npm:${firstAt === -1 ? withoutPrefix : withoutPrefix.slice(0, firstAt)}`;
-}
-
-function gitIdentity(source) {
-	let value = source.trim();
-	if (value.startsWith("git:")) value = value.slice("git:".length).trim();
-	value = value.replace(/^https?:\/\//i, "");
-	value = value.replace(/^ssh:\/\//i, "");
-	value = value.replace(/^git:\/\//i, "");
-	value = value.replace(/^git@([^:]+):/, "$1/");
-	value = value.replace(/#.*$/, "");
-	value = value.replace(/\.git$/, "");
-	value = value.replace(/\.git(?=@)/, "");
-
-	const lastSlash = value.lastIndexOf("/");
-	const refAt = lastSlash === -1 ? -1 : value.indexOf("@", lastSlash + 1);
-	if (refAt !== -1) value = value.slice(0, refAt);
-
-	return `git:${value.toLowerCase()}`;
-}
-
-function packageIdentity(entry) {
-	const source = packageSourceOf(entry);
-	if (!source) return undefined;
-	const trimmed = source.trim();
-	if (trimmed.startsWith("npm:")) return npmIdentity(trimmed);
-	if (
-		trimmed.startsWith("git:") ||
-		/^(https?|ssh|git):\/\//i.test(trimmed) ||
-		trimmed.startsWith("git@")
-	) {
-		return gitIdentity(trimmed);
-	}
-	return `local:${trimmed}`;
 }
 
 function packageEntryDisablesExtensions(entry) {
@@ -232,38 +140,6 @@ function packageEntryDisablesExtensions(entry) {
 		.filter((value) => typeof value === "string")
 		.map((value) => value.trim())
 		.some((value) => disablingPatterns.has(value));
-}
-
-function rawDisabledIdsFromSettings(settings) {
-	if (!isPlainObject(settings)) return new Set();
-	const values = settings.tlh?.disabledDefaultExtensions;
-	if (!Array.isArray(values)) return new Set();
-	return new Set(values.filter((value) => typeof value === "string" && value.trim()).map((value) => value.trim()));
-}
-
-function criticalDefaultExtensionOptOutIds(defaultExtensions) {
-	const ids = new Set();
-	for (const extension of defaultExtensions) {
-		if (extension.critical !== true) continue;
-		ids.add(extension.id);
-		for (const alias of extension.aliases) ids.add(alias);
-	}
-	return ids;
-}
-
-function disabledIdsFromSettings(settings, defaultExtensions = []) {
-	const ids = rawDisabledIdsFromSettings(settings);
-	for (const id of criticalDefaultExtensionOptOutIds(defaultExtensions)) {
-		ids.delete(id);
-	}
-	for (const extension of defaultExtensions) {
-		if (extension.critical === true) continue;
-		if ([extension.id, ...extension.aliases].some((id) => ids.has(id))) {
-			ids.add(extension.id);
-			for (const alias of extension.aliases) ids.delete(alias);
-		}
-	}
-	return ids;
 }
 
 function validateSettings(settings) {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 
+import { packageIdentity, readDefaultExtensions } from "../scripts/lib/default-extensions.mjs";
+
 const repoRoot = resolve(import.meta.dirname, "..");
 const mergeScript = join(repoRoot, "scripts", "merge-settings.mjs");
 const defaultsScript = join(repoRoot, "scripts", "tlh-defaults.mjs");
@@ -43,6 +45,62 @@ const disablingExtensionFilterCases = [
 	{ name: "allowlist excluding hard-coded entrypoint", extensions: ["other.ts"] },
 	{ name: "allowlist excluding real subagents entrypoint", extensions: ["index.ts"] },
 ];
+
+test("shared package identity keeps npm, git, and local source semantics", () => {
+	assert.equal(packageIdentity("npm:helper@1.2.3"), "npm:helper");
+	assert.equal(packageIdentity("npm:@scope/helper@1.2.3"), "npm:@scope/helper");
+	assert.equal(packageIdentity("git:github.com/TLH/helper@pin"), "git:github.com/tlh/helper");
+	assert.equal(packageIdentity("https://github.com/TLH/helper.git#pin"), "git:github.com/tlh/helper");
+	assert.equal(packageIdentity("git@github.com:TLH/helper.git"), "git:github.com/tlh/helper");
+	assert.equal(packageIdentity("../local-helper@pin"), "local:../local-helper@pin");
+});
+
+test("shared default-extension reader trims descriptions and can allow missing manifests", () => {
+	const fixture = tempFixture();
+	writeFileSync(fixture.extensions, JSON.stringify([
+		{
+			id: "helper",
+			description: "  Helpful default  ",
+			source: "npm:helper",
+		},
+	], null, 2));
+
+	assert.deepEqual(readDefaultExtensions(fixture.extensions), [
+		{
+			id: "helper",
+			aliases: [],
+			replaces: [],
+			migrateReplacements: false,
+			critical: false,
+			source: "npm:helper",
+			description: "Helpful default",
+		},
+	]);
+	assert.deepEqual(readDefaultExtensions(join(fixture.dir, "missing-default-extensions.json"), { allowMissing: true }), []);
+	assert.throws(
+		() => readDefaultExtensions(join(fixture.dir, "missing-default-extensions.json")),
+		/File does not exist:/,
+	);
+});
+
+test("tlh-defaults errors when the default-extension manifest is missing", () => {
+	const fixture = tempFixture();
+	writeFileSync(fixture.settings, JSON.stringify({ packages: [] }, null, 2));
+
+	const result = spawnSync(process.execPath, [
+		defaultsScript,
+		"--settings", fixture.settings,
+		"--defaults", join(fixture.dir, "missing-default-extensions.json"),
+		"list",
+	], {
+		cwd: repoRoot,
+		env: process.env,
+		encoding: "utf8",
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /File does not exist:/);
+});
 
 test("merge ignores and cleans stale/manual critical opt-outs while preserving non-critical opt-outs", () => {
 	const fixture = tempFixture();

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -38,6 +38,27 @@ function readJson(path) {
 	return JSON.parse(readFileSync(path, "utf8"));
 }
 
+test("merge treats a missing default-extension manifest as empty", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{ packages: [harnessPackage] },
+	);
+
+	execFileSync(process.execPath, [
+		mergeScript,
+		fixture.defaults,
+		"--settings", fixture.settings,
+		"--default-extensions", `${fixture.extensions}.missing`,
+		"--quiet",
+	], {
+		cwd: repoRoot,
+		env: process.env,
+		encoding: "utf8",
+	});
+
+	assert.deepEqual(readJson(fixture.settings).packages, [harnessPackage]);
+});
+
 test("merge treats normalized subagents.agentDirs paths as duplicates", () => {
 	const fixture = tempFixture(
 		{


### PR DESCRIPTION
## Summary
- Add `scripts/lib/default-extensions.mjs` for shared default-extension manifest parsing, package identity, replacement identity, and critical opt-out helpers.
- Update `merge-settings` and `tlh-defaults` to use the shared helpers while preserving their different missing-manifest behavior.
- Add focused regression tests and close `tlht-632w`.

## Validation
- `node --test tests/default-extensions.test.mjs tests/merge-settings.test.mjs tests/install-stage1.test.mjs`
- `npm run lint`
- `node scripts/merge-settings.mjs --dry-run`
- `npm run validate`
- After rebasing on `origin/main`: `node --test tests/default-extensions.test.mjs tests/merge-settings.test.mjs`
- After rebasing on `origin/main`: `npm run lint`

## Notes
- Rebased onto current `origin/main`; duplicate commits from the already-merged aggregate-validation PR were skipped.