### PR TITLE
Fix installer helper support manifest

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -360,6 +360,7 @@ required|scripts/lib/tlh-install-utils.mjs
 required|scripts/lib/tlh-install-git.mjs
 required|scripts/lib/tlh-install-subagents.mjs
 required|scripts/lib/tlh-install-support-files.mjs
+required|scripts/lib/default-extensions.mjs
 required|scripts/tlh-install-query.mjs
 required|scripts/merge-settings.mjs
 required|scripts/tlh-defaults.mjs

--- a/scripts/check-installer-smoke.sh
+++ b/scripts/check-installer-smoke.sh
@@ -138,6 +138,53 @@ run_support_manifest_smoke() {
   done
 }
 
+run_runtime_helper_import_manifest_smoke() {
+  log "Running installer runtime helper import manifest smoke check..."
+  run_scrubbed_installer_env node --input-type=module <<'NODE_RUNTIME_IMPORT_MANIFEST'
+import { readFileSync } from 'node:fs';
+import { dirname, join, normalize, sep } from 'node:path';
+
+import { supportFileManifest } from './scripts/lib/tlh-install-support-manifest.mjs';
+
+const fetchedRuntimeScripts = [
+  'scripts/merge-settings.mjs',
+  'scripts/tlh-defaults.mjs',
+];
+
+function toPosixPath(path) {
+  return path.split(sep).join('/');
+}
+
+function importedScriptLibHelpers(scriptPath) {
+  const source = readFileSync(scriptPath, 'utf8');
+  const staticImportPattern = /(?:^|\n)\s*import\s+(?:(?:[^'\"]+?)\s+from\s+)?["']([^"']+)["']/g;
+  const dynamicImportPattern = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+  return [
+    ...source.matchAll(staticImportPattern),
+    ...source.matchAll(dynamicImportPattern),
+  ]
+    .map((match) => match[1])
+    .filter((specifier) => specifier.startsWith('./lib/') || specifier.startsWith('../scripts/lib/'))
+    .map((specifier) => toPosixPath(normalize(join(dirname(scriptPath), specifier))))
+    .filter((relativePath) => relativePath.startsWith('scripts/lib/'));
+}
+
+const importedHelpers = new Set(fetchedRuntimeScripts.flatMap(importedScriptLibHelpers));
+const missingByMode = [];
+for (const noSettings of [false, true]) {
+  const manifestPaths = new Set(supportFileManifest({ noSettings }).map((file) => file.relativePath));
+  const missing = [...importedHelpers].filter((relativePath) => !manifestPaths.has(relativePath));
+  if (missing.length > 0) {
+    missingByMode.push(`${noSettings ? 'no-settings' : 'with-settings'}: ${missing.join(', ')}`);
+  }
+}
+
+if (missingByMode.length > 0) {
+  throw new Error(`scripts/lib helper imports are absent from installer support manifest: ${missingByMode.join('; ')}`);
+}
+NODE_RUNTIME_IMPORT_MANIFEST
+}
+
 run_install_query_smoke() {
   log "Running installer query smoke check..."
   local case_dir="${TMP_ROOT}/install-query"
@@ -1110,6 +1157,7 @@ EOF_FAKE_RELEASE_STAGE1
 
 run_static_checks
 run_support_manifest_smoke
+run_runtime_helper_import_manifest_smoke
 run_install_query_smoke
 run_stage1_dry_run_smoke
 run_stage1_relative_path_canonicalization_smoke

--- a/scripts/lib/tlh-install-support-manifest.mjs
+++ b/scripts/lib/tlh-install-support-manifest.mjs
@@ -59,6 +59,13 @@ const BASE_SUPPORT_FILES = Object.freeze([
 		installName: "",
 	},
 	{
+		variable: "DEFAULT_EXTENSIONS_LIB",
+		requirement: REQUIRED,
+		relativePath: "scripts/lib/default-extensions.mjs",
+		tempPath: "lib/default-extensions.mjs",
+		installName: "lib/default-extensions.mjs",
+	},
+	{
 		variable: "TLH_INSTALL_QUERY_SCRIPT",
 		requirement: REQUIRED,
 		relativePath: "scripts/tlh-install-query.mjs",


### PR DESCRIPTION
## Summary
- include `scripts/lib/default-extensions.mjs` in the stage-0/stage-1 installer support manifests
- install the helper under the isolated profile support dir for installed helper scripts
- add a smoke check that catches missing `scripts/lib` helper imports from fetched runtime scripts

## Tests
- `npm run validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installer verification to validate all required helper files are included in the installation manifest.
  * Improved support file dependency tracking for installer configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->