### PR TITLE
Force checkout after dirty-tree backup

### DIFF
--- a/scripts/lib/tlh-install-git.mjs
+++ b/scripts/lib/tlh-install-git.mjs
@@ -181,9 +181,10 @@ export function refreshGitCheckout(config, { targetDir, repo, ref, label, missin
 		commitTreeArgs.push("-m", `tlh backup ${timestamp}`);
 		const commit = gitOutput(config, targetDir, commitTreeArgs, io);
 
-		// Store behind a private ref and drop the staged index.
+		// Store behind a private ref. The working tree stays dirty for now; the
+		// forced checkout below discards it safely because the backup ref holds
+		// the user's changes.
 		runGitCommand(config, ["git", "-C", targetDir, "update-ref", backupRef, commit], io);
-		runGitCommand(config, ["git", "-C", targetDir, "reset", "--mixed"], io);
 
 		// Report the backup so the user knows how to recover.
 		const parentOrEmpty = parent ?? "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
@@ -208,7 +209,7 @@ export function refreshGitCheckout(config, { targetDir, repo, ref, label, missin
 		targetRef = `refs/remotes/origin/${ref}`;
 	}
 
-	runGitCommand(config, ["git", "-C", targetDir, "checkout", "--detach", targetRef], io);
+	runGitCommand(config, ["git", "-C", targetDir, "checkout", "-f", "--detach", targetRef], io);
 	runGitCommand(config, ["git", "-C", targetDir, "reset", "--hard", targetRef], io);
 	runGitCommand(config, ["git", "-C", targetDir, "clean", "-fdx"], io);
 	if (existsSync(join(targetDir, "package.json"))) {


### PR DESCRIPTION
Follow-up to #24.

The dirty-checkout backup added in #24 saves local changes to a `refs/tlh-backup/*` ref, but the subsequent `git reset --mixed` only unstages — it does not clean the working tree. The next `git checkout --detach <ref>` therefore still aborts with the same \"Your local changes would be overwritten by checkout\" error that the backup was meant to unblock.

Repro on `main` after #24:

\`\`\`sh
# Inside the cached package checkout under the isolated profile:
echo change >> agents/primary/architect.md
bash install.sh
# ... backup ref is created, then:
# error: Your local changes to the following files would be overwritten by checkout:
#     agents/primary/architect.md
# Please commit your changes or stash them before you switch branches.
# Aborting
\`\`\`

This change:

- Drops the no-op `git reset --mixed` (the backup ref already holds the user's changes; clearing the index without touching the working tree does nothing useful).
- Passes `-f` to the existing `git checkout --detach` so it discards the working tree, which is safe because the backup ref preserves everything.

Verified manually: with both a modified tracked file and an untracked file in the cached checkout, `bash install.sh` now completes; `git for-each-ref refs/tlh-backup/` shows the backup; `git show <ref>` contains both changes; the working tree is clean after install.