### PR TITLE
Restructure TLH footer into three lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Footer restructured into three logical lines: working directory/git (unchanged), a single flowing `agent: … • model • thinking • context` line, and an optional session-stats line showing cost and/or subscription usage. Empty lines are omitted entirely.
+- Subscription usage session label now reads e.g. `5h session 27% used` (was `5h 27% used`).
+
 ## [0.10.0] - 2026-05-21
 
 ### Added

--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -79,16 +79,16 @@ function formatUsageWindowLabel(
 
 	const duration = formatUsageDuration(window.durationMs);
 	if (duration) {
-		return duration;
+		return `${duration} session`;
 	}
 
 	const key = normalizedUsageLabel(window.key);
 	const label = normalizedUsageLabel(window.label);
 	if (provider === "anthropic" && [key, label].some((value) => ["five-hour", "five-hours", "5h"].includes(value))) {
-		return "5h";
+		return "5h session";
 	}
 
-	return window.label && window.label !== windowType ? window.label : "session";
+	return "session";
 }
 
 function formatUsageWindow(

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import {
 	keyText,
 	type ExtensionAPI,
@@ -79,6 +79,7 @@ export function createTlhFooter(
 			const contextPercentValue = contextUsage?.percent ?? 0;
 			const contextPercent = contextUsage?.percent !== null ? contextPercentValue.toFixed(1) : "?";
 
+			// Line 1: cwd • branch • git-status • PR • sessionName (unchanged)
 			const pwd = composeTlhFooterFirstLine({
 				cwd: formatHomePath(ctx.sessionManager.getCwd()),
 				sessionName: ctx.sessionManager.getSessionName(),
@@ -86,17 +87,21 @@ export function createTlhFooter(
 				pullRequest: gitCache?.getPullRequestSnapshot(),
 				fallbackBranch: footerData?.getGitBranch?.(),
 			});
+			const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
 
-			const statsParts: string[] = [];
-			const subscriptionUsageState = getTlhSubscriptionUsageFooterState(ctx, model, usageOptions);
-			// In tlh, hide dollar-cost estimates whenever the user is on a subscription (eligible)
-			// or any other OAuth-authenticated provider (e.g. GitHub Copilot). The subscription-usage
-			// segment still renders only for supported subscription providers.
-			if (totals.cost > 0 && !subscriptionUsageState.suppressCost) {
-				statsParts.push(formatCost(totals.cost));
+			// Line 2 (single flowing left-justified line):
+			//   agent: <primaryName> • [(provider)] <model|no-model> [• thinking] • context% [• DUMB ZONE]
+			const modelOrNoModel = model?.id ?? "no-model";
+			let modelPart: string = modelOrNoModel;
+			if ((footerData?.getAvailableProviderCount?.() ?? 1) > 1 && model) {
+				modelPart = `(${model.provider}) ${modelOrNoModel}`;
 			}
-			if (subscriptionUsageState.segment) {
-				statsParts.push(subscriptionUsageState.segment);
+
+			const line2Parts: string[] = [`agent: ${getPrimaryName()}`, modelPart];
+
+			if (model?.reasoning) {
+				const thinkingLevel = getCurrentThinkingLevel(pi);
+				line2Parts.push(thinkingLevel === "off" ? "thinking off" : thinkingLevel);
 			}
 
 			const contextPercentDisplay =
@@ -109,61 +114,29 @@ export function createTlhFooter(
 			} else {
 				contextPercentStr = contextPercentDisplay;
 			}
-			let contextStats = contextPercentStr;
+			line2Parts.push(contextPercentStr);
+
+			let agentLine2Str = line2Parts.join(" • ");
 			if ((contextUsage?.tokens ?? 0) > DUMB_ZONE_THRESHOLD_TOKENS) {
-				contextStats += `${theme.fg("dim", " • ")}${theme.fg("error", DUMB_ZONE_LABEL)}`;
+				agentLine2Str += `${theme.fg("dim", " • ")}${theme.fg("error", DUMB_ZONE_LABEL)}`;
 			}
-			statsParts.push(contextStats);
+			const agentLine2 = truncateToWidth(theme.fg("dim", agentLine2Str), width, theme.fg("dim", "..."));
 
-			let statsLeft = statsParts.join(" ");
-			let statsLeftWidth = visibleWidth(statsLeft);
-			if (statsLeftWidth > width) {
-				statsLeft = truncateToWidth(statsLeft, width, "...");
-				statsLeftWidth = visibleWidth(statsLeft);
-			}
+			// Line 3 (optional): [<cost> · ]<subscription usage segment>
+			// Omitted entirely when both parts are absent.
+			const subscriptionUsageState = getTlhSubscriptionUsageFooterState(ctx, model, usageOptions);
+			const costStr = totals.cost > 0 && !subscriptionUsageState.suppressCost ? formatCost(totals.cost) : undefined;
+			const line3Parts: string[] = [];
+			if (costStr) line3Parts.push(costStr);
+			if (subscriptionUsageState.segment) line3Parts.push(subscriptionUsageState.segment);
+			const line3 = line3Parts.length > 0 ? line3Parts.join(" · ") : undefined;
 
-			const modelName = model?.id || "no-model";
-			let rightSideWithoutProvider = modelName;
-			if (model?.reasoning) {
-				const thinkingLevel = getCurrentThinkingLevel(pi);
-				rightSideWithoutProvider =
-					thinkingLevel === "off" ? `${modelName} • thinking off` : `${modelName} • ${thinkingLevel}`;
-			}
-
-			const minPadding = 2;
-			let rightSide = rightSideWithoutProvider;
-			if ((footerData?.getAvailableProviderCount?.() ?? 1) > 1 && model) {
-				rightSide = `(${model.provider}) ${rightSideWithoutProvider}`;
-				if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
-					rightSide = rightSideWithoutProvider;
-				}
+			const lines: string[] = [pwdLine, agentLine2];
+			if (line3 !== undefined) {
+				lines.push(truncateToWidth(theme.fg("dim", line3), width, theme.fg("dim", "...")));
 			}
 
-			const rightSideWidth = visibleWidth(rightSide);
-			const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
-			let statsLine: string;
-			if (totalNeeded <= width) {
-				const padding = " ".repeat(width - statsLeftWidth - rightSideWidth);
-				statsLine = statsLeft + padding + rightSide;
-			} else {
-				const availableForRight = width - statsLeftWidth - minPadding;
-				if (availableForRight > 0) {
-					const truncatedRight = truncateToWidth(rightSide, availableForRight, "");
-					const truncatedRightWidth = visibleWidth(truncatedRight);
-					const padding = " ".repeat(Math.max(0, width - statsLeftWidth - truncatedRightWidth));
-					statsLine = statsLeft + padding + truncatedRight;
-				} else {
-					statsLine = statsLeft;
-				}
-			}
-
-			const dimStatsLeft = theme.fg("dim", statsLeft);
-			const remainder = statsLine.slice(statsLeft.length);
-			const dimRemainder = theme.fg("dim", remainder);
-			const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
-			const agentLine = truncateToWidth(theme.fg("dim", `agent: ${getPrimaryName()}`), width, theme.fg("dim", "..."));
-			const lines = [pwdLine, dimStatsLeft + dimRemainder, agentLine];
-
+			// Hint line (conditional on pending editor text during an active turn)
 			const editorText = ctx.ui.getEditorText();
 			if (editorText.length > 0 && !ctx.isIdle()) {
 				const steerKey = keyText("tui.input.submit") || "enter";
@@ -173,6 +146,7 @@ export function createTlhFooter(
 				lines.push(truncateToWidth(`${steeringHint}${theme.fg("muted", " · ")}${queueHint}`, width, theme.fg("dim", "...")));
 			}
 
+			// Extension status line (conditional on registered extension statuses)
 			const extensionStatuses = footerData?.getExtensionStatuses?.();
 			if (extensionStatuses && extensionStatuses.size > 0) {
 				const statusLine = Array.from(extensionStatuses.entries())

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -7,7 +7,9 @@ import { createJiti } from "jiti";
 import { createTlhSubscriptionUsageService } from "../extensions/the-last-harness/subscription-usage.mjs";
 
 const jiti = createJiti(import.meta.url);
-const { createTlhFooter, formatTlhSubscriptionUsageFooterSegment } = await jiti.import("../extensions/the-last-harness/footer.ts");
+const { createTlhFooter, formatTlhSubscriptionUsageFooterSegment } = await jiti.import(
+	"../extensions/the-last-harness/footer.ts",
+);
 
 const NOW_MS = Date.parse("2026-05-19T19:00:00Z");
 const WIDTH = 100;
@@ -108,39 +110,68 @@ function createCtx(options = {}) {
 	};
 }
 
-function renderFooterStatsLine(ctx, usageOptions, width = WIDTH, footerData = createFooterData()) {
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function renderFooterLines(ctx, usageOptions, width = WIDTH, footerData = createFooterData()) {
 	const footer = createTlhFooter(pi, ctx, theme, () => "architect", footerData, usageOptions);
-	return footer.render(width)[1];
+	return footer.render(width);
 }
+
+/**
+ * Line 2 (index 1): agent: <name> • [(provider)] <model> [• thinking] • context%
+ */
+function renderAgentLine(ctx, usageOptions, width = WIDTH, footerData = createFooterData()) {
+	return renderFooterLines(ctx, usageOptions, width, footerData)[1] ?? "";
+}
+
+/**
+ * Line 3 (index 2, optional): [<cost> · ]<subscription usage segment>
+ * Returns "" when Line 3 is omitted.
+ */
+function renderSessionStatsLine(ctx, usageOptions, width = WIDTH, footerData = createFooterData()) {
+	return renderFooterLines(ctx, usageOptions, width, footerData)[2] ?? "";
+}
+
+// ---------------------------------------------------------------------------
+// Existing rendering tests (updated for three-line layout)
+// ---------------------------------------------------------------------------
 
 test("footer renders OpenAI/Codex session usage and hides weekly by default", () => {
 	let requestedProvider;
-	const line = renderFooterStatsLine(createCtx({ provider: "openai-codex" }), {
+	const usageOptions = {
 		subscriptionUsage: usageProvider(openAiSnapshot(), (provider) => {
 			requestedProvider = provider;
 		}),
 		shouldShowWeekly: () => false,
-	});
+	};
+	const ctx = createCtx({ provider: "openai-codex" });
+	const lines = renderFooterLines(ctx, usageOptions);
+	const agentLine = lines[1] ?? "";
+	const sessionLine = lines[2] ?? "";
 
 	assert.equal(requestedProvider, "openai-codex");
-	assert.match(line, /session 42% used/);
-	assert.doesNotMatch(line, /weekly/);
-	assert.doesNotMatch(line, /\$/);
-	assert.match(line, /12\.3%\/200k/);
+	assert.match(sessionLine, /session 42% used/);
+	assert.doesNotMatch(sessionLine, /weekly/);
+	assert.doesNotMatch(sessionLine, /\$/);
+	assert.match(agentLine, /12\.3%\/200k/);
 });
 
 test("footer includes Anthropic weekly usage only when the preference enables it", () => {
 	const snapshot = anthropicSnapshot();
-	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: false }), "5h 42% used");
-	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true }), "5h 42% used · weekly 88.9% used");
+	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: false }), "5h session 42% used");
+	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true }), "5h session 42% used · weekly 88.9% used");
 
-	const line = renderFooterStatsLine(createCtx({ provider: "anthropic" }), {
+	const ctx = createCtx({ provider: "anthropic" });
+	const usageOptions = {
 		subscriptionUsage: usageProvider(snapshot),
 		shouldShowWeekly: () => true,
-	});
+	};
+	const sessionLine = renderSessionStatsLine(ctx, usageOptions);
 
-	assert.match(line, /5h 42% used/);
-	assert.match(line, /weekly 88\.9% used/);
+	assert.match(sessionLine, /5h session 42% used/);
+	assert.match(sessionLine, /weekly 88\.9% used/);
 });
 
 test("footer render reads cached usage snapshots without refreshing", () => {
@@ -155,26 +186,29 @@ test("footer render reads cached usage snapshots without refreshing", () => {
 		},
 	};
 
-	const line = renderFooterStatsLine(createCtx({ provider: "openai-codex" }), {
+	const sessionLine = renderSessionStatsLine(createCtx({ provider: "openai-codex" }), {
 		subscriptionUsage,
 		shouldShowWeekly: () => false,
 	});
 
-	assert.match(line, /session 42% used/);
+	assert.match(sessionLine, /session 42% used/);
 	assert.equal(refreshCalls, 0);
 });
 
 test("footer falls back to dollar cost when subscription usage is not strictly eligible", () => {
 	// Non-OAuth Anthropic session (e.g. API-key user): no subscription tracking and no OAuth gate,
 	// so the dollar fallback must remain visible.
-	const line = renderFooterStatsLine(createCtx({ provider: "anthropic", usingOAuth: false }), {
+	const ctx = createCtx({ provider: "anthropic", usingOAuth: false });
+	const usageOptions = {
 		subscriptionUsage: usageProvider(anthropicSnapshot(), undefined, false),
 		shouldShowWeekly: () => true,
-	});
+	};
+	const agentLine = renderAgentLine(ctx, usageOptions);
+	const sessionLine = renderSessionStatsLine(ctx, usageOptions);
 
-	assert.match(line, /\$1\.250/);
-	assert.doesNotMatch(line, /5h 42% used/);
-	assert.match(line, /12\.3%\/200k/);
+	assert.match(sessionLine, /\$1\.250/);
+	assert.doesNotMatch(sessionLine, /5h session 42% used/);
+	assert.match(agentLine, /12\.3%\/200k/);
 });
 
 test("footer suppresses dollar cost for eligible OAuth sessions before usage is cached", () => {
@@ -195,42 +229,53 @@ test("footer suppresses dollar cost for eligible OAuth sessions before usage is 
 		},
 	});
 
-	const line = renderFooterStatsLine(ctx, {
+	const usageOptions = {
 		subscriptionUsage: service,
 		shouldShowWeekly: () => true,
-	});
+	};
 
-	assert.doesNotMatch(line, /\$/);
-	assert.doesNotMatch(line, /used/);
-	assert.match(line, /12\.3%\/200k/);
+	const lines = renderFooterLines(ctx, usageOptions);
+	const agentLine = lines[1] ?? "";
+	const sessionLine = lines[2] ?? "";
+
+	assert.doesNotMatch(agentLine, /\$/);
+	assert.doesNotMatch(agentLine, /used/);
+	assert.match(agentLine, /12\.3%\/200k/);
+	// Line 3 is omitted: cost suppressed (OAuth), no subscription segment yet
+	assert.equal(sessionLine, "");
 	assert.equal(fetchCalls, 0);
 
 	runtimeOverrides.set("anthropic", "runtime-api-key");
-	const runtimeLine = renderFooterStatsLine(ctx, {
-		subscriptionUsage: service,
-		shouldShowWeekly: () => true,
-	});
+	const runtimeLines = renderFooterLines(ctx, usageOptions);
+	const runtimeAgentLine = runtimeLines[1] ?? "";
+	const runtimeSessionLine = runtimeLines[2] ?? "";
 
 	// The runtime override disables the subscription-usage panel, but the stored Anthropic
 	// credential is still OAuth so isUsingOAuth(model) remains true and the dollar fallback
 	// stays suppressed.
-	assert.doesNotMatch(runtimeLine, /\$/);
-	assert.doesNotMatch(runtimeLine, /used/);
+	assert.doesNotMatch(runtimeAgentLine, /\$/);
+	assert.doesNotMatch(runtimeAgentLine, /used/);
+	assert.equal(runtimeSessionLine, "");
 	assert.equal(fetchCalls, 0);
 });
 
 test("footer leaves usage unchanged for unsupported providers and snapshot errors", () => {
 	// API-key user on an unsupported provider: cost should still render as the fallback.
-	const unsupportedLine = renderFooterStatsLine(createCtx({ provider: "openrouter", usingOAuth: false }), {
+	const unsupportedCtx = createCtx({ provider: "openrouter", usingOAuth: false });
+	const unsupportedUsage = {
 		subscriptionUsage: usageProvider(openAiSnapshot()),
 		shouldShowWeekly: () => true,
-	});
-	assert.doesNotMatch(unsupportedLine, /used/);
-	assert.doesNotMatch(unsupportedLine, /weekly/);
-	assert.match(unsupportedLine, /\$1\.250/);
-	assert.match(unsupportedLine, /12\.3%\/200k/);
+	};
+	const unsupportedAgentLine = renderAgentLine(unsupportedCtx, unsupportedUsage);
+	const unsupportedSessionLine = renderSessionStatsLine(unsupportedCtx, unsupportedUsage);
 
-	const errorLine = renderFooterStatsLine(createCtx({ provider: "anthropic" }), {
+	assert.doesNotMatch(unsupportedSessionLine, /used/);
+	assert.doesNotMatch(unsupportedSessionLine, /weekly/);
+	assert.match(unsupportedSessionLine, /\$1\.250/);
+	assert.match(unsupportedAgentLine, /12\.3%\/200k/);
+
+	const errorCtx = createCtx({ provider: "anthropic" });
+	const errorUsage = {
 		subscriptionUsage: {
 			getSnapshot() {
 				throw new Error("cached usage unavailable");
@@ -243,33 +288,42 @@ test("footer leaves usage unchanged for unsupported providers and snapshot error
 			},
 		},
 		shouldShowWeekly: () => true,
-	});
-	assert.doesNotMatch(errorLine, /used/);
-	assert.doesNotMatch(errorLine, /weekly/);
-	assert.doesNotMatch(errorLine, /\$/);
-	assert.match(errorLine, /12\.3%\/200k/);
+	};
+	const errorAgentLine = renderAgentLine(errorCtx, errorUsage);
+	const errorSessionLine = renderSessionStatsLine(errorCtx, errorUsage);
+
+	assert.doesNotMatch(errorSessionLine, /used/);
+	assert.doesNotMatch(errorSessionLine, /weekly/);
+	assert.doesNotMatch(errorSessionLine, /\$/);
+	assert.match(errorAgentLine, /12\.3%\/200k/);
 });
 
 test("footer suppresses dollar cost for OAuth users on unsupported providers", () => {
-	const line = renderFooterStatsLine(createCtx({ provider: "github-copilot", usingOAuth: true }), {
+	const ctx = createCtx({ provider: "github-copilot", usingOAuth: true });
+	const usageOptions = {
 		subscriptionUsage: usageProvider(openAiSnapshot(), undefined, false),
 		shouldShowWeekly: () => true,
-	});
+	};
+	const agentLine = renderAgentLine(ctx, usageOptions);
+	const sessionLine = renderSessionStatsLine(ctx, usageOptions);
 
-	assert.doesNotMatch(line, /\$/);
-	assert.doesNotMatch(line, /used/);
-	assert.match(line, /12\.3%\/200k/);
+	assert.doesNotMatch(sessionLine, /\$/);
+	assert.doesNotMatch(sessionLine, /used/);
+	assert.match(agentLine, /12\.3%\/200k/);
 });
 
 test("footer shows dollar cost when neither OAuth nor subscription-eligible", () => {
-	const line = renderFooterStatsLine(createCtx({ provider: "openrouter", usingOAuth: false }), {
+	const ctx = createCtx({ provider: "openrouter", usingOAuth: false });
+	const usageOptions = {
 		subscriptionUsage: usageProvider(openAiSnapshot(), undefined, false),
 		shouldShowWeekly: () => true,
-	});
+	};
+	const agentLine = renderAgentLine(ctx, usageOptions);
+	const sessionLine = renderSessionStatsLine(ctx, usageOptions);
 
-	assert.match(line, /\$1\.250/);
-	assert.doesNotMatch(line, /used/);
-	assert.match(line, /12\.3%\/200k/);
+	assert.match(sessionLine, /\$1\.250/);
+	assert.doesNotMatch(sessionLine, /used/);
+	assert.match(agentLine, /12\.3%\/200k/);
 });
 
 test("usage footer stays within narrow terminal widths", () => {
@@ -285,6 +339,89 @@ test("usage footer stays within narrow terminal widths", () => {
 	const width = 24;
 	const lines = footer.render(width);
 	assert.ok(lines.every((line) => visibleWidth(line) <= width));
+	// Agent line (index 1) is truncated due to the long model name
 	assert.match(lines[1], /\.\.\./);
-	assert.match(lines[1], /^5h 42% used/);
+	// Session stats line (index 2) starts with the subscription segment
+	assert.match(lines[2], /^5h session 42% used/);
+});
+
+// ---------------------------------------------------------------------------
+// NEW: focused line-2 composition tests
+// ---------------------------------------------------------------------------
+
+test("line 2 shows model without provider prefix when single provider", () => {
+	const line = renderAgentLine(createCtx({ provider: "anthropic" }), {});
+	assert.match(line, /^agent: architect • claude-sonnet-4-20250514 • /);
+	assert.doesNotMatch(line, /\(anthropic\)/);
+});
+
+test("line 2 shows provider prefix when multiple providers available", () => {
+	const line = renderAgentLine(createCtx({ provider: "anthropic" }), {}, WIDTH, createFooterData({ providerCount: 2 }));
+	assert.match(line, /^agent: architect • \(anthropic\) claude-sonnet-4-20250514 • /);
+});
+
+test("line 2 shows thinking level for reasoning models", () => {
+	const ctx = createCtx({
+		model: { provider: "anthropic", id: "claude-opus-4-reasoning", contextWindow: 200000, reasoning: true },
+	});
+	const line = renderAgentLine(ctx, {});
+	assert.match(line, /claude-opus-4-reasoning • medium • /);
+});
+
+test("line 2 shows thinking off label when thinking is disabled on a reasoning model", () => {
+	const piOff = { getThinkingLevel: () => "off" };
+	const ctx = createCtx({
+		model: { provider: "anthropic", id: "claude-opus-4-reasoning", contextWindow: 200000, reasoning: true },
+	});
+	const footer = createTlhFooter(piOff, ctx, theme, () => "architect", createFooterData(), {});
+	const line = footer.render(WIDTH)[1];
+	assert.match(line, /claude-opus-4-reasoning • thinking off • /);
+});
+
+test("line 2 shows no-model placeholder when context has no model", () => {
+	const ctx = { ...createCtx(), model: undefined };
+	const line = renderAgentLine(ctx, {});
+	assert.match(line, /^agent: architect • no-model • /);
+	assert.doesNotMatch(line, /\(undefined\)/);
+});
+
+test("line 2 includes context percent and omits provider prefix for no-model", () => {
+	const ctx = { ...createCtx(), model: undefined };
+	const line = renderAgentLine(ctx, {});
+	assert.match(line, /12\.3%\/200k/);
+	assert.doesNotMatch(line, /\(/);
+});
+
+// ---------------------------------------------------------------------------
+// NEW: focused line-3 rendered omission and presence tests
+// ---------------------------------------------------------------------------
+
+test("line 3 is omitted when cost is zero and there is no subscription segment", () => {
+	const ctx = createCtx({ entries: [], usingOAuth: false });
+	const lines = renderFooterLines(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot(), undefined, false),
+		shouldShowWeekly: () => false,
+	});
+	// Only pwd (index 0) and agent line (index 1) — no stats line
+	assert.equal(lines.length, 2);
+});
+
+test("line 3 renders cost only when cost is present and subscription is absent", () => {
+	const ctx = createCtx({ provider: "openrouter", usingOAuth: false });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(undefined, undefined, false),
+		shouldShowWeekly: () => false,
+	});
+	assert.match(sessionLine, /^\$1\.250$/);
+	assert.doesNotMatch(sessionLine, /·/);
+});
+
+test("line 3 renders subscription only when cost is suppressed and segment is present", () => {
+	const ctx = createCtx({ provider: "anthropic" }); // usingOAuth: true → suppressCost
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(anthropicSnapshot()),
+		shouldShowWeekly: () => false,
+	});
+	assert.match(sessionLine, /^5h session 42% used$/);
+	assert.doesNotMatch(sessionLine, /\$/);
 });


### PR DESCRIPTION
## Summary

Reworks the TLH footer into three logical lines and tightens the subscription usage label.

- **Line 1** (unchanged): cwd • branch • git status • PR • session name
- **Line 2** (new, single flowing line): `agent: <name> • [(provider)] <model> [• <thinking>] • <ctx%>/<window> [• DUMB ZONE]`. The previous right-justified model display is gone — the selected agent, its model, thinking effort, and context budget now read together.
- **Line 3** (new): `[<cost> · ]<subscription usage>`. Omitted entirely when both are absent. Other dependent lines (typing hints, extension status) remain conditional as before.
- **Subscription session label**: `5h 27% used` → `5h session 27% used` (or just `session 27% used` when no duration is known). Weekly label unchanged.

Provider-prefix gating (only when `getAvailableProviderCount() > 1` and a model exists), context-percent warning/error coloring (>70 / >90), DUMB ZONE indicator, and dim-truncation behavior are all preserved.

## Files

- `extensions/the-last-harness/footer.ts` — new 3-line layout, line 3 omitted when empty
- `extensions/the-last-harness/footer-subscription-usage.ts` — session label tweak
- `tests/the-last-harness-footer-usage.test.mjs` — updated assertions, added focused tests for line-2 variants and line-3 cost-only / subscription-only / omitted cases
- `CHANGELOG.md` — Unreleased entry

## Validation

`npm run validate` — 217 tests pass, lint clean, installer smoke checks pass, `npm pack --dry-run` OK.

## Notes

- The intermediate `formatTlhFooterLine3` helper was inlined after review: its cost+subscription branch is unreachable through `createTlhFooter` (`suppressCost` is always true when a subscription segment exists).
- Vendor-supplied non-standard session labels are now collapsed to `session`. Acceptable for the currently supported providers (`openai-codex`, `anthropic`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Restructured footer layout into three logical sections: working directory status, agent/model/thinking/context information, and optional session stats
  * Updated subscription usage label formatting (e.g., "5h session" instead of previous format)

* **Documentation**
  * Updated changelog documenting footer restructuring

* **Tests**
  * Expanded test coverage for new footer layout and subscription label formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->