### PR TITLE
Fix footer git cache repaint

### DIFF
--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -87,6 +87,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 				requestFooterRenderByContext.set(ctx, () => tui.requestRender());
 				const gitCache = new FooterGitCache({
 					cwd: () => ctx.sessionManager.getCwd(),
+					onChange: () => tui.requestRender(),
 					onBranchChangeSource:
 						typeof footerData?.onBranchChange === "function" ? (cb) => footerData.onBranchChange(cb) : undefined,
 				});

--- a/extensions/the-last-harness/footer-git-cache.ts
+++ b/extensions/the-last-harness/footer-git-cache.ts
@@ -69,6 +69,12 @@ export type FooterGitCacheOptions = {
 	/** Skip the construction-time refresh. Useful for deterministic tests. */
 	skipInitialRefresh?: boolean;
 	/**
+	 * Optional callback fired after a refresh changes the visible footer git
+	 * snapshots. Not called for transient failures, identical snapshots, or
+	 * once the cache has been disposed.
+	 */
+	onChange?: () => void;
+	/**
 	 * Optional subscription to an external branch-change notifier. Shape
 	 * matches Pi's `ReadonlyFooterDataProvider.onBranchChange`: pass a
 	 * callback, receive an unsubscribe handle. When supplied, the cache
@@ -199,6 +205,34 @@ function parsePullRequestJson(stdout: string): PullRequestSnapshot | undefined {
 	return snapshot;
 }
 
+function gitStatusSnapshotsEqual(
+	left: GitStatusSnapshot | undefined,
+	right: GitStatusSnapshot | undefined,
+): boolean {
+	return (
+		left?.branch === right?.branch
+		&& left?.staged === right?.staged
+		&& left?.unstaged === right?.unstaged
+		&& left?.untracked === right?.untracked
+		&& left?.conflict === right?.conflict
+		&& left?.ahead === right?.ahead
+		&& left?.behind === right?.behind
+	);
+}
+
+function pullRequestSnapshotsEqual(
+	left: PullRequestSnapshot | undefined,
+	right: PullRequestSnapshot | undefined,
+): boolean {
+	return (
+		left?.number === right?.number
+		&& left?.state === right?.state
+		&& left?.isDraft === right?.isDraft
+		&& left?.url === right?.url
+		&& left?.title === right?.title
+	);
+}
+
 /**
  * Background cache for the TLH footer's git status and (best-effort) GitHub PR
  * metadata. Refreshes asynchronously and exposes synchronous snapshot getters
@@ -211,6 +245,7 @@ export class FooterGitCache {
 	private readonly refreshIntervalMs: number;
 	private readonly gitTimeoutMs: number;
 	private readonly ghTimeoutMs: number;
+	private readonly onChange: (() => void) | undefined;
 
 	private intervalHandle: TimerHandle | undefined;
 	private readonly inflightControllers = new Set<AbortController>();
@@ -229,6 +264,7 @@ export class FooterGitCache {
 		this.refreshIntervalMs = options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
 		this.gitTimeoutMs = options.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
 		this.ghTimeoutMs = options.ghTimeoutMs ?? DEFAULT_GH_TIMEOUT_MS;
+		this.onChange = options.onChange;
 
 		this.intervalHandle = this.clock.setInterval(() => {
 			void this.refresh();
@@ -281,6 +317,9 @@ export class FooterGitCache {
 	}
 
 	private async runRefresh(): Promise<void> {
+		const previousStatusSnapshot = this.statusSnapshot;
+		const previousPullRequestSnapshot = this.pullRequestSnapshot;
+
 		const result = await this.fetchGitStatus();
 		if (this.disposed) {
 			return;
@@ -297,6 +336,7 @@ export class FooterGitCache {
 			this.statusSnapshot = undefined;
 			this.pullRequestSnapshot = undefined;
 			this.lastSeenBranch = undefined;
+			this.emitChangeIfSnapshotsChanged(previousStatusSnapshot, previousPullRequestSnapshot);
 			return;
 		}
 		const status = result.status;
@@ -315,6 +355,7 @@ export class FooterGitCache {
 
 		if (!isValidBranch) {
 			this.pullRequestSnapshot = undefined;
+			this.emitChangeIfSnapshotsChanged(previousStatusSnapshot, previousPullRequestSnapshot);
 			return;
 		}
 
@@ -329,6 +370,27 @@ export class FooterGitCache {
 			this.pullRequestSnapshot = undefined;
 		}
 		// Otherwise (same branch, gh failed): keep prior PR snapshot.
+		this.emitChangeIfSnapshotsChanged(previousStatusSnapshot, previousPullRequestSnapshot);
+	}
+
+	private emitChangeIfSnapshotsChanged(
+		previousStatusSnapshot: GitStatusSnapshot | undefined,
+		previousPullRequestSnapshot: PullRequestSnapshot | undefined,
+	): void {
+		if (this.disposed) {
+			return;
+		}
+		if (
+			gitStatusSnapshotsEqual(previousStatusSnapshot, this.statusSnapshot)
+			&& pullRequestSnapshotsEqual(previousPullRequestSnapshot, this.pullRequestSnapshot)
+		) {
+			return;
+		}
+		try {
+			this.onChange?.();
+		} catch {
+			// Silent: rendering hooks must not break refreshes.
+		}
 	}
 
 	// Three-way split so runRefresh can distinguish persistent "not a repo"

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -201,6 +201,8 @@ test("extension wires subscription usage to lifecycle refreshes and footer", () 
 	assert.match(sessionStart, /refreshSubscriptionUsage\(ctx\)/);
 	assert.match(sessionStart, /subscriptionUsage: subscriptionUsageService/);
 	assert.match(sessionStart, /shouldShowTlhUsageWeekly\(getTlhUsageLimitsConfig\(ctx\.cwd\)\)/);
+	assert.match(sessionStart, /onChange: \(\) => tui\.requestRender\(\)/);
+	assert.match(sessionStart, /typeof footerData\?\.onBranchChange === "function" \? \(cb\) => footerData\.onBranchChange\(cb\) : undefined/);
 });
 
 test("extension wires usage-limit command to isolated TLH settings", () => {

--- a/tests/the-last-harness-extension-usage-refresh.test.mjs
+++ b/tests/the-last-harness-extension-usage-refresh.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -42,13 +42,19 @@ function createPi() {
 }
 
 function createCtx(options) {
+	const provider = options.provider ?? "anthropic";
 	return {
 		hasUI: true,
 		cwd: options.cwd,
-		model: { provider: "anthropic", id: "claude-sonnet-4-20250514", contextWindow: 200000 },
+		model: {
+			provider,
+			id: options.modelId ?? (provider === "anthropic" ? "claude-sonnet-4-20250514" : `${provider}-model`),
+			contextWindow: 200000,
+		},
 		modelRegistry: {
-			isUsingOAuth: (model) => model?.provider === "anthropic",
-			getApiKeyForProvider: async (provider) => (provider === "anthropic" ? options.currentAccessToken() : undefined),
+			isUsingOAuth: (model) => options.isUsingOAuth?.(model) ?? model?.provider === "anthropic",
+			getApiKeyForProvider: async (targetProvider) =>
+				targetProvider === provider ? options.currentAccessToken?.() : undefined,
 			find: () => undefined,
 			authStorage: options.authStorage,
 		},
@@ -72,8 +78,8 @@ function createCtx(options) {
 	};
 }
 
-async function eventually(predicate, message) {
-	for (let attempt = 0; attempt < 30; attempt += 1) {
+async function eventually(predicate, message, { attempts = 30 } = {}) {
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
 		if (predicate()) {
 			return;
 		}
@@ -91,6 +97,76 @@ function restoreEnv(previousEnv) {
 		}
 	}
 }
+
+function writeFakeCommand(fakebin, name, body) {
+	mkdirSync(fakebin, { recursive: true });
+	const commandPath = join(fakebin, name);
+	writeFileSync(commandPath, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`, "utf8");
+	chmodSync(commandPath, 0o755);
+}
+
+test("git cache refresh requests a footer render without unrelated UI activity", async () => {
+	const tempDir = mkdtempSync(join(tmpdir(), "tlh-git-footer-refresh-"));
+	const agentDir = join(tempDir, "agent");
+	const cwd = join(tempDir, "workspace");
+	const fakebin = join(tempDir, "fakebin");
+	const previousEnv = {
+		PATH: process.env.PATH,
+		PI_SUBAGENT_CHILD: process.env.PI_SUBAGENT_CHILD,
+		PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+		TLH_SKIP_UPDATE_CHECK: process.env.TLH_SKIP_UPDATE_CHECK,
+	};
+
+	let renderRequests = 0;
+	const authStorage = {
+		runtimeOverrides: new Map(),
+		get: () => undefined,
+	};
+
+	try {
+		delete process.env.PI_SUBAGENT_CHILD;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.TLH_SKIP_UPDATE_CHECK = "1";
+		process.env.PATH = `${fakebin}:${previousEnv.PATH ?? ""}`;
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			`${JSON.stringify({ tlh: { primaryAgent: { enabled: false, selected: "disabled" }, updateCheck: { enabled: false } } }, null, 2)}\n`,
+		);
+		writeFakeCommand(
+			fakebin,
+			"git",
+			`cat <<'EOF'
+# branch.oid 1234567890abcdef1234567890abcdef12345678
+# branch.head (detached)
+EOF`,
+		);
+		writeFakeCommand(fakebin, "gh", "exit 1");
+
+		const pi = createPi();
+		theLastHarness(pi);
+		const ctx = createCtx({
+			cwd,
+			provider: "example-provider",
+			authStorage,
+			isUsingOAuth: () => false,
+			requestRender: () => {
+				renderRequests += 1;
+			},
+		});
+
+		await pi.handlers.get("session_start")?.[0]?.({ reason: "restore" }, ctx);
+		await eventually(() => renderRequests === 1, "initial git cache refresh should request one footer render", {
+			attempts: 500,
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(renderRequests, 1, "git cache refresh should be the only render trigger in this scenario");
+	} finally {
+		restoreEnv(previousEnv);
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
 
 test("subscription usage refresh requests a footer render when a runtime override clears active usage", async () => {
 	const tempDir = mkdtempSync(join(tmpdir(), "tlh-usage-refresh-"));

--- a/tests/the-last-harness-footer-git-cache.test.mjs
+++ b/tests/the-last-harness-footer-git-cache.test.mjs
@@ -545,3 +545,234 @@ test("ok -> not-a-repo -> ok with a different branch transitions correctly", asy
 		cache.dispose();
 	}
 });
+
+test("onChange fires after the initial refresh populates visible snapshots", async () => {
+	const notifications = [];
+	const runner = (command) => {
+		if (command === "git") {
+			return Promise.resolve({
+				stdout: gitStatusStdout({ branch: "main" }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		if (command === "gh") {
+			return Promise.resolve({
+				stdout: ghPrStdout({ number: 17, state: "OPEN", isDraft: false }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		return Promise.reject(new Error(`unexpected ${command}`));
+	};
+	const clock = createFakeClock();
+	let cache;
+	cache = new FooterGitCache({
+		cwd: () => "/repo",
+		runner,
+		clock,
+		onChange: () => {
+			notifications.push({
+				branch: cache.getStatusSnapshot()?.branch,
+				prNumber: cache.getPullRequestSnapshot()?.number,
+			});
+		},
+	});
+	try {
+		await cache.refresh();
+		assert.deepEqual(notifications, [{ branch: "main", prNumber: 17 }]);
+	} finally {
+		cache.dispose();
+	}
+});
+
+test("onChange does not fire when a manual refresh keeps both snapshots identical", async () => {
+	let notifications = 0;
+	const runner = (command) => {
+		if (command === "git") {
+			return Promise.resolve({
+				stdout: gitStatusStdout({ branch: "main", ahead: 1 }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		if (command === "gh") {
+			return Promise.resolve({
+				stdout: ghPrStdout({ number: 8, state: "OPEN", isDraft: false }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		return Promise.reject(new Error(`unexpected ${command}`));
+	};
+	const clock = createFakeClock();
+	const cache = new FooterGitCache({
+		cwd: () => "/repo",
+		runner,
+		clock,
+		skipInitialRefresh: true,
+		onChange: () => {
+			notifications += 1;
+		},
+	});
+	try {
+		await cache.refresh();
+		await cache.refresh();
+		assert.equal(notifications, 1);
+	} finally {
+		cache.dispose();
+	}
+});
+
+test("onChange fires when a timer refresh clears stale snapshots after leaving a repo", async () => {
+	let gitMode = "ok";
+	const notifications = [];
+	const runner = (command) => {
+		if (command === "git") {
+			if (gitMode === "not-a-repo") {
+				return Promise.resolve({
+					stdout: "",
+					stderr: "fatal: not a git repository\n",
+					exitCode: 128,
+				});
+			}
+			return Promise.resolve({
+				stdout: gitStatusStdout({ branch: "main" }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		if (command === "gh") {
+			return Promise.resolve({
+				stdout: ghPrStdout({ number: 42, state: "OPEN", isDraft: false }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		return Promise.reject(new Error(`unexpected ${command}`));
+	};
+	const clock = createFakeClock();
+	let cache;
+	cache = new FooterGitCache({
+		cwd: () => "/repo",
+		runner,
+		clock,
+		skipInitialRefresh: true,
+		onChange: () => {
+			notifications.push({
+				branch: cache.getStatusSnapshot()?.branch,
+				prNumber: cache.getPullRequestSnapshot()?.number,
+			});
+		},
+	});
+	try {
+		await cache.refresh();
+		gitMode = "not-a-repo";
+		const [intervalHandle] = [...clock.intervals.keys()];
+		clock.tick(intervalHandle);
+		await flushMicrotasks();
+		await flushMicrotasks();
+		assert.deepEqual(notifications, [
+			{ branch: "main", prNumber: 42 },
+			{ branch: undefined, prNumber: undefined },
+		]);
+	} finally {
+		cache.dispose();
+	}
+});
+
+test("onChange fires after branch-change refresh clears a stale PR snapshot", async () => {
+	let branch = "main";
+	let branchChangeCallback;
+	const notifications = [];
+	const runner = (command) => {
+		if (command === "git") {
+			return Promise.resolve({
+				stdout: gitStatusStdout({ branch }),
+				stderr: "",
+				exitCode: 0,
+			});
+		}
+		if (command === "gh") {
+			if (branch === "main") {
+				return Promise.resolve({
+					stdout: ghPrStdout({ number: 3, state: "OPEN", isDraft: false }),
+					stderr: "",
+					exitCode: 0,
+				});
+			}
+			return Promise.resolve({ stdout: "", stderr: "no pr", exitCode: 1 });
+		}
+		return Promise.reject(new Error(`unexpected ${command}`));
+	};
+	const clock = createFakeClock();
+	let cache;
+	cache = new FooterGitCache({
+		cwd: () => "/repo",
+		runner,
+		clock,
+		skipInitialRefresh: true,
+		onChange: () => {
+			notifications.push({
+				branch: cache.getStatusSnapshot()?.branch,
+				prNumber: cache.getPullRequestSnapshot()?.number,
+			});
+		},
+		onBranchChangeSource: (callback) => {
+			branchChangeCallback = callback;
+			return () => {};
+		},
+	});
+	try {
+		await cache.refresh();
+		branch = "feature/x";
+		branchChangeCallback();
+		await flushMicrotasks();
+		await flushMicrotasks();
+		assert.deepEqual(notifications, [
+			{ branch: "main", prNumber: 3 },
+			{ branch: "feature/x", prNumber: undefined },
+		]);
+	} finally {
+		cache.dispose();
+	}
+});
+
+test("onChange does not fire when dispose() interrupts an in-flight refresh", async () => {
+	let observedSignal;
+	let notifications = 0;
+	const runner = (command, _args, options) => {
+		if (command !== "git") {
+			return Promise.reject(new Error(`unexpected ${command}`));
+		}
+		observedSignal = options.signal;
+		return new Promise((_resolve, reject) => {
+			options.signal.addEventListener(
+				"abort",
+				() => reject(new Error("aborted")),
+				{ once: true },
+			);
+		});
+	};
+	const clock = createFakeClock();
+	const cache = new FooterGitCache({
+		cwd: () => "/repo",
+		runner,
+		clock,
+		gitTimeoutMs: 60_000,
+		onChange: () => {
+			notifications += 1;
+		},
+		skipInitialRefresh: true,
+	});
+
+	const refreshPromise = cache.refresh();
+	while (!observedSignal) {
+		await flushMicrotasks();
+	}
+
+	cache.dispose();
+	await refreshPromise;
+	assert.ok(observedSignal.aborted);
+	assert.equal(notifications, 0);
+});


### PR DESCRIPTION
## Summary
- notify the TLH footer when cached git/PR snapshots actually change
- wire footer git-cache changes to `tui.requestRender()`
- add regression coverage for startup/timer/branch refresh repaint behavior and no-op refreshes

## Validation
- `npm run validate`
