### PR TITLE
Warn on non-stable TLH installs at launch

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,8 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/main/install.sh | bash -s -- --ref main --track ref
 ```
 
+These alternatives keep TLH isolated, but they are not the official latest stable install path. TLH surfaces that at launch with an install warning so you can tell when you are on a pinned tag, non-stable ref, custom track, custom package source, non-default repo/fork, or an install with missing/invalid metadata.
+
 ## Installer options
 
 ```text
@@ -57,6 +59,20 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 You can just run `tlh update`.
 
 This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
+
+At launch, TLH also warns when your install metadata says you are not on the official latest stable path, or when it cannot verify that metadata. That warning is informational only; it does not change your isolated install or auto-update anything.
+
+- If you installed from a pinned release tag, a non-stable git ref, or another custom update track while still using the default TLH repo/package source, return to the official latest stable release track with:
+
+```sh
+tlh update --track latest-release
+```
+
+- If you installed from a custom package source, a non-default repo/fork, or TLH reports missing/invalid install metadata, return to the official latest stable release path by rerunning the official latest-release installer:
+
+```sh
+curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/latest/download/install.sh | bash -s --
+```
 
 Normal updates keep Gnosis and ticket integration enabled. They install or refresh the managed isolated `gn` binary when needed, re-enable legacy `settings.tlh.tickets.enabled=false` values, reuse a valid configured/existing `tk` when possible, and install or refresh the managed isolated copy at `~/.the-last-harness/agent/bin/tk` when needed. If no valid `tk` is available and the managed install fails, `tlh update` fails with an actionable error; provide a valid command with `tlh tickets enable --install-path /path/to/tk` or rerun the update once the managed download can succeed. Existing repo-local `.gnosis` and `.tickets` data is left in place.
 

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -5,6 +5,7 @@ import { registerEffortCommand } from "./the-last-harness/effort.js";
 import { createTlhFooter } from "./the-last-harness/footer.js";
 import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
+import { maybeNotifyTlhInstallNotice } from "./the-last-harness/install-state.js";
 import { scheduleTlhLaunchTelemetry } from "./the-last-harness/launch-telemetry.js";
 import { registerTlhPrimaryAgentRuntime } from "./the-last-harness/primary-agent-runtime.js";
 import { collectStartupResources } from "./the-last-harness/resources.js";
@@ -69,6 +70,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 
 		if (event.reason === "startup") {
 			scheduleTlhLaunchTelemetry(ctx);
+			maybeNotifyTlhInstallNotice(ctx);
 		}
 
 		ctx.ui.addAutocompleteProvider(createTlhAutocompleteProvider);

--- a/extensions/the-last-harness/install-state.ts
+++ b/extensions/the-last-harness/install-state.ts
@@ -1,0 +1,116 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { TLH_PACKAGE_NAME, TLH_RELEASES_URL, TLH_REPO } from "./constants.js";
+import { readTlhInstallState } from "./profile-state.js";
+import type { TlhInstallNotice, TlhInstallState } from "./types.js";
+
+const STABLE_TRACK = "latest-release";
+const VALID_TRACKS = new Set([STABLE_TRACK, "pinned-tag", "ref", "custom"]);
+
+function normalizedString(value: unknown): string | undefined {
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	const normalized = value.trim();
+	return normalized ? normalized : undefined;
+}
+
+function isDefaultPackageSource(state: TlhInstallState | undefined): boolean | undefined {
+	if (state?.packageSourceIsDefault === true) {
+		return true;
+	}
+	if (state?.packageSourceIsDefault === false) {
+		return false;
+	}
+	return undefined;
+}
+
+export function classifyTlhInstallState(state: TlhInstallState | undefined): TlhInstallNotice | undefined {
+	const repo = normalizedString(state?.repo);
+	const track = normalizedString(state?.track);
+	const ref = normalizedString(state?.ref);
+	const packageSource = normalizedString(state?.packageSource);
+
+	if (!repo || !track || !VALID_TRACKS.has(track)) {
+		return {
+			kind: "unknown",
+			summary: "TLH install metadata is missing or invalid.",
+		};
+	}
+
+	if (repo !== TLH_REPO) {
+		return {
+			kind: "non-default-repo",
+			summary: "TLH is installed from a non-default repository.",
+			detail: repo,
+		};
+	}
+
+	const defaultPackageSource = isDefaultPackageSource(state);
+	if (defaultPackageSource === false) {
+		return {
+			kind: "custom-package-source",
+			summary: "TLH uses a custom package source.",
+			detail: packageSource,
+		};
+	}
+	if (defaultPackageSource !== true) {
+		return {
+			kind: "unknown",
+			summary: "TLH install metadata is missing or invalid.",
+		};
+	}
+
+	if (track === STABLE_TRACK) {
+		return undefined;
+	}
+	if (track === "pinned-tag") {
+		return {
+			kind: "pinned-tag",
+			summary: "TLH is pinned to a specific release tag.",
+			detail: ref,
+		};
+	}
+	if (track === "ref") {
+		return {
+			kind: "ref",
+			summary: "TLH follows a non-stable git ref.",
+			detail: ref,
+		};
+	}
+	return {
+		kind: "custom-track",
+		summary: "TLH uses a custom update track.",
+		detail: track,
+	};
+}
+
+export function readTlhInstallNotice(): TlhInstallNotice | undefined {
+	return classifyTlhInstallState(readTlhInstallState());
+}
+
+function formatTlhInstallNoticeAction(notice: TlhInstallNotice): string {
+	switch (notice.kind) {
+		case "pinned-tag":
+		case "ref":
+		case "custom-track":
+			return "To switch to the latest stable release track, run: tlh update --track latest-release.";
+		case "custom-package-source":
+		case "non-default-repo":
+		case "unknown":
+		default:
+			return "To get back to the official latest stable release install path, rerun the official latest-release installer.";
+	}
+}
+
+export function formatTlhInstallNoticeMessage(notice: TlhInstallNotice): string {
+	const detail = notice.detail ? ` Detail: ${notice.detail}.` : "";
+	return `${TLH_PACKAGE_NAME} install warning: ${notice.summary}${detail} ${formatTlhInstallNoticeAction(notice)} Releases: ${TLH_RELEASES_URL}`;
+}
+
+export function maybeNotifyTlhInstallNotice(ctx: ExtensionContext): void {
+	const notice = readTlhInstallNotice();
+	if (!notice) {
+		return;
+	}
+	ctx.ui.notify(formatTlhInstallNoticeMessage(notice), "warning");
+}

--- a/extensions/the-last-harness/types.ts
+++ b/extensions/the-last-harness/types.ts
@@ -106,8 +106,31 @@ export type TlhStartupState = {
 };
 
 export type TlhInstallState = {
-	track?: string;
+	schemaVersion?: number;
+	repo?: string;
 	ref?: string;
+	track?: string;
+	packageSource?: string;
+	packageSourceIsDefault?: boolean;
+	rawBase?: string;
+	agentDir?: string;
+	binDir?: string;
+	wrapperName?: string;
+	installedAt?: string;
+};
+
+export type TlhInstallNoticeKind =
+	| "pinned-tag"
+	| "ref"
+	| "custom-track"
+	| "custom-package-source"
+	| "non-default-repo"
+	| "unknown";
+
+export type TlhInstallNotice = {
+	kind: TlhInstallNoticeKind;
+	summary: string;
+	detail?: string;
 };
 
 export type TlhTelemetryState = {

--- a/tests/the-last-harness-extension-startup-warning.test.mjs
+++ b/tests/the-last-harness-extension-startup-warning.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { default: theLastHarness } = await jiti.import("../extensions/the-last-harness.ts");
+
+const PINNED_TAG_INSTALL_STATE = {
+	repo: "diegopetrucci/the-last-harness",
+	track: "pinned-tag",
+	ref: "v0.10.0",
+	packageSource: "git:github.com/diegopetrucci/the-last-harness@v0.10.0",
+	packageSourceIsDefault: true,
+};
+
+const LATEST_STABLE_INSTALL_STATE = {
+	...PINNED_TAG_INSTALL_STATE,
+	track: "latest-release",
+};
+
+function createPi() {
+	const handlers = new Map();
+	return {
+		handlers,
+		on(event, handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerCommand() {},
+		registerShortcut() {},
+		appendEntry() {},
+		getAllTools: () => [],
+		getActiveTools: () => [],
+		getThinkingLevel: () => "medium",
+		setThinkingLevel() {},
+		setModel: async () => true,
+	};
+}
+
+function createCtx({ cwd, notifications, hasUI = true }) {
+	return {
+		hasUI,
+		cwd,
+		model: undefined,
+		modelRegistry: {
+			isUsingOAuth: () => false,
+			getApiKeyForProvider: async () => undefined,
+			find: () => undefined,
+			authStorage: { get: () => undefined },
+		},
+		sessionManager: {
+			getEntries: () => [],
+			getCwd: () => cwd,
+			getSessionName: () => undefined,
+			getBranch: () => undefined,
+		},
+		getContextUsage: () => undefined,
+		ui: {
+			addAutocompleteProvider() {},
+			setFooter() {},
+			setHeader() {},
+			notify(message, type) {
+				notifications.push({ message, type });
+			},
+			getEditorText: () => "",
+		},
+		isIdle: () => true,
+	};
+}
+
+function restoreEnv(previousEnv) {
+	for (const [key, value] of Object.entries(previousEnv)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+}
+
+function writeProfileFixture(agentDir, installState) {
+	mkdirSync(join(agentDir, "tlh"), { recursive: true });
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		`${JSON.stringify({ tlh: { primaryAgent: { enabled: false, selected: "disabled" }, telemetry: { enabled: false }, updateCheck: { enabled: false } } }, null, 2)}\n`,
+	);
+	writeFileSync(join(agentDir, "tlh", "install-state.json"), `${JSON.stringify(installState, null, 2)}\n`);
+}
+
+async function runSessionStart({ reason, installState, hasUI = true }) {
+	const tempDir = mkdtempSync(join(tmpdir(), "tlh-startup-warning-"));
+	const agentDir = join(tempDir, "agent");
+	const cwd = join(tempDir, "workspace");
+	const previousEnv = {
+		PI_SUBAGENT_CHILD: process.env.PI_SUBAGENT_CHILD,
+		PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+		TLH_SKIP_UPDATE_CHECK: process.env.TLH_SKIP_UPDATE_CHECK,
+		TLH_SKIP_TELEMETRY: process.env.TLH_SKIP_TELEMETRY,
+	};
+
+	try {
+		delete process.env.PI_SUBAGENT_CHILD;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.TLH_SKIP_UPDATE_CHECK = "1";
+		process.env.TLH_SKIP_TELEMETRY = "1";
+		mkdirSync(cwd, { recursive: true });
+		writeProfileFixture(agentDir, installState);
+
+		const pi = createPi();
+		theLastHarness(pi);
+		const notifications = [];
+		const ctx = createCtx({ cwd, notifications, hasUI });
+		const sessionStartHandler = pi.handlers.get("session_start")?.[0];
+		assert.ok(sessionStartHandler, "session_start handler must be registered by the extension");
+
+		await sessionStartHandler({ reason }, ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+		return notifications;
+	} finally {
+		restoreEnv(previousEnv);
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+test("interactive startup warns for non-latest-stable installs with an actionable stable-track hint", async () => {
+	const notifications = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE });
+
+	assert.equal(notifications.length, 1);
+	assert.equal(notifications[0]?.type, "warning");
+	assert.match(notifications[0]?.message ?? "", /The Last Harness install warning:/);
+	assert.match(notifications[0]?.message ?? "", /pinned to a specific release tag/i);
+	assert.match(notifications[0]?.message ?? "", /Detail: v0\.10\.0\./);
+	assert.match(notifications[0]?.message ?? "", /latest stable release track/i);
+	assert.match(notifications[0]?.message ?? "", /tlh update --track latest-release/);
+	assert.match(notifications[0]?.message ?? "", /github\.com\/diegopetrucci\/the-last-harness\/releases/);
+});
+
+test("interactive startup stays quiet for latest-stable installs", async () => {
+	const notifications = await runSessionStart({ reason: "startup", installState: LATEST_STABLE_INSTALL_STATE });
+	assert.deepEqual(notifications, []);
+});
+
+test("non-startup session reasons do not show the non-stable install warning", async () => {
+	for (const reason of ["reload", "new", "resume", "fork"]) {
+		const notifications = await runSessionStart({ reason, installState: PINNED_TAG_INSTALL_STATE });
+		assert.deepEqual(notifications, [], `expected no install warning for ${reason}`);
+	}
+});
+
+test("startup without UI does not show the non-stable install warning", async () => {
+	const notifications = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE, hasUI: false });
+	assert.deepEqual(notifications, []);
+});

--- a/tests/the-last-harness-install-state-classifier.test.mjs
+++ b/tests/the-last-harness-install-state-classifier.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { classifyTlhInstallState, formatTlhInstallNoticeMessage } = await jiti.import("../extensions/the-last-harness/install-state.ts");
+
+const OFFICIAL_LATEST_STABLE = {
+	repo: "diegopetrucci/the-last-harness",
+	track: "latest-release",
+	ref: "v0.10.0",
+	packageSource: "git:github.com/diegopetrucci/the-last-harness@v0.10.0",
+	packageSourceIsDefault: true,
+};
+
+test("classifier returns no notice for official latest-stable installs", () => {
+	assert.equal(classifyTlhInstallState(OFFICIAL_LATEST_STABLE), undefined);
+});
+
+test("classifier flags pinned-tag installs", () => {
+	assert.deepEqual(classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		track: "pinned-tag",
+	}), {
+		kind: "pinned-tag",
+		summary: "TLH is pinned to a specific release tag.",
+		detail: "v0.10.0",
+	});
+});
+
+test("classifier flags ref installs", () => {
+	assert.deepEqual(classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		track: "ref",
+		ref: "main",
+		packageSource: "git:github.com/diegopetrucci/the-last-harness@main",
+	}), {
+		kind: "ref",
+		summary: "TLH follows a non-stable git ref.",
+		detail: "main",
+	});
+});
+
+test("classifier flags custom tracks", () => {
+	assert.deepEqual(classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		track: "custom",
+	}), {
+		kind: "custom-track",
+		summary: "TLH uses a custom update track.",
+		detail: "custom",
+	});
+});
+
+test("classifier flags custom package sources even on latest-release", () => {
+	const notice = classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		packageSource: "git:github.com/custom/pkg@main",
+		packageSourceIsDefault: false,
+	});
+	assert.deepEqual(notice, {
+		kind: "custom-package-source",
+		summary: "TLH uses a custom package source.",
+		detail: "git:github.com/custom/pkg@main",
+	});
+	assert.ok(notice);
+	const message = formatTlhInstallNoticeMessage(notice);
+	assert.match(message, /rerun the official latest-release installer/i);
+	assert.doesNotMatch(message, /tlh update --track latest-release/);
+});
+
+test("classifier flags non-default repositories", () => {
+	const notice = classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		repo: "someone-else/the-last-harness",
+	});
+	assert.deepEqual(notice, {
+		kind: "non-default-repo",
+		summary: "TLH is installed from a non-default repository.",
+		detail: "someone-else/the-last-harness",
+	});
+	assert.ok(notice);
+	const message = formatTlhInstallNoticeMessage(notice);
+	assert.match(message, /rerun the official latest-release installer/i);
+	assert.doesNotMatch(message, /tlh update --track latest-release/);
+});
+
+test("classifier flags missing install-state as unknown", () => {
+	const notice = classifyTlhInstallState(undefined);
+	assert.deepEqual(notice, {
+		kind: "unknown",
+		summary: "TLH install metadata is missing or invalid.",
+	});
+	assert.ok(notice);
+	const message = formatTlhInstallNoticeMessage(notice);
+	assert.match(message, /rerun the official latest-release installer/i);
+	assert.doesNotMatch(message, /tlh update --track latest-release/);
+});
+
+test("classifier flags invalid install-state as unknown", () => {
+	assert.deepEqual(classifyTlhInstallState({
+		...OFFICIAL_LATEST_STABLE,
+		track: "latest-release",
+		packageSourceIsDefault: undefined,
+	}), {
+		kind: "unknown",
+		summary: "TLH install metadata is missing or invalid.",
+	});
+});


### PR DESCRIPTION
## Summary
- classify TLH install metadata as official latest-stable vs pinned/ref/custom/fork/unknown
- show a launch-only warning for non-latest-stable or unverifiable installs
- document recovery paths for returning to the official latest-release install path

## Validation
- npm run validate
- git diff --check

## Review
- code-reviewer: no blocking findings