### PR TITLE
Parse nested OpenAI subscription usage

### DIFF
--- a/extensions/the-last-harness/subscription-usage.mjs
+++ b/extensions/the-last-harness/subscription-usage.mjs
@@ -230,8 +230,9 @@ export function isSupportedTlhSubscriptionUsageProvider(provider) {
 export function normalizeOpenAICodexUsage(data, options = {}) {
 	const nowMs = options.nowMs ?? Date.now();
 	const root = asObject(data);
-	const session = normalizeUsageWindow(root?.primary_window, "primary_window", "session", nowMs);
-	const weekly = normalizeUsageWindow(root?.secondary_window, "secondary_window", "weekly", nowMs);
+	const rateLimit = asObject(root?.rate_limit);
+	const session = normalizeUsageWindow(rateLimit?.primary_window ?? root?.primary_window, "primary_window", "session", nowMs);
+	const weekly = normalizeUsageWindow(rateLimit?.secondary_window ?? root?.secondary_window, "secondary_window", "weekly", nowMs);
 	return createSnapshot("openai-codex", session, weekly, nowMs);
 }
 

--- a/tests/the-last-harness-subscription-usage.test.mjs
+++ b/tests/the-last-harness-subscription-usage.test.mjs
@@ -30,6 +30,12 @@ function openAiUsage(used = 25) {
 	};
 }
 
+function openAiNestedUsage(used = 25) {
+	return {
+		rate_limit: openAiUsage(used),
+	};
+}
+
 function assertNoCredentialMaterial(value) {
 	assert.doesNotMatch(JSON.stringify(value), /Authorization|Bearer|access|refresh|token/i);
 }
@@ -48,8 +54,33 @@ function createDeferred() {
 	return { promise, resolve, reject };
 }
 
-test("normalizes OpenAI/Codex wham usage primary and secondary windows", () => {
+test("normalizes OpenAI/Codex wham usage top-level primary and secondary windows", () => {
 	const snapshot = normalizeOpenAICodexUsage(openAiUsage(75), { nowMs: NOW_MS });
+
+	assert.equal(snapshot?.provider, "openai-codex");
+	assert.equal(snapshot?.fetchedAt, NOW_MS);
+	assert.deepEqual(snapshot?.windows.session, {
+		key: "primary_window",
+		label: "session",
+		used: 75,
+		limit: 100,
+		remaining: 25,
+		percent: 75,
+		resetsAt: RESET_AT,
+	});
+	assert.deepEqual(snapshot?.windows.weekly, {
+		key: "secondary_window",
+		label: "weekly",
+		used: 200,
+		limit: 1000,
+		remaining: 800,
+		percent: 20,
+		resetsAt: RESET_AT,
+	});
+});
+
+test("normalizes OpenAI/Codex wham nested rate_limit primary and secondary windows", () => {
+	const snapshot = normalizeOpenAICodexUsage(openAiNestedUsage(75), { nowMs: NOW_MS });
 
 	assert.equal(snapshot?.provider, "openai-codex");
 	assert.equal(snapshot?.fetchedAt, NOW_MS);
@@ -200,18 +231,6 @@ test("normalizes Anthropic OAuth utilization-only windows", () => {
 });
 
 test("normalizers fail closed for unobserved window shapes", () => {
-	assert.equal(
-		normalizeOpenAICodexUsage(
-			{
-				rate_limit: {
-					primary_window: { used: 1, limit: 10 },
-					secondary_window: { used: 2, limit: 10 },
-				},
-			},
-			{ nowMs: NOW_MS },
-		),
-		undefined,
-	);
 	assert.equal(normalizeOpenAICodexUsage({ primaryWindow: { used: 1, limit: 10 } }, { nowMs: NOW_MS }), undefined);
 	assert.equal(
 		normalizeAnthropicUsage(


### PR DESCRIPTION
## Summary
- Parse OpenAI/Codex subscription usage windows from the current nested `rate_limit` response shape
- Preserve the older top-level OpenAI window fallback
- Add regression coverage for nested OpenAI usage while keeping Anthropic coverage unchanged

## Validation
- npm run validate
- live read-only OpenAI usage check produced a footer segment after the fix