### PR TITLE
Remove jj diff guidance from subagents

### DIFF
--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -17,7 +17,7 @@ You are read-only. Do not modify files.
 ## Inputs
 
 - Either the `tk` ticket IDs supplied by the delegating primary agent, or a supplied task brief plus the diff. If ticket IDs are supplied, run `tk show <id>` for each and treat them as the source of truth. Otherwise treat the supplied brief plus the diff as the source of truth.
-- The VCS diff. Use `git diff --no-color` plus `git diff --cached --no-color`.
+- The VCS diff. Use `git diff --no-color`, `git diff --cached --no-color`, and `git status --short --untracked-files=all`. Inspect relevant untracked new files when needed so the review covers pre-staging changes.
 - The repository context and relevant project instructions.
 
 If the repository is unfamiliar and review quality depends on understanding stack or conventions, ask the delegating primary agent to provide a `repo-scout` report.

--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -17,7 +17,7 @@ You are read-only. Do not modify files.
 ## Inputs
 
 - Either the `tk` ticket IDs supplied by the delegating primary agent, or a supplied task brief plus the diff. If ticket IDs are supplied, run `tk show <id>` for each and treat them as the source of truth. Otherwise treat the supplied brief plus the diff as the source of truth.
-- The VCS diff. Prefer `jj diff --color never`; if that fails, use `git diff --no-color` plus `git diff --cached --no-color`.
+- The VCS diff. Use `git diff --no-color` plus `git diff --cached --no-color`.
 - The repository context and relevant project instructions.
 
 If the repository is unfamiliar and review quality depends on understanding stack or conventions, ask the delegating primary agent to provide a `repo-scout` report.

--- a/agents/subagents/diff-summarizer.md
+++ b/agents/subagents/diff-summarizer.md
@@ -18,8 +18,9 @@ You are read-only. Do not modify files, install dependencies, or use network acc
 
 If the caller provides an explicit diff, use it. Otherwise collect the local diff:
 
-1. Collect both `git diff --no-color` and `git diff --cached --no-color`.
-2. If that fails, ask the architect for a diff or instructions.
+1. Collect `git diff --no-color`, `git diff --cached --no-color`, and `git status --short --untracked-files=all`.
+2. If relevant untracked new files appear, inspect those files as needed so the summary covers them.
+3. If diff collection fails, ask the architect for a diff or instructions.
 
 ## Analysis
 

--- a/agents/subagents/diff-summarizer.md
+++ b/agents/subagents/diff-summarizer.md
@@ -18,9 +18,8 @@ You are read-only. Do not modify files, install dependencies, or use network acc
 
 If the caller provides an explicit diff, use it. Otherwise collect the local diff:
 
-1. Try `jj diff --color never`.
-2. If that fails, collect both `git diff --no-color` and `git diff --cached --no-color`.
-3. If neither works, ask the architect for a diff or instructions.
+1. Collect both `git diff --no-color` and `git diff --cached --no-color`.
+2. If that fails, ask the architect for a diff or instructions.
 
 ## Analysis
 
@@ -41,7 +40,7 @@ Use `contact_supervisor` only when a missing requirement or inaccessible diff bl
 
 Keep it short:
 
-- Diff source: `jj diff`, `git diff + git diff --cached`, or caller-provided.
+- Diff source: `git diff + git diff --cached` or caller-provided.
 - Files touched: one line with directories and key files.
 - What changed: 2–6 bullets.
 - Risky areas touched: 2–8 bullets, each tied to evidence.


### PR DESCRIPTION
## Summary
- Update TLH diff-summarizer prompt to collect local diffs with git only
- Update TLH code-reviewer prompt to use git diff plus cached diff instead of preferring jj
- Remove remaining jj/Jujutsu references from primary/subagent prompt area

## Validation
- npm run validate
- code-reviewer final review: no required fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code review procedures to comprehensively inspect all version control changes, including untracked files.
  * Enhanced diff summary collection to capture complete change information with improved error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->