### PR TITLE
Add safe profile write helper

### DIFF
--- a/.tickets/tlhf-1eer.md
+++ b/.tickets/tlhf-1eer.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-1eer
+status: open
+deps: [tlhf-6y8r]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 2: package safe profile write helper for installer support scripts
+
+Make the shared helper available to stage-1 and installed support scripts without otherwise changing write behavior.
+
+## Acceptance Criteria
+
+scripts/lib/tlh-install-support-manifest.mjs and install.sh bootstrap manifest include the helper consistently; installed helper paths resolve when copied under agent/tlh/lib; installer smoke and npm run validate pass; no production call-site migration is included except any minimal import-resolution test.
+

--- a/.tickets/tlhf-6y8r.md
+++ b/.tickets/tlhf-6y8r.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-6y8r
+status: open
+deps: []
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 1: add safe profile write helper and helper tests
+
+Add a reusable scripts-level helper for safety-critical writes inside the isolated TLH profile, but do not migrate production call sites yet.
+
+## Design
+
+Extract the strongest ticket-grade primitives into scripts/lib/tlh-profile-writes.mjs or an equivalent shared module. This phase is intentionally unused by production scripts except tests so it can merge without changing install behavior.
+
+## Acceptance Criteria
+
+Helper exists with tests for normal ~/.pi rejection, symlinked root/parents/final target, hardlinked rewritten targets, parent swaps before mkdir/open/realpath, predictable temp precreation, helper-owned cleanup safety, and mode behavior; npm run validate passes; no production install behavior changes.
+

--- a/.tickets/tlhf-6y8r.md
+++ b/.tickets/tlhf-6y8r.md
@@ -1,6 +1,6 @@
 ---
 id: tlhf-6y8r
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-05-23T09:53:08Z

--- a/.tickets/tlhf-82ly.md
+++ b/.tickets/tlhf-82ly.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-82ly
+status: open
+deps: [tlhf-1eer]
+links: []
+created: 2026-05-23T12:07:03Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 2.5: harden safe profile helper before production migrations
+
+Address oracle low-priority helper hardening items before migrating production write call sites.
+
+## Design
+
+Keep this as a small pre-migration gate after packaging plumbing and before merge-settings adopts the helper. Decide/document helper policy before broad use rather than discovering it during call-site migrations.
+
+## Acceptance Criteria
+
+Helper behavior is tested or documented for missing agent dirs, target equal to agent root, targets outside the configured profile, non-file target parents and final targets, exclusive writes, replace:false writes, permissive caller-supplied modes, symlink ancestors above agentRoot, and atomicity/backups expectations for future settings writes; any necessary code changes preserve Phase 1 safety guarantees and npm run validate passes.
+

--- a/.tickets/tlhf-cysu.md
+++ b/.tickets/tlhf-cysu.md
@@ -1,7 +1,7 @@
 ---
 id: tlhf-cysu
 status: open
-deps: [tlhf-1eer]
+deps: [tlhf-82ly]
 links: []
 created: 2026-05-23T09:53:08Z
 type: task

--- a/.tickets/tlhf-cysu.md
+++ b/.tickets/tlhf-cysu.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-cysu
+status: open
+deps: [tlhf-1eer]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 3: migrate merge-settings to safe profile write helper
+
+Adopt the shared safe profile write helper for scripts/merge-settings.mjs only.
+
+## Acceptance Criteria
+
+merge-settings writes and backups use the shared helper; normal Pi rejection, symlink/parent-swap, backup leak prevention, existing-mode preservation or documented mode behavior, and dry-run behavior are covered; npm run validate passes.
+

--- a/.tickets/tlhf-d77a.md
+++ b/.tickets/tlhf-d77a.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-d77a
+status: open
+deps: [tlhf-cysu]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 8: document safe TLH profile write architecture
+
+Add a new docs document explaining the safe profile write architecture and current migration status.
+
+## Acceptance Criteria
+
+docs/safe-profile-writes.md documents isolated profile write invariants, helper/module structure, safe APIs/patterns, forbidden ad hoc patterns, migrated call sites, test strategy, and explicit follow-ups such as runtime TS write hardening if not completed.
+

--- a/.tickets/tlhf-pbnd.md
+++ b/.tickets/tlhf-pbnd.md
@@ -1,0 +1,23 @@
+---
+id: tlhf-pbnd
+status: open
+deps: [tlhf-vjga]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 5: route installer support profile copies through safe helper
+
+Preserve existing installer APIs while internally delegating support directory and support-file copy writes to the shared safe profile write helper.
+
+## Design
+
+Prefer adapter-style changes in scripts/lib/tlh-install-paths.mjs so tlh-install.mjs and tlh-install-subagents.mjs call sites stay small.
+
+## Acceptance Criteria
+
+ensureSafeProfileDir/copySafeProfileFile or replacements delegate to the shared helper; support files and subagent prompt copies reject symlinked agent/tlh parents and paths outside the isolated profile; dry-run output remains stable; installer smoke and npm run validate pass.
+

--- a/.tickets/tlhf-pouj.md
+++ b/.tickets/tlhf-pouj.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-pouj
+status: open
+deps: [tlhf-pbnd]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 6: migrate managed Gnosis writes to safe helper
+
+Replace duplicated managed Gnosis target write safety code with the shared safe profile write helper after lower-risk call sites are proven.
+
+## Acceptance Criteria
+
+scripts/tlh-gnosis.mjs uses the shared helper for managed gn writes without weakening mandatory Gnosis behavior; existing Gnosis tests remain green; added tests cover ticket-grade parent/target swap and cleanup behavior; npm run validate passes.
+

--- a/.tickets/tlhf-umo9.md
+++ b/.tickets/tlhf-umo9.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-umo9
+status: open
+deps: [tlhf-pouj]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 7: migrate managed tk writes to safe helper
+
+Replace duplicated ticket-grade managed tk/settings write primitives with the shared helper once the helper has been exercised by other migrations.
+
+## Acceptance Criteria
+
+scripts/tlh-tickets.mjs reuses the shared helper for managed tk and settings writes without weakening existing guarantees; existing adversarial tk tests remain green or are moved to shared-helper coverage with equivalent assertions; npm run validate passes.
+

--- a/.tickets/tlhf-vjga.md
+++ b/.tickets/tlhf-vjga.md
@@ -1,0 +1,19 @@
+---
+id: tlhf-vjga
+status: open
+deps: [tlhf-cysu]
+links: []
+created: 2026-05-23T09:53:08Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+parent: tlhf-oxht
+---
+# Phase 4: migrate keybindings defaults and install-state writers
+
+Adopt the shared safe profile write helper for scripts/merge-keybindings.mjs, scripts/tlh-defaults.mjs, and scripts/tlh-install-state.mjs after merge-settings proves the pattern.
+
+## Acceptance Criteria
+
+Each writer uses the shared helper or an explicitly documented shared wrapper; installed tlh-defaults import resolution remains valid; targeted tests cover normal Pi rejection, symlink/parent-swap, backup leak prevention where applicable, mode behavior, and dry-run behavior; npm run validate passes.
+

--- a/scripts/lib/tlh-profile-writes.mjs
+++ b/scripts/lib/tlh-profile-writes.mjs
@@ -1,0 +1,426 @@
+import {
+	closeSync,
+	constants,
+	fchmodSync,
+	fstatSync,
+	ftruncateSync,
+	lstatSync,
+	mkdirSync,
+	openSync,
+	realpathSync,
+	rmdirSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { pathIsProtectedPiConfig, pathWithinOrEqual, realpathForCompare } from "./tlh-install-paths.mjs";
+
+function lstatIfExists(path) {
+	try {
+		return lstatSync(path);
+	} catch (error) {
+		if (error && typeof error === "object" && ["ENOENT", "ENOTDIR"].includes(error.code)) return undefined;
+		throw error;
+	}
+}
+
+function sameFileStats(left, right) {
+	return left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertNotProtectedPiPath(path, label, { homeDir = homedir() } = {}) {
+	if (pathIsProtectedPiConfig(path, { homeDir })) {
+		throw new Error(`refusing to write ${label} under normal Pi config root: ${path}`);
+	}
+}
+
+function stableRealpathOfExistingDirectory(path, firstStats, label) {
+	const resolved = realpathSync(path);
+	const secondStats = lstatIfExists(path);
+	if (!secondStats) {
+		throw new Error(`refusing to write ${label} because a directory component changed while planning: ${path}`);
+	}
+	if (secondStats.isSymbolicLink()) {
+		throw new Error(`refusing to write ${label} through symlinked directory component: ${path}`);
+	}
+	if (!secondStats.isDirectory()) {
+		throw new Error(`refusing to write ${label} because a directory component is not a directory: ${path}`);
+	}
+	if (!sameFileStats(firstStats, secondStats)) {
+		throw new Error(`refusing to write ${label} because a directory component changed while planning: ${path}`);
+	}
+	return resolved;
+}
+
+function intendedPathFromNearestExistingNonSymlinkAncestor(path, label) {
+	const suffixParts = [];
+	let current = resolve(path);
+
+	while (true) {
+		const stats = lstatIfExists(current);
+		if (stats && !stats.isSymbolicLink()) {
+			if (!stats.isDirectory()) {
+				throw new Error(`refusing to write ${label} because an ancestor is not a directory: ${current}`);
+			}
+			const resolvedAncestor = stableRealpathOfExistingDirectory(current, stats, `${label} ancestor`);
+			return resolve(resolvedAncestor, ...suffixParts);
+		}
+
+		const parent = dirname(current);
+		if (parent === current) {
+			throw new Error(`refusing to write ${label} because no non-symlink directory ancestor was found: ${path}`);
+		}
+		suffixParts.unshift(basename(current));
+		current = parent;
+	}
+}
+
+function captureIntendedProfileRoot(agentRoot, label) {
+	const stats = lstatIfExists(agentRoot);
+	if (!stats) return intendedPathFromNearestExistingNonSymlinkAncestor(agentRoot, label);
+	if (stats.isSymbolicLink()) {
+		throw new Error(`refusing to write ${label} through symlinked TLH profile root: ${agentRoot}`);
+	}
+	if (!stats.isDirectory()) {
+		throw new Error(`refusing to write ${label} because the TLH profile root is not a directory: ${agentRoot}`);
+	}
+	return stableRealpathOfExistingDirectory(agentRoot, stats, label);
+}
+
+function assertProfileRootSafe(plan) {
+	assertNotProtectedPiPath(plan.agentRoot, `${plan.label} profile root`, { homeDir: plan.homeDir });
+	const stats = lstatIfExists(plan.agentRoot);
+	let resolvedAgentRoot;
+
+	if (stats) {
+		if (stats.isSymbolicLink()) {
+			throw new Error(`refusing to write ${plan.label} through symlinked TLH profile root: ${plan.agentRoot}`);
+		}
+		if (!stats.isDirectory()) {
+			throw new Error(`refusing to write ${plan.label} because the TLH profile root is not a directory: ${plan.agentRoot}`);
+		}
+		resolvedAgentRoot = stableRealpathOfExistingDirectory(plan.agentRoot, stats, `${plan.label} profile root`);
+	} else {
+		resolvedAgentRoot = intendedPathFromNearestExistingNonSymlinkAncestor(plan.agentRoot, `${plan.label} profile root`);
+	}
+
+	if (resolvedAgentRoot !== plan.intendedAgentDir) {
+		throw new Error(`refusing to write ${plan.label} outside the intended TLH profile: ${plan.agentRoot} (resolves to ${resolvedAgentRoot}; intended profile: ${plan.intendedAgentDir})`);
+	}
+}
+
+function assertNoSymlinkedTargetParents(target, boundary, label) {
+	const parent = dirname(target);
+	if (!pathWithinOrEqual(boundary, parent)) return;
+
+	const relativeParent = relative(boundary, parent);
+	if (!relativeParent) return;
+
+	let current = boundary;
+	for (const part of relativeParent.split(sep).filter(Boolean)) {
+		current = join(current, part);
+		const stats = lstatIfExists(current);
+		if (!stats) return;
+		if (stats.isSymbolicLink()) {
+			throw new Error(`refusing to write ${label} through symlinked target parent component: ${current}`);
+		}
+		if (!stats.isDirectory()) {
+			throw new Error(`refusing to write ${label} because a target parent component is not a directory: ${current}`);
+		}
+	}
+}
+
+function resolvedPathFromRoot(path, root, resolvedRoot) {
+	const relativePath = relative(root, path);
+	if (relativePath === "") return resolvedRoot;
+	if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+		throw new Error(`path is outside the configured root: ${path} (root: ${root})`);
+	}
+	return resolve(resolvedRoot, relativePath);
+}
+
+function assertTargetParentSafe(plan) {
+	assertNotProtectedPiPath(plan.targetParent, `${plan.label} parent directory`, { homeDir: plan.homeDir });
+	const parentStats = lstatIfExists(plan.targetParent);
+	let resolvedTargetParent;
+
+	if (parentStats) {
+		if (parentStats.isSymbolicLink()) {
+			throw new Error(`refusing to write ${plan.label} through symlinked target parent: ${plan.targetParent}`);
+		}
+		if (!parentStats.isDirectory()) {
+			throw new Error(`refusing to write ${plan.label} because the target parent is not a directory: ${plan.targetParent}`);
+		}
+		resolvedTargetParent = realpathSync(plan.targetParent);
+	} else {
+		resolvedTargetParent = realpathForCompare(plan.targetParent);
+	}
+
+	if (!pathWithinOrEqual(plan.intendedAgentDir, resolvedTargetParent)) {
+		throw new Error(`refusing to write ${plan.label} outside the isolated TLH profile: ${plan.targetParent} (resolves to ${resolvedTargetParent}; profile: ${plan.intendedAgentDir})`);
+	}
+	if (resolvedTargetParent !== plan.intendedTargetParent) {
+		throw new Error(`refusing to write ${plan.label} outside the intended target parent: ${plan.targetParent} (resolves to ${resolvedTargetParent}; intended parent: ${plan.intendedTargetParent})`);
+	}
+}
+
+function validateAnchoredDirectory(path, expectedResolvedPath, label, firstStats) {
+	const stats = firstStats || lstatIfExists(path);
+	if (!stats) {
+		throw new Error(`refusing to create ${label} because a directory component is missing: ${path}`);
+	}
+	if (stats.isSymbolicLink()) {
+		throw new Error(`refusing to create ${label} through symlinked directory component: ${path}`);
+	}
+	if (!stats.isDirectory()) {
+		throw new Error(`refusing to create ${label} because a directory component is not a directory: ${path}`);
+	}
+
+	const resolved = stableRealpathOfExistingDirectory(path, stats, label);
+	if (resolved !== expectedResolvedPath) {
+		throw new Error(`refusing to create ${label} outside the intended directory: ${path} (resolves to ${resolved}; intended directory: ${expectedResolvedPath})`);
+	}
+	return resolved;
+}
+
+function cleanupCreatedDirectories(createdDirs) {
+	for (const created of [...createdDirs].reverse()) {
+		try {
+			const stats = lstatSync(created.path);
+			if (stats.isSymbolicLink() || !stats.isDirectory()) continue;
+			if (!sameFileStats(stats, created.stats)) continue;
+			rmdirSync(created.path);
+		} catch {
+			// Best effort only; keep pre-existing, changed, symlinked, or non-empty directories intact.
+		}
+	}
+}
+
+function ensureDirectorySafely(directory, intendedDirectory, label) {
+	const targetDir = resolve(directory);
+	const intendedDir = resolve(intendedDirectory);
+	const missingParts = [];
+	let current = targetDir;
+	let expectedCurrent = intendedDir;
+
+	while (true) {
+		const stats = lstatIfExists(current);
+		if (stats) {
+			validateAnchoredDirectory(current, expectedCurrent, label, stats);
+			break;
+		}
+
+		const parent = dirname(current);
+		const expectedParent = dirname(expectedCurrent);
+		if (parent === current || expectedParent === expectedCurrent) {
+			throw new Error(`refusing to create ${label} because no anchored directory ancestor was found: ${directory}`);
+		}
+		missingParts.unshift(basename(current));
+		current = parent;
+		expectedCurrent = expectedParent;
+	}
+
+	const createdDirs = [];
+	try {
+		for (const part of missingParts) {
+			validateAnchoredDirectory(current, expectedCurrent, label);
+			const child = join(current, part);
+			const expectedChild = resolve(expectedCurrent, part);
+			const childStats = lstatIfExists(child);
+
+			if (childStats) {
+				validateAnchoredDirectory(child, expectedChild, label, childStats);
+			} else {
+				try {
+					mkdirSync(child);
+				} catch (error) {
+					if (!error || typeof error !== "object" || error.code !== "EEXIST") throw error;
+					const racedStats = lstatIfExists(child);
+					validateAnchoredDirectory(child, expectedChild, label, racedStats);
+					current = child;
+					expectedCurrent = expectedChild;
+					continue;
+				}
+
+				validateAnchoredDirectory(current, expectedCurrent, label);
+				const createdStats = lstatSync(child);
+				validateAnchoredDirectory(child, expectedChild, label, createdStats);
+				createdDirs.push({ path: child, stats: createdStats });
+			}
+
+			current = child;
+			expectedCurrent = expectedChild;
+		}
+
+		validateAnchoredDirectory(targetDir, intendedDir, label);
+	} catch (error) {
+		cleanupCreatedDirectories(createdDirs);
+		throw error;
+	}
+}
+
+function validateOpenedFileForDirectWrite(fd, path, intendedRoot, label) {
+	const fdStats = fstatSync(fd);
+	if (!fdStats.isFile()) {
+		throw new Error(`refusing to write ${label} because the opened path is not a regular file: ${path}`);
+	}
+
+	let pathStats;
+	try {
+		pathStats = lstatSync(path);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`refusing to write ${label} because the opened path could not be validated: ${path} (${message})`);
+	}
+
+	if (pathStats.isSymbolicLink()) {
+		throw new Error(`refusing to write ${label} through a symlinked path: ${path}`);
+	}
+	if (!pathStats.isFile()) {
+		throw new Error(`refusing to write ${label} because the path is not a regular file: ${path}`);
+	}
+	if (!sameFileStats(fdStats, pathStats)) {
+		throw new Error(`refusing to write ${label} because the opened file no longer matches the target path: ${path}`);
+	}
+	if (fdStats.nlink !== 1) {
+		throw new Error(`refusing to write ${label} because the target has ${fdStats.nlink} hard links: ${path}`);
+	}
+
+	const resolvedPath = realpathSync(path);
+	if (!pathWithinOrEqual(intendedRoot, resolvedPath)) {
+		throw new Error(`refusing to write ${label} outside the intended directory: ${path} (resolves to ${resolvedPath}; intended directory: ${intendedRoot})`);
+	}
+}
+
+function cleanupCreatedEmptyFile(fd, path) {
+	let fdStats;
+	let pathStats;
+	try {
+		fdStats = fstatSync(fd);
+		pathStats = lstatSync(path);
+	} catch {
+		return false;
+	}
+
+	if (!fdStats.isFile() || !pathStats.isFile() || pathStats.isSymbolicLink()) return false;
+	if (!sameFileStats(fdStats, pathStats)) return false;
+	if (fdStats.size !== 0 || pathStats.size !== 0) return false;
+	if (fdStats.nlink !== 1 || pathStats.nlink !== 1) return false;
+
+	try {
+		closeSync(fd);
+	} catch {
+		return false;
+	}
+	try {
+		unlinkSync(path);
+	} catch {
+		// Best effort only; validation has already failed and no content was written.
+	}
+	return true;
+}
+
+function writeDirectValidated(path, content, { mode, intendedRoot, label, exclusive = false, replace = false, validateParent }) {
+	let fd;
+	let createdByUs = false;
+	let validationComplete = false;
+	try {
+		if (validateParent) validateParent();
+		const noFollowFlag = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+		const targetStats = lstatIfExists(path);
+		if (targetStats) {
+			if (targetStats.isSymbolicLink()) {
+				throw new Error(`refusing to write ${label} through a symlinked path: ${path}`);
+			}
+			if (!targetStats.isFile()) {
+				throw new Error(`refusing to write ${label} because the path is not a regular file: ${path}`);
+			}
+			if (exclusive) {
+				throw new Error(`refusing to write ${label} because the path already exists: ${path}`);
+			}
+			fd = openSync(path, constants.O_RDWR | noFollowFlag, mode);
+		} else {
+			fd = openSync(path, constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | noFollowFlag, mode);
+			createdByUs = true;
+		}
+		if (validateParent) validateParent();
+		validateOpenedFileForDirectWrite(fd, path, intendedRoot, label);
+		validationComplete = true;
+		fchmodSync(fd, mode);
+		if (replace) ftruncateSync(fd, 0);
+		writeFileSync(fd, content);
+		fchmodSync(fd, mode);
+	} catch (error) {
+		if (createdByUs && !validationComplete && fd !== undefined && cleanupCreatedEmptyFile(fd, path)) {
+			fd = undefined;
+		}
+		throw error;
+	} finally {
+		if (fd !== undefined) closeSync(fd);
+	}
+}
+
+export function createSafeTlhProfileWritePlan({ agentDir, targetPath, label = "TLH profile file", homeDir = homedir() }) {
+	const agentRoot = resolve(agentDir);
+	const target = resolve(targetPath);
+	assertNotProtectedPiPath(agentRoot, `${label} profile root`, { homeDir });
+	assertNotProtectedPiPath(target, label, { homeDir });
+	if (target === agentRoot) {
+		throw new Error(`refusing to write ${label} over the configured TLH profile directory: ${target}`);
+	}
+	if (!pathWithinOrEqual(agentRoot, target)) {
+		throw new Error(`refusing to write ${label} outside the configured TLH profile path: ${target} (profile: ${agentRoot})`);
+	}
+
+	const intendedAgentDir = captureIntendedProfileRoot(agentRoot, `${label} profile root`);
+	const plan = {
+		agentRoot,
+		homeDir,
+		intendedAgentDir,
+		intendedTargetParent: "",
+		label,
+		targetPath: target,
+		targetParent: dirname(target),
+	};
+	assertProfileRootSafe(plan);
+
+	const targetStats = lstatIfExists(target);
+	if (targetStats?.isSymbolicLink()) {
+		throw new Error(`refusing to write ${label} through a symlinked path: ${target}`);
+	}
+	if (targetStats && !targetStats.isFile()) {
+		throw new Error(`refusing to write ${label} because the path is not a regular file: ${target}`);
+	}
+
+	assertNoSymlinkedTargetParents(target, agentRoot, label);
+
+	const resolvedTarget = realpathForCompare(target);
+	if (!pathWithinOrEqual(intendedAgentDir, resolvedTarget)) {
+		throw new Error(`refusing to write ${label} outside the isolated TLH profile: ${target} (resolves to ${resolvedTarget}; profile: ${intendedAgentDir})`);
+	}
+
+	plan.intendedTargetParent = resolvedPathFromRoot(plan.targetParent, agentRoot, intendedAgentDir);
+	assertTargetParentSafe(plan);
+	return Object.freeze(plan);
+}
+
+export function writeSafeTlhProfileFile(plan, content, { mode = 0o600, exclusive = false, replace } = {}) {
+	const replaceContent = replace ?? !exclusive;
+	ensureDirectorySafely(plan.targetParent, plan.intendedTargetParent, `${plan.label} parent directory`);
+	assertProfileRootSafe(plan);
+	assertTargetParentSafe(plan);
+	writeDirectValidated(plan.targetPath, content, {
+		exclusive,
+		intendedRoot: plan.intendedTargetParent,
+		label: plan.label,
+		mode,
+		replace: replaceContent,
+		validateParent: () => {
+			assertProfileRootSafe(plan);
+			assertTargetParentSafe(plan);
+		},
+	});
+	return plan.targetPath;
+}

--- a/tests/tlh-profile-writes.test.mjs
+++ b/tests/tlh-profile-writes.test.mjs
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import fs, { existsSync, linkSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { createSafeTlhProfileWritePlan, writeSafeTlhProfileFile } from "../scripts/lib/tlh-profile-writes.mjs";
+
+function tempFixture(t) {
+	const dir = mkdtempSync(join(tmpdir(), "tlh-profile-writes-test-"));
+	const home = join(dir, "home");
+	const agent = join(dir, "agent");
+	const external = join(dir, "external");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(agent, { recursive: true });
+	mkdirSync(external, { recursive: true });
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	return { dir, home, agent, external };
+}
+
+function symlinkDirectory(target, path) {
+	symlinkSync(target, path, process.platform === "win32" ? "junction" : "dir");
+}
+
+function symlinkFile(target, path) {
+	symlinkSync(target, path, process.platform === "win32" ? "file" : "file");
+}
+
+function patchFs(t, overrides) {
+	const original = new Map();
+	for (const [name, value] of Object.entries(overrides)) {
+		const originalValue = fs[name];
+		original.set(name, originalValue);
+		if (name === "realpathSync" && typeof value === "function" && typeof originalValue?.native === "function" && typeof value.native !== "function") {
+			value.native = (...args) => value(...args);
+		}
+		fs[name] = value;
+	}
+	syncBuiltinESMExports();
+	t.after(() => {
+		for (const [name, value] of original.entries()) {
+			fs[name] = value;
+		}
+		syncBuiltinESMExports();
+	});
+}
+
+test("safe TLH profile writes reject normal Pi config targets before creating them", (t) => {
+	const fixture = tempFixture(t);
+	const protectedAgent = join(fixture.home, ".pi", "agent");
+	const protectedTarget = join(protectedAgent, "settings.json");
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: protectedAgent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: protectedTarget,
+		}),
+		/refusing to write settings profile root under normal Pi config root/i,
+	);
+	assert.equal(existsSync(join(fixture.home, ".pi")), false);
+});
+
+test("safe TLH profile writes reject symlinked TLH profile roots", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const linkedAgent = join(fixture.dir, "agent-link");
+	symlinkDirectory(fixture.agent, linkedAgent);
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: linkedAgent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: join(linkedAgent, "settings.json"),
+		}),
+		/symlinked TLH profile root/i,
+	);
+});
+
+test("safe TLH profile writes reject symlinked target parents", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const linkedParent = join(fixture.agent, "config");
+	symlinkDirectory(fixture.external, linkedParent);
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: join(linkedParent, "settings.json"),
+		}),
+		/symlinked target parent component/i,
+	);
+});
+
+test("safe TLH profile writes reject symlinked final targets", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	const sentinel = join(fixture.external, "sentinel-settings.json");
+	writeFileSync(sentinel, "do-not-touch");
+	symlinkFile(sentinel, target);
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: target,
+		}),
+		/symlinked path/i,
+	);
+	assert.equal(readFileSync(sentinel, "utf8"), "do-not-touch");
+});
+
+test("safe TLH profile writes reject rewriting hard-linked targets", (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	const linkedCopy = join(fixture.agent, "settings-linked.json");
+	writeFileSync(target, "original\n");
+	linkSync(target, linkedCopy);
+
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+	assert.throws(
+		() => writeSafeTlhProfileFile(plan, "new\n", { mode: 0o600 }),
+		/hard links/i,
+	);
+	assert.equal(readFileSync(target, "utf8"), "original\n");
+	assert.equal(readFileSync(linkedCopy, "utf8"), "original\n");
+});
+
+test("safe TLH profile writes refuse parent swaps before mkdir and keep attacker-owned paths intact", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "nested", "child", "settings.json");
+	const nested = dirname(dirname(target));
+	const swappedParent = dirname(target);
+	const externalSentinel = join(fixture.external, "sentinel.txt");
+	writeFileSync(externalSentinel, "external sentinel");
+
+	const originalMkdirSync = fs.mkdirSync;
+	let sabotaged = false;
+	patchFs(t, {
+		mkdirSync(path, ...args) {
+			const createdPath = String(path);
+			const result = originalMkdirSync(path, ...args);
+			if (!sabotaged && createdPath === swappedParent) {
+				sabotaged = true;
+				rmSync(createdPath, { recursive: true, force: true });
+				symlinkDirectory(fixture.external, createdPath);
+			}
+			return result;
+		},
+	});
+
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+	assert.throws(
+		() => writeSafeTlhProfileFile(plan, "{}\n", { mode: 0o600 }),
+		/symlinked directory component|outside the intended directory/i,
+	);
+	assert.equal(lstatSync(swappedParent).isSymbolicLink(), true);
+	assert.equal(existsSync(nested), true);
+	assert.equal(readFileSync(externalSentinel, "utf8"), "external sentinel");
+});
+
+test("safe TLH profile writes ignore a pre-created predictable temp symlink", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	const oldTempPath = `${target}.tmp-${process.pid}`;
+	const externalSentinel = join(fixture.external, "sentinel-settings.json");
+	writeFileSync(externalSentinel, "original sentinel");
+	symlinkFile(externalSentinel, oldTempPath);
+
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+	writeSafeTlhProfileFile(plan, '{"ok":true}\n', { mode: 0o600 });
+
+	assert.equal(readFileSync(target, "utf8"), '{"ok":true}\n');
+	assert.equal(readFileSync(externalSentinel, "utf8"), "original sentinel");
+	assert.equal(lstatSync(oldTempPath).isSymbolicLink(), true);
+});
+
+test("safe TLH profile writes refuse parent swaps before open and clean empty external files", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const parent = join(fixture.agent, "config");
+	mkdirSync(parent, { recursive: true });
+	const target = join(parent, "settings.json");
+	const externalSentinel = join(fixture.external, "sentinel.txt");
+	writeFileSync(externalSentinel, "external sentinel");
+
+	const originalOpenSync = fs.openSync;
+	let sabotaged = false;
+	patchFs(t, {
+		openSync(path, flags, mode) {
+			const pathString = String(path);
+			if (!sabotaged && pathString === target) {
+				sabotaged = true;
+				rmSync(parent, { recursive: true, force: true });
+				symlinkDirectory(fixture.external, parent);
+			}
+			return originalOpenSync(path, flags, mode);
+		},
+	});
+
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+	assert.throws(
+		() => writeSafeTlhProfileFile(plan, '{"ok":true}\n', { mode: 0o600 }),
+		/symlinked target parent|outside the intended target parent|outside the intended TLH profile/i,
+	);
+	assert.deepEqual(readdirSync(fixture.external), ["sentinel.txt"]);
+	assert.equal(readFileSync(externalSentinel, "utf8"), "external sentinel");
+});
+
+test("safe TLH profile writes refuse parent swaps before realpath without touching external files", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const parent = join(fixture.agent, "config");
+	mkdirSync(parent, { recursive: true });
+	const target = join(parent, "settings.json");
+	const externalTarget = join(fixture.external, "settings.json");
+	writeFileSync(externalTarget, "external sentinel");
+
+	const originalRealpathSync = fs.realpathSync;
+	let sabotaged = false;
+	patchFs(t, {
+		realpathSync(path, ...args) {
+			const pathString = String(path);
+			if (!sabotaged && pathString === target) {
+				sabotaged = true;
+				rmSync(parent, { recursive: true, force: true });
+				symlinkDirectory(fixture.external, parent);
+			}
+			return originalRealpathSync(path, ...args);
+		},
+	});
+
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+	assert.throws(
+		() => writeSafeTlhProfileFile(plan, '{"ok":true}\n', { mode: 0o600 }),
+		/outside the intended directory|ENOENT|no such file/i,
+	);
+	assert.equal(readFileSync(externalTarget, "utf8"), "external sentinel");
+});
+
+test("safe TLH profile writes set requested modes for new and rewritten files", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	writeSafeTlhProfileFile(plan, '{"step":1}\n', { mode: 0o600 });
+	assert.equal(statSync(target).mode & 0o777, 0o600);
+	assert.equal(readFileSync(target, "utf8"), '{"step":1}\n');
+
+	writeSafeTlhProfileFile(plan, '{"step":2}\n', { mode: 0o640, replace: true });
+	assert.equal(statSync(target).mode & 0o777, 0o640);
+	assert.equal(readFileSync(target, "utf8"), '{"step":2}\n');
+});
+
+test("safe TLH profile writes tighten existing file mode before truncating rewritten content", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	writeFileSync(target, "original\n", { mode: 0o666 });
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	const originalFtruncateSync = fs.ftruncateSync;
+	let observed = false;
+	patchFs(t, {
+		ftruncateSync(fd, len) {
+			observed = true;
+			assert.equal(statSync(target).mode & 0o777, 0o600);
+			assert.equal(readFileSync(target, "utf8"), "original\n");
+			return originalFtruncateSync(fd, len);
+		},
+	});
+
+	writeSafeTlhProfileFile(plan, '{"step":2}\n', { mode: 0o600, replace: true });
+	assert.equal(observed, true);
+	assert.equal(statSync(target).mode & 0o777, 0o600);
+	assert.equal(readFileSync(target, "utf8"), '{"step":2}\n');
+});


### PR DESCRIPTION
## Summary
- Add an unused scripts-level safe TLH profile write helper for isolated-profile writes.
- Add helper-level adversarial tests for normal Pi rejection, symlinks, hardlinks, parent swaps, cleanup safety, predictable temp precreation, and mode behavior.
- Close Phase 1 ticket `tlhf-6y8r`.

## Multi-step rollout
This PR is the first batch of a multi-step safe-profile-write centralization effort. The work is intentionally split so each batch can merge into `main` without breaking installs or runtime behavior.

Committed phase tickets:
- `tlhf-6y8r` — Phase 1: add safe profile write helper and helper tests (this PR)
- `tlhf-1eer` — Phase 2: package safe profile write helper for installer support scripts
- `tlhf-82ly` — Phase 2.5: harden safe profile helper before production migrations
- `tlhf-cysu` — Phase 3: migrate `merge-settings` to safe profile write helper
- `tlhf-vjga` — Phase 4: migrate keybindings, defaults, and install-state writers
- `tlhf-pbnd` — Phase 5: route installer support profile copies through safe helper
- `tlhf-pouj` — Phase 6: migrate managed Gnosis writes to safe helper
- `tlhf-umo9` — Phase 7: migrate managed tk writes to safe helper
- `tlhf-d77a` — Phase 8: document safe TLH profile write architecture

## Safety / mergeability
- No production call sites migrated in this phase.
- No `install.sh` or stage-1 support manifest changes.
- Installer behavior should be unchanged; helper is only exercised by tests for now.

## Validation
- `npm run validate`

Follow-up phases are tracked in the committed `tk` tickets.
