### PR TITLE
Package safe profile write helper

### DIFF
--- a/.tickets/tlhf-1eer.md
+++ b/.tickets/tlhf-1eer.md
@@ -1,6 +1,6 @@
 ---
 id: tlhf-1eer
-status: open
+status: closed
 deps: [tlhf-6y8r]
 links: []
 created: 2026-05-23T09:53:08Z

--- a/install.sh
+++ b/install.sh
@@ -356,6 +356,7 @@ required|scripts/tlh-install.mjs
 required|scripts/lib/tlh-install-support-manifest.mjs
 required|scripts/lib/tlh-install-package-source.mjs
 required|scripts/lib/tlh-install-paths.mjs
+required|scripts/lib/tlh-profile-writes.mjs
 required|scripts/lib/tlh-install-utils.mjs
 required|scripts/lib/tlh-install-git.mjs
 required|scripts/lib/tlh-install-subagents.mjs

--- a/scripts/lib/tlh-install-support-manifest.mjs
+++ b/scripts/lib/tlh-install-support-manifest.mjs
@@ -31,6 +31,13 @@ const BASE_SUPPORT_FILES = Object.freeze([
 		installName: "lib/tlh-install-paths.mjs",
 	},
 	{
+		variable: "TLH_PROFILE_WRITES_LIB",
+		requirement: REQUIRED,
+		relativePath: "scripts/lib/tlh-profile-writes.mjs",
+		tempPath: "lib/tlh-profile-writes.mjs",
+		installName: "lib/tlh-profile-writes.mjs",
+	},
+	{
 		variable: "TLH_INSTALL_UTILS_LIB",
 		requirement: REQUIRED,
 		relativePath: "scripts/lib/tlh-install-utils.mjs",

--- a/tests/install-libs.test.mjs
+++ b/tests/install-libs.test.mjs
@@ -307,12 +307,20 @@ test("support manifest includes stage-1 and installed helper library dependencie
 	assert.ok(relativePaths.includes("scripts/lib/tlh-install-git.mjs"));
 	assert.ok(relativePaths.includes("scripts/lib/tlh-install-support-files.mjs"));
 	assert.ok(relativePaths.includes("scripts/lib/tlh-install-utils.mjs"));
+	assert.ok(relativePaths.includes("scripts/lib/tlh-profile-writes.mjs"));
 	assert.deepEqual(manifest.find((file) => file.variable === "TLH_INSTALL_PATHS_LIB"), {
 		variable: "TLH_INSTALL_PATHS_LIB",
 		requirement: "required",
 		relativePath: "scripts/lib/tlh-install-paths.mjs",
 		tempPath: "lib/tlh-install-paths.mjs",
 		installName: "lib/tlh-install-paths.mjs",
+	});
+	assert.deepEqual(manifest.find((file) => file.variable === "TLH_PROFILE_WRITES_LIB"), {
+		variable: "TLH_PROFILE_WRITES_LIB",
+		requirement: "required",
+		relativePath: "scripts/lib/tlh-profile-writes.mjs",
+		tempPath: "lib/tlh-profile-writes.mjs",
+		installName: "lib/tlh-profile-writes.mjs",
 	});
 	assert.deepEqual(manifest.find((file) => file.variable === "TLH_INSTALL_UTILS_LIB"), {
 		variable: "TLH_INSTALL_UTILS_LIB",
@@ -332,6 +340,7 @@ test("support manifest includes stage-1 and installed helper library dependencie
 
 	const bootstrap = readFileSync(resolve(import.meta.dirname, "..", "install.sh"), "utf8");
 	assert.match(bootstrap, /^required\|scripts\/lib\/default-extensions\.mjs$/m);
+	assert.match(bootstrap, /^required\|scripts\/lib\/tlh-profile-writes\.mjs$/m);
 	assert.match(bootstrap, /^required\|scripts\/lib\/tlh-install-utils\.mjs$/m);
 });
 

--- a/tests/tlh-profile-writes.test.mjs
+++ b/tests/tlh-profile-writes.test.mjs
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
-import fs, { existsSync, linkSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import fs, { copyFileSync, existsSync, linkSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import { createSafeTlhProfileWritePlan, writeSafeTlhProfileFile } from "../scripts/lib/tlh-profile-writes.mjs";
+
+const repoRoot = join(import.meta.dirname, "..");
 
 function tempFixture(t) {
 	const dir = mkdtempSync(join(tmpdir(), "tlh-profile-writes-test-"));
@@ -45,6 +48,18 @@ function patchFs(t, overrides) {
 		syncBuiltinESMExports();
 	});
 }
+
+test("copied profile write helper resolves its installed sibling dependency", async (t) => {
+	const fixture = tempFixture(t);
+	const supportLibDir = join(fixture.agent, "tlh", "lib");
+	mkdirSync(supportLibDir, { recursive: true });
+	copyFileSync(join(repoRoot, "scripts", "lib", "tlh-profile-writes.mjs"), join(supportLibDir, "tlh-profile-writes.mjs"));
+	copyFileSync(join(repoRoot, "scripts", "lib", "tlh-install-paths.mjs"), join(supportLibDir, "tlh-install-paths.mjs"));
+
+	const helper = await import(pathToFileURL(join(supportLibDir, "tlh-profile-writes.mjs")).href);
+	assert.equal(typeof helper.createSafeTlhProfileWritePlan, "function");
+	assert.equal(typeof helper.writeSafeTlhProfileFile, "function");
+});
 
 test("safe TLH profile writes reject normal Pi config targets before creating them", (t) => {
 	const fixture = tempFixture(t);


### PR DESCRIPTION
## Summary
- Package `scripts/lib/tlh-profile-writes.mjs` as an installer support helper.
- Add it to the stage-1 support manifest and stage-0 bootstrap manifest.
- Add tests for manifest alignment and installed sibling import resolution.
- Close Phase 2 ticket `tlhf-1eer`.

## Multi-step rollout
This is the second batch of the safe-profile-write centralization effort. It only makes the Phase 1 helper available to future stage-1/installed support scripts; production write call sites are not migrated here.

Relevant tickets:
- `tlhf-6y8r` — Phase 1: add safe profile write helper and helper tests (merged)
- `tlhf-1eer` — Phase 2: package safe profile write helper for installer support scripts (this PR)
- `tlhf-82ly` — Phase 2.5: harden safe profile helper before production migrations
- `tlhf-cysu` and later — production migrations in later batches

## Safety / mergeability
- No production call sites migrated.
- Installer behavior changes only by fetching/copying one additional required helper file.
- Stage-0 and stage-1 manifests are kept aligned.

## Validation
- `node --test tests/install-libs.test.mjs tests/tlh-profile-writes.test.mjs`
- `npm run validate`
