### PR TITLE
Harden safe profile write helper

### DIFF
--- a/.tickets/tlhf-82ly.md
+++ b/.tickets/tlhf-82ly.md
@@ -1,6 +1,6 @@
 ---
 id: tlhf-82ly
-status: open
+status: closed
 deps: [tlhf-1eer]
 links: []
 created: 2026-05-23T12:07:03Z

--- a/scripts/lib/tlh-profile-writes.mjs
+++ b/scripts/lib/tlh-profile-writes.mjs
@@ -17,6 +17,32 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 
 import { pathIsProtectedPiConfig, pathWithinOrEqual, realpathForCompare } from "./tlh-install-paths.mjs";
 
+const FILE_PERMISSION_MASK = 0o777;
+const FILE_MODE_COMPARISON_MASK = 0o7777;
+const REQUIRED_OWNER_READ_WRITE_BITS = 0o600;
+const DISALLOWED_GROUP_OTHER_WRITE_BITS = 0o022;
+const INITIAL_CREATED_FILE_MODE = REQUIRED_OWNER_READ_WRITE_BITS;
+
+function formatMode(mode) {
+	return `0o${mode.toString(8)}`;
+}
+
+function validateSafeWriteMode(mode, label) {
+	if (!Number.isSafeInteger(mode)) {
+		throw new Error(`refusing to write ${label} with invalid file mode: ${mode}`);
+	}
+	if (mode < 0 || mode > FILE_PERMISSION_MASK) {
+		throw new Error(`refusing to write ${label} with unsupported file mode outside 0o000-0o777: ${formatMode(mode)}`);
+	}
+	if ((mode & REQUIRED_OWNER_READ_WRITE_BITS) !== REQUIRED_OWNER_READ_WRITE_BITS) {
+		throw new Error(`refusing to write ${label} with unsupported file mode missing owner read/write bits: ${formatMode(mode)}`);
+	}
+	if ((mode & DISALLOWED_GROUP_OTHER_WRITE_BITS) !== 0) {
+		throw new Error(`refusing to write ${label} with unsupported file mode containing group or other write bits: ${formatMode(mode)}`);
+	}
+	return mode;
+}
+
 function lstatIfExists(path) {
 	try {
 		return lstatSync(path);
@@ -322,6 +348,10 @@ function cleanupCreatedEmptyFile(fd, path) {
 	return true;
 }
 
+function shouldTightenModeBeforeWrite(currentMode, requestedMode) {
+	return requestedMode !== currentMode && (requestedMode & ~currentMode) === 0;
+}
+
 function writeDirectValidated(path, content, { mode, intendedRoot, label, exclusive = false, replace = false, validateParent }) {
 	let fd;
 	let createdByUs = false;
@@ -342,13 +372,17 @@ function writeDirectValidated(path, content, { mode, intendedRoot, label, exclus
 			}
 			fd = openSync(path, constants.O_RDWR | noFollowFlag, mode);
 		} else {
-			fd = openSync(path, constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | noFollowFlag, mode);
+			fd = openSync(path, constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | noFollowFlag, INITIAL_CREATED_FILE_MODE);
 			createdByUs = true;
 		}
 		if (validateParent) validateParent();
 		validateOpenedFileForDirectWrite(fd, path, intendedRoot, label);
 		validationComplete = true;
-		fchmodSync(fd, mode);
+
+		const currentMode = fstatSync(fd).mode & FILE_MODE_COMPARISON_MASK;
+		if (!createdByUs && shouldTightenModeBeforeWrite(currentMode, mode)) {
+			fchmodSync(fd, mode);
+		}
 		if (replace) ftruncateSync(fd, 0);
 		writeFileSync(fd, content);
 		fchmodSync(fd, mode);
@@ -362,6 +396,14 @@ function writeDirectValidated(path, content, { mode, intendedRoot, label, exclus
 	}
 }
 
+/**
+ * Captures a direct-write plan for a managed tlh profile file.
+ *
+ * Safety policy:
+ * - anchor all later containment checks to the captured realpath of the configured profile root
+ * - allow symlink ancestors above `agentDir` only when that resolved profile root and the resolved target still stay inside the intended profile
+ * - reject symlinked profile roots, target parents, and final targets inside the managed profile path
+ */
 export function createSafeTlhProfileWritePlan({ agentDir, targetPath, label = "TLH profile file", homeDir = homedir() }) {
 	const agentRoot = resolve(agentDir);
 	const target = resolve(targetPath);
@@ -406,7 +448,21 @@ export function createSafeTlhProfileWritePlan({ agentDir, targetPath, label = "T
 	return Object.freeze(plan);
 }
 
+/**
+ * Writes directly to `plan.targetPath` in place.
+ *
+ * This helper does not provide atomic rename semantics, backups, or rollback/crash-recovery guarantees.
+ * Callers that need recovery must create backups before writing.
+ *
+ * `replace: true` truncates before writing. `replace: false` writes from offset 0 without truncating,
+ * so shorter content can leave trailing bytes behind.
+ *
+ * Accepted modes are safe integer permission bits within `0o000..0o777` that keep owner read/write,
+ * reject special bits, and reject group/other write bits. This preserves `0o600`/`0o640` behavior while
+ * still allowing future managed executable profile artifacts such as `0o755`.
+ */
 export function writeSafeTlhProfileFile(plan, content, { mode = 0o600, exclusive = false, replace } = {}) {
+	const validatedMode = validateSafeWriteMode(mode, plan.label);
 	const replaceContent = replace ?? !exclusive;
 	ensureDirectorySafely(plan.targetParent, plan.intendedTargetParent, `${plan.label} parent directory`);
 	assertProfileRootSafe(plan);
@@ -415,7 +471,7 @@ export function writeSafeTlhProfileFile(plan, content, { mode = 0o600, exclusive
 		exclusive,
 		intendedRoot: plan.intendedTargetParent,
 		label: plan.label,
-		mode,
+		mode: validatedMode,
 		replace: replaceContent,
 		validateParent: () => {
 			assertProfileRootSafe(plan);

--- a/tests/tlh-profile-writes.test.mjs
+++ b/tests/tlh-profile-writes.test.mjs
@@ -78,6 +78,163 @@ test("safe TLH profile writes reject normal Pi config targets before creating th
 	assert.equal(existsSync(join(fixture.home, ".pi")), false);
 });
 
+test("safe TLH profile writes create missing agent directories inside the intended profile", (t) => {
+	const fixture = tempFixture(t);
+	const agentDir = join(fixture.dir, "missing-agent", "profile");
+	const target = join(agentDir, "config", "settings.json");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	writeSafeTlhProfileFile(plan, '{"created":true}\n', { exclusive: true, mode: 0o600 });
+
+	assert.equal(readFileSync(target, "utf8"), '{"created":true}\n');
+	assert.equal(existsSync(join(agentDir, "config")), true);
+	assert.equal(existsSync(join(fixture.external, "config", "settings.json")), false);
+});
+
+test("safe TLH profile writes reject targets equal to the configured profile root", (t) => {
+	const fixture = tempFixture(t);
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: fixture.agent,
+		}),
+		/configured TLH profile directory/i,
+	);
+});
+
+test("safe TLH profile writes reject targets outside the configured profile", (t) => {
+	const fixture = tempFixture(t);
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: join(fixture.external, "settings.json"),
+		}),
+		/outside the configured TLH profile path/i,
+	);
+});
+
+test("safe TLH profile writes reject non-directory target parents", (t) => {
+	const fixture = tempFixture(t);
+	const parentFile = join(fixture.agent, "config");
+	writeFileSync(parentFile, "not-a-directory\n");
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: join(parentFile, "settings.json"),
+		}),
+		/target parent component is not a directory|target parent is not a directory/i,
+	);
+});
+
+test("safe TLH profile writes reject non-file final targets", (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	mkdirSync(target, { recursive: true });
+
+	assert.throws(
+		() => createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: target,
+		}),
+		/path is not a regular file/i,
+	);
+});
+
+test("safe TLH profile writes honor exclusive creation for new and existing targets", (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	writeSafeTlhProfileFile(plan, '{"created":1}\n', { exclusive: true, mode: 0o600 });
+	assert.equal(readFileSync(target, "utf8"), '{"created":1}\n');
+
+	assert.throws(
+		() => writeSafeTlhProfileFile(plan, '{"created":2}\n', { exclusive: true, mode: 0o600 }),
+		/already exists/i,
+	);
+	assert.equal(readFileSync(target, "utf8"), '{"created":1}\n');
+});
+
+test("safe TLH profile writes honor explicit replace:false without truncating trailing content", (t) => {
+	const fixture = tempFixture(t);
+	const target = join(fixture.agent, "settings.json");
+	writeFileSync(target, "abcdef");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir: fixture.agent,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	writeSafeTlhProfileFile(plan, "xy", { mode: 0o600, replace: false });
+	assert.equal(readFileSync(target, "utf8"), "xycdef");
+});
+
+test("safe TLH profile writes accept symlink ancestors above the configured profile root when containment stays anchored", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const realBase = join(fixture.external, "real-base");
+	mkdirSync(join(realBase, "agent"), { recursive: true });
+	const linkedBase = join(fixture.dir, "linked-base");
+	symlinkDirectory(realBase, linkedBase);
+	const agentDir = join(linkedBase, "agent");
+	const target = join(agentDir, "settings.json");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	writeSafeTlhProfileFile(plan, '{"anchored":true}\n', { mode: 0o600, replace: true });
+	assert.equal(readFileSync(target, "utf8"), '{"anchored":true}\n');
+	assert.equal(readFileSync(join(realBase, "agent", "settings.json"), "utf8"), '{"anchored":true}\n');
+});
+
+test("safe TLH profile writes reject invalid modes before mutating the filesystem", (t) => {
+	const fixture = tempFixture(t);
+	const agentDir = join(fixture.dir, "mode-agent", "profile");
+	const target = join(agentDir, "config", "settings.json");
+	const plan = createSafeTlhProfileWritePlan({
+		agentDir,
+		homeDir: fixture.home,
+		label: "settings",
+		targetPath: target,
+	});
+
+	for (const [mode, pattern] of [
+		["0o600", /invalid file mode/i],
+		[0o1000, /outside 0o000-0o777/i],
+		[0o666, /group or other write bits/i],
+		[0o777, /group or other write bits/i],
+		[0o400, /owner read\/write bits/i],
+	]) {
+		assert.throws(() => writeSafeTlhProfileFile(plan, '{}\n', { mode }), pattern);
+		assert.equal(existsSync(agentDir), false);
+		assert.equal(existsSync(target), false);
+	}
+});
+
 test("safe TLH profile writes reject symlinked TLH profile roots", { skip: process.platform === "win32" }, (t) => {
 	const fixture = tempFixture(t);
 	const linkedAgent = join(fixture.dir, "agent-link");
@@ -280,7 +437,7 @@ test("safe TLH profile writes refuse parent swaps before realpath without touchi
 	assert.equal(readFileSync(externalTarget, "utf8"), "external sentinel");
 });
 
-test("safe TLH profile writes set requested modes for new and rewritten files", { skip: process.platform === "win32" }, (t) => {
+test("safe TLH profile writes set requested modes for new, rewritten, and executable-safe files", { skip: process.platform === "win32" }, (t) => {
 	const fixture = tempFixture(t);
 	const target = join(fixture.agent, "settings.json");
 	const plan = createSafeTlhProfileWritePlan({
@@ -297,6 +454,116 @@ test("safe TLH profile writes set requested modes for new and rewritten files", 
 	writeSafeTlhProfileFile(plan, '{"step":2}\n', { mode: 0o640, replace: true });
 	assert.equal(statSync(target).mode & 0o777, 0o640);
 	assert.equal(readFileSync(target, "utf8"), '{"step":2}\n');
+
+	writeSafeTlhProfileFile(plan, "#!/bin/sh\n", { mode: 0o755, replace: true });
+	assert.equal(statSync(target).mode & 0o777, 0o755);
+	assert.equal(readFileSync(target, "utf8"), "#!/bin/sh\n");
+});
+
+test("safe TLH profile writes keep new wider-mode files restrictive until content write completes", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const originalOpenSync = fs.openSync;
+	const originalWriteFileSync = fs.writeFileSync;
+	const originalFchmodSync = fs.fchmodSync;
+	let expectedTarget;
+	let expectedMode;
+	let writeCompleted = false;
+	let sawCreate = false;
+	let sawFinalChmod = false;
+	patchFs(t, {
+		openSync(path, flags, mode) {
+			if (String(path) === expectedTarget && (flags & fs.constants.O_CREAT) !== 0) {
+				sawCreate = true;
+				assert.equal(mode, 0o600);
+			}
+			return originalOpenSync(path, flags, mode);
+		},
+		writeFileSync(fd, content, ...args) {
+			if (typeof fd !== "number") {
+				return originalWriteFileSync(fd, content, ...args);
+			}
+			assert.ok(expectedTarget);
+			assert.equal(statSync(expectedTarget).mode & 0o777, 0o600);
+			const result = originalWriteFileSync(fd, content, ...args);
+			writeCompleted = true;
+			return result;
+		},
+		fchmodSync(fd, mode) {
+			if (mode === expectedMode) {
+				assert.equal(writeCompleted, true);
+				sawFinalChmod = true;
+			}
+			return originalFchmodSync(fd, mode);
+		},
+	});
+
+	for (const mode of [0o644, 0o755]) {
+		expectedTarget = join(fixture.agent, `mode-${mode.toString(8)}.txt`);
+		expectedMode = mode;
+		writeCompleted = false;
+		sawCreate = false;
+		sawFinalChmod = false;
+		const plan = createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: expectedTarget,
+		});
+
+		writeSafeTlhProfileFile(plan, `mode=${mode.toString(8)}\n`, { exclusive: true, mode });
+		assert.equal(sawCreate, true);
+		assert.equal(sawFinalChmod, true);
+		assert.equal(statSync(expectedTarget).mode & 0o777, mode);
+		assert.equal(readFileSync(expectedTarget, "utf8"), `mode=${mode.toString(8)}\n`);
+	}
+});
+
+test("safe TLH profile writes keep restrictive modes until wider rewrites finish writing", { skip: process.platform === "win32" }, (t) => {
+	const fixture = tempFixture(t);
+	const originalWriteFileSync = fs.writeFileSync;
+	const originalFchmodSync = fs.fchmodSync;
+	let expectedTarget;
+	let expectedMode;
+	let writeCompleted = false;
+	let sawFinalChmod = false;
+	patchFs(t, {
+		writeFileSync(fd, content, ...args) {
+			if (typeof fd !== "number") {
+				return originalWriteFileSync(fd, content, ...args);
+			}
+			assert.ok(expectedTarget);
+			assert.equal(statSync(expectedTarget).mode & 0o777, 0o600);
+			const result = originalWriteFileSync(fd, content, ...args);
+			writeCompleted = true;
+			return result;
+		},
+		fchmodSync(fd, mode) {
+			if (mode === expectedMode) {
+				assert.equal(writeCompleted, true);
+				sawFinalChmod = true;
+			}
+			return originalFchmodSync(fd, mode);
+		},
+	});
+
+	for (const mode of [0o644, 0o755]) {
+		expectedTarget = join(fixture.agent, `rewrite-${mode.toString(8)}.txt`);
+		expectedMode = mode;
+		writeCompleted = false;
+		sawFinalChmod = false;
+		writeFileSync(expectedTarget, "original\n", { mode: 0o600 });
+		const plan = createSafeTlhProfileWritePlan({
+			agentDir: fixture.agent,
+			homeDir: fixture.home,
+			label: "settings",
+			targetPath: expectedTarget,
+		});
+
+		writeSafeTlhProfileFile(plan, `mode=${mode.toString(8)}\n`, { mode, replace: true });
+		assert.equal(sawFinalChmod, true);
+		assert.equal(statSync(expectedTarget).mode & 0o777, mode);
+		assert.equal(readFileSync(expectedTarget, "utf8"), `mode=${mode.toString(8)}\n`);
+	}
 });
 
 test("safe TLH profile writes tighten existing file mode before truncating rewritten content", { skip: process.platform === "win32" }, (t) => {


### PR DESCRIPTION
## Summary
- Harden `writeSafeTlhProfileFile()` mode handling before production migrations.
- Document direct/in-place write, backup, `replace:false`, and symlink-ancestor policies.
- Expand helper coverage for Phase 2.5 edge cases.
- Close Phase 2.5 ticket `tlhf-82ly`.

## Multi-step rollout
This is the pre-migration hardening batch for the safe-profile-write centralization effort. It does not migrate production call sites; it prepares the shared helper before `merge-settings` and later support scripts adopt it.

Relevant tickets:
- `tlhf-6y8r` — Phase 1: add safe profile write helper and helper tests (merged)
- `tlhf-1eer` — Phase 2: package safe profile write helper for installer support scripts (merged)
- `tlhf-82ly` — Phase 2.5: harden safe profile helper before production migrations (this PR)
- `tlhf-cysu` — Phase 3: migrate `merge-settings` to safe profile write helper

## Safety / mergeability
- No production call sites migrated.
- Mode validation runs before filesystem mutation.
- New wider-mode files are created restrictively and widened only after content is written.
- Existing files are pre-chmodded only when tightening permissions before rewrite.

## Validation
- `node --test tests/tlh-profile-writes.test.mjs`
- `npm run validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file permission validation to enforce stricter safety for profile operations, preventing unintended permission changes on existing files.

* **Tests**
  * Expanded test coverage for profile write scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->