### PR TITLE
Add TLH session analysis prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Common TLH commands:
 - `/usage [status|weekly on|weekly off|weekly toggle]` — inspect or change whether the footer shows weekly subscription usage.
 - `/context [--no-open] [--keep] [--redact] [--full|--current]` — generate a local HTML breakdown of where the session context is going.
 - `/harness-plan` — open the bundled implementation-planning prompt.
+- `/analyse-tlh-sessions` — open a bundled read-only prompt to review the past week of tlh sessions for notable issues.
 
 Persistent primary-agent changes are written under `tlh.primaryAgent` in the isolated TLH settings file at `~/.the-last-harness/agent/settings.json`, with a backup when an existing settings file is changed. Use `/agent default reset` or `/architect default reset` to remove those persistent fields and return future sessions to the built-in `architect` default. Use `/agent reset` or `/architect reset` for the current session only.
 

--- a/prompts/analyse-tlh-sessions.md
+++ b/prompts/analyse-tlh-sessions.md
@@ -1,0 +1,13 @@
+---
+description: Analyse the past week of tlh sessions for notable issues without changing files
+---
+Review the past week of tlh sessions under `~/.the-last-harness`.
+
+Provide a read-only analysis that:
+
+- identifies notable issues, risks, failures, or recurring friction,
+- cites concrete evidence such as session file paths, timestamps, and relevant excerpts or summaries,
+- states clearly when nothing concerning stands out,
+- highlights any follow-up areas worth reviewing manually.
+
+Do not modify any files during this analysis.


### PR DESCRIPTION
## Summary
- add packaged `/analyse-tlh-sessions` prompt template for read-only weekly tlh session analysis
- document the slash command in README

## Validation
- npm run validate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/analyse-tlh-sessions` slash command to review past TLH sessions, identifying notable issues, risks, and recurring friction points with concrete evidence and timestamps. Analysis is read-only with no file modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->