### PR TITLE
Move track warning into header

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/main/install.sh | bash -s -- --ref main --track ref
 ```
 
-These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a short track notice only for those installs, formatted as `TLH: <label> track` (for example `TLH: v0.6.0 track`, `TLH: main track`, `TLH: local track`, or `TLH: unknown track`). Official latest-release installs stay silent.
+These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a header warning only for those installs. It appears above `Context:` and reads `Warning: running TLH from {name} track` (for example `Warning: running TLH from v0.6.0 track`, `Warning: running TLH from main track`, `Warning: running TLH from local track`, or `Warning: running TLH from unknown track`). Official latest-release installs stay silent.
 
 ## Installer options
 
@@ -60,7 +60,7 @@ You can just run `tlh update`.
 
 This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
 
-At launch, TLH also shows that short `TLH: <label> track` notice when your install metadata says you are not on the official latest stable path, or when it cannot verify that metadata. The notice is informational only; it does not change your isolated install or auto-update anything.
+At launch, TLH also shows that `Warning: running TLH from {name} track` header warning above `Context:` when your install metadata says you are not on the official latest stable path, or when it cannot verify that metadata. The warning is informational only; it does not change your isolated install or auto-update anything.
 
 - If you installed from a pinned release tag, a non-stable git ref, or another custom update track while still using the default TLH repo/package source, return to the official latest stable release track with:
 

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -5,7 +5,7 @@ import { registerEffortCommand } from "./the-last-harness/effort.js";
 import { createTlhFooter } from "./the-last-harness/footer.js";
 import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
-import { maybeNotifyTlhInstallNotice } from "./the-last-harness/install-state.js";
+import { readTlhInstallNotice } from "./the-last-harness/install-state.js";
 import { scheduleTlhLaunchTelemetry } from "./the-last-harness/launch-telemetry.js";
 import { registerTlhPrimaryAgentRuntime } from "./the-last-harness/primary-agent-runtime.js";
 import { collectStartupResources } from "./the-last-harness/resources.js";
@@ -70,7 +70,6 @@ export default function theLastHarness(pi: ExtensionAPI) {
 
 		if (event.reason === "startup") {
 			scheduleTlhLaunchTelemetry(ctx);
-			maybeNotifyTlhInstallNotice(ctx);
 		}
 
 		ctx.ui.addAutocompleteProvider(createTlhAutocompleteProvider);
@@ -83,6 +82,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 		}
 
 		const headerUpdate = getTlhHeaderUpdate();
+		const installNotice = event.reason === "startup" ? readTlhInstallNotice() : undefined;
 
 		if (typeof ctx.ui.setFooter === "function") {
 			ctx.ui.setFooter((tui, theme, footerData) => {
@@ -100,7 +100,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 			});
 		}
 		if (typeof ctx.ui.setHeader === "function") {
-			ctx.ui.setHeader((_tui, theme) => createTlhHeader(theme, resources, headerUpdate));
+			ctx.ui.setHeader((_tui, theme) => createTlhHeader(theme, resources, headerUpdate, installNotice));
 		}
 
 		refreshSubscriptionUsage(ctx);

--- a/extensions/the-last-harness/header.ts
+++ b/extensions/the-last-harness/header.ts
@@ -1,14 +1,21 @@
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { TLH_NAME } from "./constants.js";
-import type { StartupResources, TlhHeaderUpdate } from "./types.js";
+import { formatTlhInstallNoticeTrackLabel } from "./install-state.js";
+import type { StartupResources, TlhHeaderUpdate, TlhInstallNotice } from "./types.js";
 
-export function createTlhHeader(theme: Theme, resources: StartupResources, headerUpdate: TlhHeaderUpdate | undefined) {
+export function createTlhHeader(
+	theme: Theme,
+	resources: StartupResources,
+	headerUpdate: TlhHeaderUpdate | undefined,
+	installNotice?: TlhInstallNotice,
+) {
 	let expanded = false;
 	const color = {
 		heading: (text: string) => theme.fg("mdHeading", text),
 		dim: (text: string) => theme.fg("dim", text),
 		accent: (text: string) => theme.fg("accent", text),
+		warning: (text: string) => theme.fg("warning", text),
 	};
 
 	const logo = headerUpdate
@@ -22,6 +29,15 @@ export function createTlhHeader(theme: Theme, resources: StartupResources, heade
 		return [color.heading(`[${name}]`), color.dim(`  ${items.join(", ")}`)];
 	};
 
+	const installWarningLine = (width: number): string[] => {
+		if (!installNotice) {
+			return [];
+		}
+		const label = formatTlhInstallNoticeTrackLabel(installNotice);
+		const warningLine = `${color.warning("Warning")}${color.dim(`: running TLH from ${label} track`)}`;
+		return [truncateToWidth(warningLine, width, color.dim("..."))];
+	};
+
 	const contextLine = (items: string[], width: number): string[] => {
 		if (items.length === 0) {
 			return [];
@@ -31,9 +47,9 @@ export function createTlhHeader(theme: Theme, resources: StartupResources, heade
 
 	const renderCollapsed = (width: number) => {
 		const lines = [logo];
-		const contextLines = contextLine(resources.context, width);
-		if (contextLines.length > 0) {
-			lines.push("", ...contextLines);
+		const headerDetails = [...installWarningLine(width), ...contextLine(resources.context, width)];
+		if (headerDetails.length > 0) {
+			lines.push("", ...headerDetails);
 		}
 		return lines;
 	};

--- a/extensions/the-last-harness/install-state.ts
+++ b/extensions/the-last-harness/install-state.ts
@@ -1,4 +1,3 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { TLH_REPO } from "./constants.js";
 import { readTlhInstallState } from "./profile-state.js";
 import type { TlhInstallNotice, TlhInstallState } from "./types.js";
@@ -126,7 +125,7 @@ export function readTlhInstallNotice(): TlhInstallNotice | undefined {
 	return classifyTlhInstallState(readTlhInstallState());
 }
 
-function formatTlhInstallNoticeLabel(notice: TlhInstallNotice): string {
+export function formatTlhInstallNoticeTrackLabel(notice: TlhInstallNotice): string {
 	if (notice.kind === "unknown") {
 		return "unknown";
 	}
@@ -140,13 +139,6 @@ function formatTlhInstallNoticeLabel(notice: TlhInstallNotice): string {
 }
 
 export function formatTlhInstallNoticeMessage(notice: TlhInstallNotice): string {
-	return `TLH: ${formatTlhInstallNoticeLabel(notice)} track`;
+	return `Warning: running TLH from ${formatTlhInstallNoticeTrackLabel(notice)} track`;
 }
 
-export function maybeNotifyTlhInstallNotice(ctx: ExtensionContext): void {
-	const notice = readTlhInstallNotice();
-	if (!notice) {
-		return;
-	}
-	ctx.ui.notify(formatTlhInstallNoticeMessage(notice), "warning");
-}

--- a/tests/the-last-harness-extension-startup-warning.test.mjs
+++ b/tests/the-last-harness-extension-startup-warning.test.mjs
@@ -9,6 +9,11 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url);
 const { default: theLastHarness } = await jiti.import("../extensions/the-last-harness.ts");
 
+const theme = {
+	fg: (_color, text) => text,
+	bold: (text) => text,
+};
+
 const PINNED_TAG_INSTALL_STATE = {
 	repo: "diegopetrucci/the-last-harness",
 	track: "pinned-tag",
@@ -46,7 +51,7 @@ function createPi() {
 	};
 }
 
-function createCtx({ cwd, notifications, hasUI = true }) {
+function createCtx({ cwd, notifications, hasUI = true, onSetHeader }) {
 	return {
 		hasUI,
 		cwd,
@@ -67,7 +72,9 @@ function createCtx({ cwd, notifications, hasUI = true }) {
 		ui: {
 			addAutocompleteProvider() {},
 			setFooter() {},
-			setHeader() {},
+			setHeader(factory) {
+				onSetHeader?.(factory);
+			},
 			notify(message, type) {
 				notifications.push({ message, type });
 			},
@@ -118,49 +125,66 @@ async function runSessionStart({ reason, installState, hasUI = true }) {
 		const pi = createPi();
 		theLastHarness(pi);
 		const notifications = [];
-		const ctx = createCtx({ cwd, notifications, hasUI });
+		let headerFactory;
+		const ctx = createCtx({
+			cwd,
+			notifications,
+			hasUI,
+			onSetHeader(factory) {
+				headerFactory = factory;
+			},
+		});
 		const sessionStartHandler = pi.handlers.get("session_start")?.[0];
 		assert.ok(sessionStartHandler, "session_start handler must be registered by the extension");
 
 		await sessionStartHandler({ reason }, ctx);
 		await new Promise((resolve) => setImmediate(resolve));
-		return notifications;
+		const headerLines = headerFactory ? headerFactory({ requestRender() {} }, theme).render(200) : undefined;
+		return { notifications, headerLines };
 	} finally {
 		restoreEnv(previousEnv);
 		rmSync(tempDir, { recursive: true, force: true });
 	}
 }
 
-test("interactive startup shows the concise non-latest track notice", async () => {
-	const notifications = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE });
+test("interactive startup renders the non-latest track warning in the TLH header", async () => {
+	const { notifications, headerLines } = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE });
 
-	assert.equal(notifications.length, 1);
-	assert.equal(notifications[0]?.type, "warning");
-	assert.equal(notifications[0]?.message, "TLH: v0.10.0 track");
+	assert.deepEqual(notifications, []);
+	assert.ok(headerLines);
+	assert.ok(headerLines.includes("Warning: running TLH from v0.10.0 track"));
 });
 
-
 test("interactive startup prefers the pinned ref label over a local package-source label", async () => {
-	const notifications = await runSessionStart({ reason: "startup", installState: PINNED_TAG_LOCAL_INSTALL_STATE });
+	const { notifications, headerLines } = await runSessionStart({ reason: "startup", installState: PINNED_TAG_LOCAL_INSTALL_STATE });
 
-	assert.equal(notifications.length, 1);
-	assert.equal(notifications[0]?.type, "warning");
-	assert.equal(notifications[0]?.message, "TLH: v0.10.0 track");
+	assert.deepEqual(notifications, []);
+	assert.ok(headerLines);
+	assert.ok(headerLines.includes("Warning: running TLH from v0.10.0 track"));
 });
 
 test("interactive startup stays quiet for latest-stable installs", async () => {
-	const notifications = await runSessionStart({ reason: "startup", installState: LATEST_STABLE_INSTALL_STATE });
+	const { notifications, headerLines } = await runSessionStart({ reason: "startup", installState: LATEST_STABLE_INSTALL_STATE });
 	assert.deepEqual(notifications, []);
+	assert.ok(headerLines);
+	assert.equal(headerLines.some((line) => line.startsWith("Warning:")), false);
 });
 
-test("non-startup session reasons do not show the install-track notice", async () => {
+test("non-startup session reasons do not render the install-track warning in the TLH header", async () => {
 	for (const reason of ["reload", "new", "resume", "fork"]) {
-		const notifications = await runSessionStart({ reason, installState: PINNED_TAG_INSTALL_STATE });
-		assert.deepEqual(notifications, [], `expected no install warning for ${reason}`);
+		const { notifications, headerLines } = await runSessionStart({ reason, installState: PINNED_TAG_INSTALL_STATE });
+		assert.deepEqual(notifications, [], `expected no install warning notification for ${reason}`);
+		assert.ok(headerLines, `expected TLH header for ${reason}`);
+		assert.equal(
+			headerLines.some((line) => line.startsWith("Warning:")),
+			false,
+			`expected no install-track warning in header for ${reason}`,
+		);
 	}
 });
 
 test("startup without UI does not show the install-track notice", async () => {
-	const notifications = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE, hasUI: false });
+	const { notifications, headerLines } = await runSessionStart({ reason: "startup", installState: PINNED_TAG_INSTALL_STATE, hasUI: false });
 	assert.deepEqual(notifications, []);
+	assert.equal(headerLines, undefined);
 });

--- a/tests/the-last-harness-header-warning.test.mjs
+++ b/tests/the-last-harness-header-warning.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { createTlhHeader } = await jiti.import("../extensions/the-last-harness/header.ts");
+
+const theme = {
+	fg: (color, text) => `<${color}>${text}</${color}>`,
+	bold: (text) => `<bold>${text}</bold>`,
+};
+
+function createResources() {
+	return {
+		context: ["AGENTS.md"],
+		skills: ["tlh-dev-hygiene"],
+		prompts: [],
+		extensions: [],
+		themes: [],
+	};
+}
+
+test("collapsed header renders the install-track warning above Context with only Warning highlighted", () => {
+	const header = createTlhHeader(theme, createResources(), undefined, {
+		kind: "ref",
+		summary: "TLH follows a non-stable git ref.",
+		detail: "main",
+	});
+
+	assert.deepEqual(header.render(200), [
+		"<bold><accent>tlh</accent></bold>",
+		"",
+		"<warning>Warning</warning><dim>: running TLH from main track</dim>",
+		"<dim>Context: AGENTS.md</dim>",
+	]);
+});
+
+test("expanded header keeps the install-track warning above Context before resource sections", () => {
+	const header = createTlhHeader(theme, createResources(), undefined, {
+		kind: "custom-package-source",
+		summary: "TLH uses a custom package source.",
+		detail: "../the-last-harness",
+	});
+	header.setExpanded(true);
+
+	assert.deepEqual(header.render(200), [
+		"<bold><accent>tlh</accent></bold>",
+		"",
+		"<warning>Warning</warning><dim>: running TLH from local track</dim>",
+		"<dim>Context: AGENTS.md</dim>",
+		"",
+		"<mdHeading>[Skills]</mdHeading>",
+		"<dim>  tlh-dev-hygiene</dim>",
+	]);
+});

--- a/tests/the-last-harness-install-state-classifier.test.mjs
+++ b/tests/the-last-harness-install-state-classifier.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { classifyTlhInstallState, formatTlhInstallNoticeMessage } = await jiti.import("../extensions/the-last-harness/install-state.ts");
+const { classifyTlhInstallState, formatTlhInstallNoticeMessage, formatTlhInstallNoticeTrackLabel } = await jiti.import(
+	"../extensions/the-last-harness/install-state.ts",
+);
 
 const OFFICIAL_LATEST_STABLE = {
 	repo: "diegopetrucci/the-last-harness",
@@ -14,8 +16,45 @@ const OFFICIAL_LATEST_STABLE = {
 	packageSourceIsDefault: true,
 };
 
+function assertNoticeLabel(notice, label, message) {
+	assert.ok(notice, message);
+	assert.equal(formatTlhInstallNoticeTrackLabel(notice), label, message);
+	assert.equal(formatTlhInstallNoticeMessage(notice), `Warning: running TLH from ${label} track`, message);
+}
+
 test("classifier returns no notice for official latest-stable installs", () => {
 	assert.equal(classifyTlhInstallState(OFFICIAL_LATEST_STABLE), undefined);
+});
+
+test("formats pinned/ref/local/unknown labels for install-track notices", () => {
+	assertNoticeLabel(
+		classifyTlhInstallState({
+			...OFFICIAL_LATEST_STABLE,
+			track: "pinned-tag",
+		}),
+		"v0.10.0",
+		"pinned-tag",
+	);
+	assertNoticeLabel(
+		classifyTlhInstallState({
+			...OFFICIAL_LATEST_STABLE,
+			track: "ref",
+			ref: "main",
+			packageSource: "git:github.com/diegopetrucci/the-last-harness@main",
+		}),
+		"main",
+		"ref",
+	);
+	assertNoticeLabel(
+		classifyTlhInstallState({
+			...OFFICIAL_LATEST_STABLE,
+			packageSource: "../the-last-harness",
+			packageSourceIsDefault: false,
+		}),
+		"local",
+		"local",
+	);
+	assertNoticeLabel(classifyTlhInstallState(undefined), "unknown", "unknown");
 });
 
 test("formats pinned-tag install notices with the pinned ref label", () => {
@@ -28,9 +67,8 @@ test("formats pinned-tag install notices with the pinned ref label", () => {
 		summary: "TLH is pinned to a specific release tag.",
 		detail: "v0.10.0",
 	});
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: v0.10.0 track");
+	assertNoticeLabel(notice, "v0.10.0");
 });
-
 
 test("prefers the pinned ref label over a custom package-source label", () => {
 	const notice = classifyTlhInstallState({
@@ -44,7 +82,7 @@ test("prefers the pinned ref label over a custom package-source label", () => {
 		summary: "TLH is pinned to a specific release tag.",
 		detail: "v0.10.0",
 	});
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: v0.10.0 track");
+	assertNoticeLabel(notice, "v0.10.0");
 });
 
 test("formats ref install notices with the ref label", () => {
@@ -59,9 +97,8 @@ test("formats ref install notices with the ref label", () => {
 		summary: "TLH follows a non-stable git ref.",
 		detail: "main",
 	});
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: main track");
+	assertNoticeLabel(notice, "main");
 });
-
 
 test("prefers the ref label over a custom package-source label", () => {
 	const notice = classifyTlhInstallState({
@@ -76,7 +113,7 @@ test("prefers the ref label over a custom package-source label", () => {
 		summary: "TLH follows a non-stable git ref.",
 		detail: "main",
 	});
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: main track");
+	assertNoticeLabel(notice, "main");
 });
 
 test("formats custom-track notices with the custom label", () => {
@@ -89,7 +126,7 @@ test("formats custom-track notices with the custom label", () => {
 		summary: "TLH uses a custom update track.",
 		detail: "custom",
 	});
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: custom track");
+	assertNoticeLabel(notice, "custom");
 });
 
 test("formats local package-source notices with the local label", () => {
@@ -103,8 +140,7 @@ test("formats local package-source notices with the local label", () => {
 		summary: "TLH uses a custom package source.",
 		detail: "../the-last-harness",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: local track");
+	assertNoticeLabel(notice, "local");
 });
 
 test("formats git@ custom package-source notices with the custom label", () => {
@@ -118,8 +154,7 @@ test("formats git@ custom package-source notices with the custom label", () => {
 		summary: "TLH uses a custom package source.",
 		detail: "git@github.com:owner/repo.git",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: custom track");
+	assertNoticeLabel(notice, "custom");
 });
 
 test("formats host-path custom package-source notices with the custom label", () => {
@@ -133,10 +168,8 @@ test("formats host-path custom package-source notices with the custom label", ()
 		summary: "TLH uses a custom package source.",
 		detail: "github.com/owner/repo@main",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: custom track");
+	assertNoticeLabel(notice, "custom");
 });
-
 
 test("formats ambiguous custom package-source notices with the custom label", () => {
 	const notice = classifyTlhInstallState({
@@ -149,8 +182,7 @@ test("formats ambiguous custom package-source notices with the custom label", ()
 		summary: "TLH uses a custom package source.",
 		detail: "the-last-harness@next",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: custom track");
+	assertNoticeLabel(notice, "custom");
 });
 
 test("formats non-default repository notices with the custom label", () => {
@@ -163,8 +195,7 @@ test("formats non-default repository notices with the custom label", () => {
 		summary: "TLH is installed from a non-default repository.",
 		detail: "someone-else/the-last-harness",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: custom track");
+	assertNoticeLabel(notice, "custom");
 });
 
 test("formats missing install-state notices with the unknown label", () => {
@@ -173,8 +204,7 @@ test("formats missing install-state notices with the unknown label", () => {
 		kind: "unknown",
 		summary: "TLH install metadata is missing or invalid.",
 	});
-	assert.ok(notice);
-	assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: unknown track");
+	assertNoticeLabel(notice, "unknown");
 });
 
 test("classifies installs with missing package-source metadata as unknown", () => {
@@ -213,8 +243,7 @@ test("classifies installs with missing package-source metadata as unknown", () =
 			kind: "unknown",
 			summary: "TLH install metadata is missing or invalid.",
 		});
-		assert.ok(notice);
-		assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: unknown track");
+		assertNoticeLabel(notice, "unknown");
 	}
 });
 
@@ -238,8 +267,7 @@ test("classifies pinned-tag/ref installs with invalid package-source metadata as
 			kind: "unknown",
 			summary: "TLH install metadata is missing or invalid.",
 		});
-		assert.ok(notice);
-		assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: unknown track");
+		assertNoticeLabel(notice, "unknown");
 	}
 });
 
@@ -276,8 +304,7 @@ test("classifies latest-release/pinned-tag/ref installs with missing ref metadat
 			kind: "unknown",
 			summary: "TLH install metadata is missing or invalid.",
 		}, label);
-		assert.ok(notice, label);
-		assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: unknown track", label);
+		assertNoticeLabel(notice, "unknown", label);
 	}
 });
 
@@ -319,8 +346,7 @@ test("classifies latest-release/pinned-tag/ref installs with blank ref metadata 
 			kind: "unknown",
 			summary: "TLH install metadata is missing or invalid.",
 		}, label);
-		assert.ok(notice, label);
-		assert.equal(formatTlhInstallNoticeMessage(notice), "TLH: unknown track", label);
+		assertNoticeLabel(notice, "unknown", label);
 	}
 });
 


### PR DESCRIPTION
## Summary
- move the non-latest/custom install-track warning from startup notifications into the TLH header
- render `Warning: running TLH from {name} track` above `Context:` with only `Warning` highlighted
- keep latest-release, non-startup, and no-UI sessions quiet
- update install docs and add focused header/startup/classifier coverage

## Validation
- node --test tests/the-last-harness-install-state-classifier.test.mjs tests/the-last-harness-header-warning.test.mjs tests/the-last-harness-extension-startup-warning.test.mjs
- npm run validate
- final code-reviewer: no findings