### PR TITLE
tweak architect prompt to (hopefully) suggest using the oracle more

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -50,7 +50,7 @@ At the start of a meaningful coding session:
 Before implementation:
 
 1. Clarify requirements, constraints, success criteria, and non-goals.
-2. If you need a second opinion, ask the user if they want you to use the `oracle`. Never trigger the `oracle` unless the user agrees.
+2. Only consider the `oracle` before ticket creation when the planning work looks high-stakes, uncertain, hard to validate, hard to undo, or likely to have a broad blast radius. Do not suggest the `oracle` for routine localized work that is reversible and directly testable. If you think the `oracle` could help, explain the specific risk or uncertainty and ask the user if they want you to use it. Never trigger the `oracle` unless the user explicitly agrees.
 3. Surface concerns and tradeoffs until ambiguity is resolved.
 4. Restate the current agreement.
 5. Ask for approval. Proceed only after the user says `approved`.

--- a/tests/architect-prompt-routing.test.mjs
+++ b/tests/architect-prompt-routing.test.mjs
@@ -20,3 +20,25 @@ test("architect.md lists librarian and web-scout as allowed minor agents with di
 		/- `librarian`: research external GitHub repositories, issues, pull requests, releases, or docs read-only when outside evidence is needed\.\n- `web-scout`: research the general web outside GitHub via Exa-backed search and fetch in an isolated read-only context\./,
 	);
 });
+
+test("architect.md limits pre-ticket oracle suggestions to higher-risk planning work", () => {
+	assert.match(
+		architectMd,
+		/Only consider the `oracle` before ticket creation when the planning work looks high-stakes, uncertain, hard to validate, hard to undo, or likely to have a broad blast radius\./,
+	);
+});
+
+test("architect.md excludes routine localized reversible directly testable work from oracle suggestions", () => {
+	assert.match(
+		architectMd,
+		/Do not suggest the `oracle` for routine localized work that is reversible and directly testable\./,
+	);
+});
+
+test("architect.md requires specific risk wording and explicit consent before using oracle", () => {
+	assert.match(
+		architectMd,
+		/If you think the `oracle` could help, explain the specific risk or uncertainty and ask the user if they want you to use it\./,
+	);
+	assert.match(architectMd, /Never trigger the `oracle` unless the user explicitly agrees\./);
+});


### PR DESCRIPTION
## Summary
- Add a generic pre-ticket Oracle checkpoint heuristic to the architect prompt
- Limit Oracle offers to high-stakes, uncertain, hard-to-validate, hard-to-undo, or broad-blast-radius planning work
- Add static tests for the prompt contract and explicit consent rule

## Validation
- npm run validate
- final code-reviewer: no issues
- oracle double-check: no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated oracle guidance policy to require explicit user consent for high-stakes/uncertain planning scenarios only.

* **Tests**
  * Added test coverage validating oracle usage constraints and approval requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->