### PR TITLE
Quiet dirty checkout backup output

### DIFF
--- a/scripts/lib/tlh-install-git.mjs
+++ b/scripts/lib/tlh-install-git.mjs
@@ -188,17 +188,21 @@ export function refreshGitCheckout(config, { targetDir, repo, ref, label, missin
 
 		// Report the backup so the user knows how to recover.
 		const parentOrEmpty = parent ?? "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-		warn(`dirty checkout at ${targetDir} — local changes backed up to ${backupRef}`, io);
-		warn(`  git -C ${targetDir} show ${backupRef}`, io);
-		warn(`  git -C ${targetDir} diff ${parentOrEmpty} ${backupRef}`, io);
+		if (!config.quiet) {
+			warn(`dirty checkout at ${targetDir} — local changes backed up to ${backupRef}`, io);
+			warn(`  git -C ${targetDir} show ${backupRef}`, io);
+			warn(`  git -C ${targetDir} diff ${parentOrEmpty} ${backupRef}`, io);
+		}
 
-		// Emit the diff body, capped at 200 lines.
-		const diffBody = gitOutput(config, targetDir, ["diff", parentOrEmpty, backupRef], io);
-		const diffLines = diffBody.split("\n");
-		const truncated = diffLines.length > 200;
-		warn(diffLines.slice(0, 200).join("\n"), io);
-		if (truncated) {
-			warn("... truncated, use the diff command above for full content", io);
+		if (config.verbose && !config.quiet) {
+			// Emit the diff body for verbose diagnostics, capped at 200 lines.
+			const diffBody = gitOutput(config, targetDir, ["diff", parentOrEmpty, backupRef], io);
+			const diffLines = diffBody.split("\n");
+			const truncated = diffLines.length > 200;
+			warn(diffLines.slice(0, 200).join("\n"), io);
+			if (truncated) {
+				warn("... truncated, use the diff command above for full content", io);
+			}
 		}
 	}
 

--- a/tests/install-libs.test.mjs
+++ b/tests/install-libs.test.mjs
@@ -239,7 +239,7 @@ test("refreshGitCheckout preserves ignored local files without creating backup r
 });
 
 
-test("refreshGitCheckout still backs up git-visible local changes", (t) => {
+test("refreshGitCheckout keeps dirty-checkout backup output concise by default", (t) => {
 	const { agentDir, targetDir, originDir } = createManagedGitCheckout(t);
 	const warnings = [];
 
@@ -258,6 +258,52 @@ test("refreshGitCheckout still backs up git-visible local changes", (t) => {
 	assert.equal(runGit(["-C", targetDir, "show", `${backupRefs[0]}:tracked.txt`]), "tracked local");
 	assert.equal(readFileSync(join(targetDir, "tracked.txt"), "utf8"), "tracked v1\n");
 	assert.equal(warnings.some((message) => message.includes("dirty checkout") && message.includes(backupRefs[0])), true);
+	assert.equal(warnings.some((message) => message.includes("diff --git")), false);
+	assert.equal(warnings.some((message) => message.includes("@@")), false);
+});
+
+
+test("refreshGitCheckout emits dirty-checkout diff details only in verbose mode", (t) => {
+	const { agentDir, targetDir, originDir } = createManagedGitCheckout(t);
+	const warnings = [];
+
+	writeFileSync(join(targetDir, "tracked.txt"), "tracked local\n");
+
+	refreshGitCheckout({ agentDir, verbose: true }, {
+		targetDir,
+		repo: originDir,
+		ref: "main",
+		label: "test checkout",
+		missingMessage: `missing checkout: ${targetDir}`,
+	}, gitCheckoutIo(warnings));
+
+	const backupRefs = listBackupRefs(targetDir);
+	assert.equal(backupRefs.length, 1);
+	assert.equal(warnings.some((message) => message.includes("dirty checkout") && message.includes(backupRefs[0])), true);
+	assert.equal(warnings.some((message) => message.includes("diff --git a/tracked.txt b/tracked.txt")), true);
+	assert.equal(warnings.some((message) => message.includes("-tracked v1") && message.includes("+tracked local")), true);
+});
+
+
+test("refreshGitCheckout stays quiet about dirty-checkout backups in quiet mode", (t) => {
+	const { agentDir, targetDir, originDir } = createManagedGitCheckout(t);
+	const warnings = [];
+
+	writeFileSync(join(targetDir, "tracked.txt"), "tracked local\n");
+
+	refreshGitCheckout({ agentDir, quiet: true }, {
+		targetDir,
+		repo: originDir,
+		ref: "main",
+		label: "test checkout",
+		missingMessage: `missing checkout: ${targetDir}`,
+	}, gitCheckoutIo(warnings));
+
+	const backupRefs = listBackupRefs(targetDir);
+	assert.equal(backupRefs.length, 1);
+	assert.equal(runGit(["-C", targetDir, "show", `${backupRefs[0]}:tracked.txt`]), "tracked local");
+	assert.equal(readFileSync(join(targetDir, "tracked.txt"), "utf8"), "tracked v1\n");
+	assert.deepEqual(warnings, []);
 });
 
 


### PR DESCRIPTION
## Summary
- keep dirty-checkout backup recovery guidance concise during normal installs
- move backup diff body output behind --verbose
- add tests for default, verbose, and quiet installer output

## Validation
- npm run validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git operation warnings now respect quiet mode (suppressed) and verbose mode (detailed diagnostics shown).

* **Tests**
  * Added comprehensive test coverage for output behavior across quiet, verbose, and default configuration modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->