### PR TITLE
Install Pi per-user under ~/.local instead of globally

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -102,8 +102,10 @@ This removes the managed `tk` copy under the TLH profile if one was installed. I
 To remove upstream Pi entirely, only if you installed it solely for The Last Harness:
 
 ```sh
-npm uninstall -g @earendil-works/pi-coding-agent
+npm uninstall -g --prefix "$HOME/.local" @earendil-works/pi-coding-agent
 ```
+
+TLH installs Pi per-user under `~/.local` (the binary lives at `~/.local/bin/pi`). If you previously installed Pi globally with sudo from older instructions, use `sudo npm uninstall -g @earendil-works/pi-coding-agent` instead.
 
 ## Security note
 

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -527,7 +527,14 @@ function installPiIfNeeded(config) {
 		throw new Error(`Pi install completed, but ${piBin} does not exist and pi is not on PATH`);
 	}
 	if (!onPath) {
-		warn(`${piBin} installed but ${piBinDir} is not on PATH. Add it with: export PATH="${piBinDir}:$PATH"`);
+		// Pi was just installed to a per-user prefix that is not yet on PATH.
+		// Prepend the prefix bin dir to PATH for the remainder of this process
+		// so downstream steps (`pi install`, `pi update`, ...) can resolve the
+		// binary by name via spawnSync. config.env is the same reference as
+		// process.env, so this mutation propagates to every later spawn.
+		const currentPath = config.env.PATH || "";
+		config.env.PATH = currentPath ? `${piBinDir}:${currentPath}` : piBinDir;
+		warn(`${piBin} installed but ${piBinDir} is not on PATH. Added it to PATH for this install; add it to your shell profile with: export PATH="${piBinDir}:$PATH"`);
 	}
 }
 

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -284,14 +284,16 @@ function buildInstallConfig(parsedArgs, env = process.env) {
 	const scriptDir = dirname(scriptPath);
 	const supportFiles = supportFileManifest({ noSettings: parsedArgs.noSettings });
 	const defaultPackageRoot = join(agentDir, "git", "github.com", parsedArgs.repo);
+	const homeDir = env.HOME || homedir();
 	const packageRoot = packageSourceInstallDir(packageSource, {
 		agentDir,
-		homeDir: env.HOME || homedir(),
+		homeDir,
 	}) || defaultPackageRoot;
 
 	return {
 		...parsedArgs,
 		env,
+		homeDir,
 		agentDir,
 		binDir,
 		settingsPath: join(agentDir, "settings.json"),
@@ -482,9 +484,17 @@ function assertSupportedPiVersion(config) {
 	}
 	const currentVersion = match[0];
 	if (!nodeVersionMeetsMinimum(currentVersion, MIN_PI_VERSION)) {
-		throw new Error(`Pi >= ${MIN_PI_VERSION} is required (found ${currentVersion}). Upgrade with: npm install -g @earendil-works/pi-coding-agent`);
+		const piPrefix = piInstallPrefix(config);
+		throw new Error(`Pi >= ${MIN_PI_VERSION} is required (found ${currentVersion}). Upgrade with: npm install -g --ignore-scripts --prefix "${piPrefix}" @earendil-works/pi-coding-agent`);
 	}
 	verboseLog(config, `Pi version: ${currentVersion}`);
+}
+
+function piInstallPrefix(config) {
+	// Install Pi per-user under ~/.local so `pi` lands at ~/.local/bin/pi
+	// without requiring sudo. Matches Pi's own docs guidance and is consistent
+	// with the default TLH bin dir (~/.local/bin).
+	return join(config.homeDir, ".local");
 }
 
 function installPiIfNeeded(config) {
@@ -498,10 +508,26 @@ function installPiIfNeeded(config) {
 		throw new Error("pi is not installed and --no-pi-install was provided");
 	}
 
-	log(config, "Installing Pi runtime...");
-	runCommand(config, ["npm", "install", "-g", "@earendil-works/pi-coding-agent"]);
-	if (!config.dryRun && !commandExists(config, "pi")) {
-		throw new Error("Pi install completed, but the pi command is still not on PATH");
+	const prefix = piInstallPrefix(config);
+	const piBinDir = join(prefix, "bin");
+	log(config, `Installing Pi runtime to ${prefix} (per-user, no sudo)...`);
+	runCommand(config, [
+		"npm",
+		"install",
+		"-g",
+		"--ignore-scripts",
+		"--prefix",
+		prefix,
+		"@earendil-works/pi-coding-agent",
+	]);
+	if (config.dryRun) return;
+	const piBin = join(piBinDir, "pi");
+	const onPath = commandExists(config, "pi");
+	if (!existsSync(piBin) && !onPath) {
+		throw new Error(`Pi install completed, but ${piBin} does not exist and pi is not on PATH`);
+	}
+	if (!onPath) {
+		warn(`${piBin} installed but ${piBinDir} is not on PATH. Add it with: export PATH="${piBinDir}:$PATH"`);
 	}
 }
 


### PR DESCRIPTION
## Summary

When the TLH installer detects that upstream Pi is not installed, it now runs:

```sh
npm install -g --ignore-scripts --prefix "$HOME/.local" @earendil-works/pi-coding-agent
```

instead of the previous global `npm install -g @earendil-works/pi-coding-agent`. This lands the `pi` binary at `~/.local/bin/pi` without requiring sudo, matches Pi's own docs guidance, and aligns with TLH's default bin dir (`~/.local/bin`), so the same PATH guidance covers both the `pi` binary and the `tlh` wrapper.

## Changes

- `scripts/tlh-install.mjs`
  - New `piInstallPrefix(config)` helper returns `$HOME/.local` (computed per user via the existing `env.HOME || homedir()` value).
  - Expose `homeDir` on the install config object so `installPiIfNeeded` and the version-check upgrade hint can derive the prefix consistently.
  - Switch the install command to `--ignore-scripts --prefix <prefix>`.
  - Soften the post-install check: look for the binary at `<prefix>/bin/pi`, and warn (rather than hard-fail) when `~/.local/bin` is not yet on PATH — mirrors the existing wrapper PATH warning.
  - Update the "Pi too old" upgrade hint in `assertSupportedPiVersion` to use the per-user prefix command.
- `docs/install.md`
  - Update the optional "remove upstream Pi entirely" uninstall command to use the per-user prefix.
  - Note for users who previously installed Pi globally with sudo from older instructions.

## Behaviour matrix

| Pre-existing `pi` on PATH | `--no-pi-install` | Result |
|---|---|---|
| yes | – | uses existing pi, runs version check (unchanged) |
| no | yes | hard error `pi is not installed and --no-pi-install was provided` (unchanged) |
| no | no | **new**: `npm install -g --ignore-scripts --prefix $HOME/.local @earendil-works/pi-coding-agent` |

## Verified

- `node --check scripts/tlh-install.mjs` ✓
- `npm run validate` → `fail 0` ✓
- Dry-run with pi missing emits the new prefix-scoped npm install line.
- Dry-run with `--no-pi-install` still short-circuits with the expected error.
- Dry-run with pi already present still skips install and runs the version check.

## Deliberate non-changes

- No new `--pi-prefix` flag or `TLH_PI_PREFIX` env var. Hard-coded to `$HOME/.local` to keep the surface minimal; easy to add later.
- No automatic prefix derivation from `--bin-dir`. That would silently install Pi into test sandboxes during `--bin-dir "$(mktemp -d)"` smoke runs; always-`$HOME/.local` is more predictable.
- No automatic cleanup of a previously sudo-installed global Pi. Docs explain the path. A user with both installs will get the one earlier on PATH (typically `~/.local/bin/pi`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Installation now supports per-user deployment to `~/.local`, allowing management without system-wide permissions.
  * Added validation to confirm proper binary installation at the expected location.

* **Documentation**
  * Updated installation and uninstall instructions to reflect per-user setup with guidance for both new and existing users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->