### PR TITLE
Stabilize eventually() test helper

### DIFF
--- a/tests/the-last-harness-extension-usage-refresh.test.mjs
+++ b/tests/the-last-harness-extension-usage-refresh.test.mjs
@@ -78,12 +78,11 @@ function createCtx(options) {
 	};
 }
 
-async function eventually(predicate, message, { attempts = 30 } = {}) {
-	for (let attempt = 0; attempt < attempts; attempt += 1) {
-		if (predicate()) {
-			return;
-		}
-		await new Promise((resolve) => setTimeout(resolve, 0));
+async function eventually(predicate, message, { timeoutMs = 5000, intervalMs = 10 } = {}) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((r) => setTimeout(r, intervalMs));
 	}
 	assert.ok(predicate(), message);
 }
@@ -157,9 +156,7 @@ EOF`,
 		});
 
 		await pi.handlers.get("session_start")?.[0]?.({ reason: "restore" }, ctx);
-		await eventually(() => renderRequests === 1, "initial git cache refresh should request one footer render", {
-			attempts: 500,
-		});
+		await eventually(() => renderRequests === 1, "initial git cache refresh should request one footer render");
 		await new Promise((resolve) => setImmediate(resolve));
 		assert.equal(renderRequests, 1, "git cache refresh should be the only render trigger in this scenario");
 	} finally {


### PR DESCRIPTION
## What

Replace the tick-budget polling in the local `eventually()` helper (in `tests/the-last-harness-extension-usage-refresh.test.mjs`) with a wall-clock deadline.

```diff
-async function eventually(predicate, message, { attempts = 30 } = {}) {
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-  assert.ok(predicate(), message);
-}
+async function eventually(predicate, message, { timeoutMs = 5000, intervalMs = 10 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  assert.ok(predicate(), message);
+}
```

Also drops the now-obsolete `{ attempts: 500 }` override at the one call site that needed it; the other five default call sites are unchanged.

## Why

The old helper counted iterations, not time. Under full-suite parallel contention the event loop could starve the polling loop before the async `session_start` chain (which spawns a fake `git` subprocess) had a chance to fire its render request, producing sporadic failures of *"git cache refresh requests a footer render without unrelated UI activity"*.

Wall-clock deadlines are immune to that starvation mode: 5 s of real time elapses regardless of how busy the loop is.

## Default timeout choice

Initially tried 2000 ms; observed 1 flake in 8 runs at that budget under heavy macOS fork load. Bumped to 5000 ms; per-run duration of the affected test then ranged 143–302 ms — ~10–35× headroom. A genuine hang now surfaces in 5 s rather than 2 s, which is acceptable for a test-only helper.

## Validation

| Check | Result |
|---|---|
| `node --test tests/the-last-harness-extension-usage-refresh.test.mjs` | 4/4 ✓ |
| `npm test` × 5 consecutive runs | 305/305 each ✓ |
| `npm run lint` | clean ✓ |
| `npm run validate` (full suite + installer smoke + settings dry-run + npm pack dry-run) | clean ✓ |

## Scope

- One file changed: `tests/the-last-harness-extension-usage-refresh.test.mjs` (+6 / −9)
- No production code touched
- No other tests touched
- Helper intentionally left file-local (only used here)