### PR TITLE
Bundle mcporter MCP adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ TLH ships [`pi-web-access`](https://github.com/diegopetrucci/pi-web-access) (an 
 
 For configuration, EXA key precedence, privacy, opt-out, and manual migration from `~/.pi/web-search.json`, see [`docs/web-search.md`](docs/web-search.md). Durable web-search / web-scout decisions live in repo-local Gnosis entries `ywsuwh` and `gbmehw`; pinned fork/tag process notes live in [`docs/web-search-fork-release-cadence.md`](docs/web-search-fork-release-cadence.md).
 
+### MCP adapter
+
+TLH also ships the upstream `pi-mcp-adapter` as the non-critical bundled default `mcporter` for connecting TLH to MCP servers.
+
+For proxy-first usage, slash commands, config locations, OAuth setup, `directTools` caveats, and opt-out/undo guidance, see [`docs/mcp.md`](docs/mcp.md).
+
 ### Launch telemetry
 
 Release builds with TelemetryDeck identifiers configured send at most one pseudonymous launch event when an interactive `tlh` process starts. The event contains a hashed random install ID, event type, TLH version, privacy-filtered model value, OS name/version, and OS architecture. It does not include prompts, cwd, command arguments, repo names, hostname, username, file contents, settings contents, full environment variables, extension/package lists, API keys, provider base URLs, auth state, headers, or account identifiers. TelemetryDeck also receives normal network metadata such as source IP address and request time.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -25,6 +25,12 @@
     "description": "Research GitHub repositories and optionally cache local checkouts."
   },
   {
+    "id": "mcporter",
+    "aliases": ["pi-mcp-adapter", "mcp-adapter"],
+    "source": "npm:pi-mcp-adapter",
+    "description": "Connect tlh to MCP servers with the upstream adapter."
+  },
+  {
     "id": "pi-web-access",
     "replaces": ["npm:pi-web-access", "git:github.com/nicobailon/pi-web-access"],
     "source": "git:github.com/diegopetrucci/pi-web-access@tlh-v0.10.7-1",

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,62 @@
+# MCP adapter
+
+TLH ships the upstream `pi-mcp-adapter` package as the non-critical bundled default `mcporter`.
+
+## Default usage
+
+TLH uses the adapter in a proxy-first way: by default you get one `mcp` tool that routes requests to your configured MCP servers, instead of exposing every MCP tool directly.
+
+Common slash commands:
+
+- `/mcp` — show adapter status.
+- `/mcp setup` — walk through MCP setup.
+- `/mcp tools` — list available MCP tools.
+- `/mcp reconnect` — reconnect all configured servers.
+- `/mcp reconnect <server>` — reconnect one server.
+- `/mcp-auth <server>` — complete OAuth login for one server.
+
+## Configuration
+
+- Bundled default id: `mcporter`
+- Extension source: `npm:pi-mcp-adapter`
+- Supported MCP config locations:
+  - Shared config: `~/.config/mcp/mcp.json`
+  - TLH isolated profile: `~/.the-last-harness/agent/mcp.json` or `${PI_CODING_AGENT_DIR}/mcp.json`
+  - Project config: `.mcp.json`
+  - Project-local Pi config: `.pi/mcp.json`
+
+Use the isolated-profile or project-local files when you want TLH-specific or repo-specific MCP server definitions without changing shared machine-wide config.
+
+The adapter expects a top-level `mcpServers` object. Minimal examples:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    },
+    "example-remote": {
+      "url": "https://example.com/mcp",
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+For stdio servers, use `command` plus `args`. For HTTP servers, use `url`; add `auth: "oauth"` when the server uses OAuth, then run `/mcp-auth <server>` to finish login. Upstream also supports `${VAR}` and `$env:VAR` interpolation in fields such as `env`, `headers`, `cwd`, and `bearerToken`.
+
+## OAuth and direct tools
+
+For OAuth-backed servers, configure an HTTP `url` for the server and then run `/mcp-auth <server>` to finish login.
+
+`directTools` is opt-in. It exposes individual MCP tools directly instead of going through the proxy `mcp` tool, but it is more token-expensive and may need cache warm-up or a manual `/mcp reconnect <server>` before the direct tool list is ready.
+
+## Opt out
+
+If you do not want TLH to manage the bundled adapter for that isolated profile:
+
+```sh
+tlh defaults disable mcporter   # opt out
+tlh defaults enable mcporter    # re-enable
+```

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -751,6 +751,32 @@ test("bundled manifest contains pi-web-access entry with correct tag and defer f
 	assert.deepEqual(webAccess.aliases, [], "pi-web-access must have no aliases");
 });
 
+test("bundled manifest contains mcporter entry and tlh-defaults accepts its aliases", () => {
+	const bundledPath = join(repoRoot, "config", "default-extensions.json");
+	const bundled = readDefaultExtensions(bundledPath);
+	const mcporter = bundled.find(({ id }) => id === "mcporter");
+
+	assert.ok(mcporter, "bundled mcporter entry should exist");
+	assert.equal(mcporter.source, "npm:pi-mcp-adapter");
+	assert.equal(mcporter.critical, false, "mcporter must not be critical");
+	assert.deepEqual(mcporter.aliases, ["pi-mcp-adapter", "mcp-adapter"]);
+	assert.deepEqual(mcporter.replaces, []);
+	assert.equal(mcporter.migrateReplacements, false, "mcporter replacements must stay disabled by default");
+
+	const fixture = tempFixture();
+	writeFileSync(fixture.settings, JSON.stringify({ packages: ["npm:pi-mcp-adapter"] }, null, 2));
+
+	runNode(defaultsScript, [
+		"--settings", fixture.settings,
+		"--defaults", bundledPath,
+		"disable", "mcp-adapter",
+	]);
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(settings.tlh.disabledDefaultExtensions, ["mcporter"]);
+	assert.deepEqual(settings.packages, []);
+});
+
 test("bundled manifest contains subagents entry with correct tag and critical flags", () => {
 	const bundled = readDefaultExtensions(join(repoRoot, "config", "default-extensions.json"));
 	const subagents = bundled.find(({ id }) => id === "subagents");


### PR DESCRIPTION
## Summary
- add the upstream pi-mcp-adapter as the non-critical bundled default mcporter
- document MCP adapter usage, configuration locations, OAuth setup, directTools caveats, and opt-out/undo
- add regression coverage for the bundled manifest entry and alias opt-out behavior

## Validation
- npm run validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP adapter is now bundled and enabled by default, allowing direct connection to MCP servers with support for stdio and HTTP servers, including OAuth configuration.

* **Documentation**
  * Added comprehensive MCP documentation covering configuration, slash command usage, and instructions to disable the adapter if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->