### PR TITLE
Allow trusted embedded subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ TLH subagents are focused child sessions used by the architect workflow: `repo-s
 
 They run in fresh child contexts: they get the task and project context, not the whole primary-agent conversation. They do not coordinate with each other as a swarm; they report back to the parent primary agent, which stays responsible for decisions and orchestration. TLH uses bundled per-role model defaults. If a child may need supervisor decisions mid-task, prefer async/background delegation; foreground children should return blockers in their final result instead of waiting on blocking supervisor contact.
 
+Advanced users can also add trusted user-owned embedded subagents in the isolated TLH profile. See [`docs/embedded-subagents.md`](docs/embedded-subagents.md) for the supported path, `embedded.<slug>` naming, starter templates, safety caveats, and removal steps. With primary agents enabled, only architect may run `embedded.<slug>`, and only when you explicitly ask for that trusted agent.
+
 ## Quality-of-life improvements to `pi`
 
 - **Project memory**: Gnosis is required and installed automatically on supported platforms (linux/darwin × x64/arm64) so agents can record decisions, constraints, rejected alternatives, and lessons in repo-local memory. Unsupported platforms hard-fail at install.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -32,8 +32,9 @@ Use the `subagent` tool for minor agents:
 - `librarian`: research external GitHub repositories, issues, pull requests, releases, or docs read-only when outside evidence is needed.
 - `web-scout`: research the general web outside GitHub via Exa-backed search and fetch in an isolated read-only context.
 - `oracle`: provide read-only high-reasoning second opinions on plans, risky decisions, bug hypotheses, or review findings.
+- Trusted user-owned embedded subagents may also exist as `embedded.<slug>`.
 
-Do not create, update, or delete subagent definitions at runtime. Do not delegate to agents outside the allowed TLH minor-agent list.
+Do not create, update, or delete subagent definitions at runtime. Do not delegate outside the bundled TLH minor-agent list unless the user explicitly names or asks for a trusted `embedded.<slug>` agent. Do not proactively choose embedded agents on the user's behalf.
 
 Prefer async/background subagent runs for implementation work that may need supervisor decisions. Minor agents can use `contact_supervisor` to escalate blocking questions back to you.
 

--- a/docs/embedded-subagents.md
+++ b/docs/embedded-subagents.md
@@ -1,0 +1,148 @@
+# Trusted embedded subagents
+
+TLH lets you add your own trusted markdown subagents inside the isolated TLH profile.
+
+This is a **trusted extension point, not a sandbox**. If you give an embedded agent write-capable tools, it can edit files and run commands with the same local access a normal user-scope subagent would have.
+
+## Supported location and runtime name
+
+Create user-owned embedded agents here:
+
+```text
+~/.the-last-harness/agent/agents/**/*.md
+```
+
+If you installed TLH with a custom `--agent-dir`, use the same `agents/**/*.md` structure under that custom profile directory instead.
+
+Create the directory if it does not exist yet:
+
+```sh
+mkdir -p ~/.the-last-harness/agent/agents
+```
+
+Do **not** put them under TLH's installer-owned bundled directory:
+
+```text
+~/.the-last-harness/agent/tlh/agents/subagents/
+```
+
+For TLH-primary use, the supported pattern is:
+
+- `package: embedded`
+- `name: <slug>` where `<slug>` is lowercase letters, digits, and hyphens only
+- runtime name: `embedded.<slug>`
+
+Example file:
+
+```text
+~/.the-last-harness/agent/agents/repo-helper.md
+```
+
+```yaml
+---
+name: repo-helper
+package: embedded
+description: Trusted read-only helper for repository inspection
+---
+```
+
+That file registers as `embedded.repo-helper`.
+
+## Least-privilege starter
+
+Start with a read-only helper unless you really need mutation:
+
+```md
+---
+name: repo-helper
+package: embedded
+description: Trusted read-only helper for focused repository inspection
+tools: read, grep, find, ls, contact_supervisor
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+defaultContext: fresh
+---
+You are a trusted embedded TLH subagent for focused local repository inspection.
+
+Rules:
+- Stay read-only.
+- Inspect files and report findings concisely.
+- Do not propose broad refactors.
+- Do not make product decisions.
+- If the task is ambiguous or blocked, use `contact_supervisor` instead of guessing.
+```
+
+Why this is the default:
+
+- read-only tools are safer
+- no inherited project context keeps the prompt narrower
+- `defaultContext: fresh` matches TLH's primary-agent safety rules
+
+## Advanced full-tools developer-like starter
+
+Use this only for a subagent you fully trust to edit files and run commands:
+
+```md
+---
+name: repo-developer
+package: embedded
+description: Trusted developer-like helper for bounded implementation tasks
+tools: read, write, edit, grep, find, ls, bash, contact_supervisor
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+---
+You are a trusted embedded TLH developer-like subagent.
+
+Rules:
+- Implement only the task you were given.
+- Prefer the smallest correct change.
+- Run narrow validation before finishing.
+- Use `contact_supervisor` for ambiguity, blockers, or decisions instead of guessing.
+- Do not launch or orchestrate other subagents.
+```
+
+This matches TLH's bundled developer-style tool set, but it is still your own trusted prompt and tool policy.
+
+## How to ask TLH to use one
+
+With TLH primary agents enabled, **architect may use `embedded.<slug>` only when you explicitly ask for that trusted agent**.
+
+Good examples:
+
+```text
+Use embedded.repo-helper to inspect the auth flow.
+```
+
+```text
+Use my trusted embedded.repo-developer agent for this small fix.
+```
+
+Do not expect architect to proactively choose an embedded agent on your behalf.
+
+## Safety and scope caveats
+
+- Embedded agents are **user-scope only** when TLH primaries are enabled.
+- Enabled TLH primaries force `agentScope: "user"` and `context: "fresh"` for embedded execution.
+- Project-scoped `.pi/agents/**/*.md` embedded agents are **not** a supported path for TLH-primary embedded delegation.
+- `Rush`, `product`, and `bug-hunter` do not run `embedded.*`; architect is the only TLH primary that can execute them.
+- `embedded.*` is for **trusted, user-owned** agents. Do not treat it as a way to safely run repo-controlled prompts from untrusted repositories.
+- If you disable TLH primaries, upstream subagent behavior still exists, but this guide documents only the supported primaries-enabled TLH flow above.
+
+## Undo or remove an embedded agent
+
+Delete the markdown file you added:
+
+```sh
+rm -f ~/.the-last-harness/agent/agents/repo-helper.md
+```
+
+Optionally remove the now-empty user agents directory:
+
+```sh
+rmdir ~/.the-last-harness/agent/agents 2>/dev/null || true
+```
+
+After removal, ask TLH to use the bundled minor agents instead, or just stop referring to the removed `embedded.<slug>` name.

--- a/docs/embedded-subagents.md
+++ b/docs/embedded-subagents.md
@@ -126,6 +126,7 @@ Do not expect architect to proactively choose an embedded agent on your behalf.
 
 - Embedded agents are **user-scope only** when TLH primaries are enabled.
 - Enabled TLH primaries force `agentScope: "user"` and `context: "fresh"` for embedded execution.
+- Runtime enforcement here is limited to user-scope execution plus strict `embedded.<slug>` target naming. The "only when you explicitly ask" rule above is architect primary-agent prompt policy, not a separate hard runtime authorization gate.
 - Project-scoped `.pi/agents/**/*.md` embedded agents are **not** a supported path for TLH-primary embedded delegation.
 - `Rush`, `product`, and `bug-hunter` do not run `embedded.*`; architect is the only TLH primary that can execute them.
 - `embedded.*` is for **trusted, user-owned** agents. Do not treat it as a way to safely run repo-controlled prompts from untrusted repositories.

--- a/extensions/the-last-harness-subagent-safety.mjs
+++ b/extensions/the-last-harness-subagent-safety.mjs
@@ -3,6 +3,8 @@ export const SAFE_SUBAGENT_ACTIONS = Object.freeze(["list", "get", "status", "in
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 
 const SAFE_SUBAGENT_ACTION_SET = new Set(SAFE_SUBAGENT_ACTIONS);
+const ALLOWED_SUBAGENT_SET = new Set(ALLOWED_SUBAGENTS);
+const EMBEDDED_SUBAGENT_TARGET_PATTERN = /^embedded\.[a-z0-9][a-z0-9-]*$/;
 
 function isRecord(value) {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -10,6 +12,19 @@ function isRecord(value) {
 
 function stringField(value) {
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function isEmbeddedSubagentTarget(value) {
+	return typeof value === "string" && EMBEDDED_SUBAGENT_TARGET_PATTERN.test(value.trim());
+}
+
+export function isAllowedSubagentTarget(value) {
+	const target = stringField(value);
+	return Boolean(target) && (ALLOWED_SUBAGENT_SET.has(target) || isEmbeddedSubagentTarget(target));
+}
+
+function allowedSubagentTargetSummary() {
+	return `${ALLOWED_SUBAGENTS.join(", ")}, or embedded.<slug>`;
 }
 
 function collectSubagentTargets(input) {
@@ -94,6 +109,23 @@ function validateNestedFreshContext(owner, path) {
 	return undefined;
 }
 
+function validateGetSubagentTarget(input) {
+	if (Object.prototype.hasOwnProperty.call(input, "chainName") && input.chainName !== undefined) {
+		return "TLH primary agents may not use subagent chain management via chainName.";
+	}
+
+	const target = stringField(input.agent);
+	if (!target) {
+		return `TLH primary-agent subagent get calls must specify agent: ${allowedSubagentTargetSummary()}.`;
+	}
+
+	if (!isAllowedSubagentTarget(target)) {
+		return `TLH primary agents may inspect only bundled or embedded subagents via get. Allowed targets: ${allowedSubagentTargetSummary()}. Disallowed target: ${target}.`;
+	}
+
+	return undefined;
+}
+
 function validateNestedFreshSubagentContexts(input) {
 	if (Array.isArray(input.tasks)) {
 		for (let index = 0; index < input.tasks.length; index += 1) {
@@ -128,7 +160,14 @@ export function validateSubagentToolInput(input) {
 		if (!SAFE_SUBAGENT_ACTION_SET.has(action)) {
 			return `TLH primary agents may not use subagent management action '${action}'. Allowed actions: ${SAFE_SUBAGENT_ACTIONS.join(", ")}.`;
 		}
-		return action === "list" || action === "get" ? forceUserAgentScope(input, action) : undefined;
+		if (action === "list") {
+			return forceUserAgentScope(input, action);
+		}
+		if (action === "get") {
+			const scopeReason = forceUserAgentScope(input, action);
+			return scopeReason ?? validateGetSubagentTarget(input);
+		}
+		return undefined;
 	}
 
 	const scopeReason = forceUserAgentScope(input, "execution");
@@ -148,12 +187,12 @@ export function validateSubagentToolInput(input) {
 
 	const targets = collectSubagentTargets(input);
 	if (targets.length === 0) {
-		return `TLH primary-agent subagent execution must target one of: ${ALLOWED_SUBAGENTS.join(", ")}.`;
+		return `TLH primary-agent subagent execution must target one of: ${allowedSubagentTargetSummary()}.`;
 	}
 
-	const disallowed = targets.filter((agent) => !ALLOWED_SUBAGENTS.includes(agent));
+	const disallowed = targets.filter((agent) => !isAllowedSubagentTarget(agent));
 	if (disallowed.length > 0) {
-		return `TLH primary agents may delegate only to: ${ALLOWED_SUBAGENTS.join(", ")}. Disallowed target(s): ${disallowed.join(", ")}.`;
+		return `TLH primary agents may delegate only to: ${allowedSubagentTargetSummary()}. Disallowed target(s): ${disallowed.join(", ")}.`;
 	}
 
 	return undefined;

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -14,7 +14,11 @@ import {
 	resolvePrimaryAgentConfig,
 } from "../the-last-harness-primary-agent.mjs";
 import { createPrimaryToolState, filterAvailableTools } from "../the-last-harness-primary-tools.mjs";
-import { registerTlhStartupMode, validateSubagentToolInput } from "../the-last-harness-subagent-safety.mjs";
+import {
+	isEmbeddedSubagentTarget,
+	registerTlhStartupMode,
+	validateSubagentToolInput,
+} from "../the-last-harness-subagent-safety.mjs";
 import { formatHomePath, isRecord } from "./common.js";
 import { GNOSIS_PROMPT, PRIMARY_AGENT_CYCLE_SHORTCUT, TLH_NAME, TLH_PACKAGE_NAME } from "./constants.js";
 import { shouldAppendGnosisPrompt } from "./gnosis.js";
@@ -192,14 +196,18 @@ function matchesSubagentName(value: unknown, target: string): boolean {
 	return typeof value === "string" && value.trim().toLowerCase() === target;
 }
 
-function subagentCallTargetsAgent(input: unknown, target: string): boolean {
+function subagentTargetMatches(value: unknown, predicate: (target: string) => boolean): boolean {
+	return typeof value === "string" && predicate(value.trim());
+}
+
+function subagentCallTargets(input: unknown, predicate: (target: string) => boolean): boolean {
 	if (!isRecord(input)) {
 		return false;
 	}
-	if (matchesSubagentName(input.agent, target)) {
+	if (subagentTargetMatches(input.agent, predicate)) {
 		return true;
 	}
-	if (Array.isArray(input.tasks) && input.tasks.some((task) => subagentCallTargetsAgent(task, target))) {
+	if (Array.isArray(input.tasks) && input.tasks.some((task) => subagentCallTargets(task, predicate))) {
 		return true;
 	}
 	if (!Array.isArray(input.chain)) {
@@ -209,18 +217,44 @@ function subagentCallTargetsAgent(input: unknown, target: string): boolean {
 		if (!isRecord(step)) {
 			continue;
 		}
-		if (matchesSubagentName(step.agent, target)) {
+		if (subagentTargetMatches(step.agent, predicate)) {
 			return true;
 		}
-		if (Array.isArray(step.parallel) && step.parallel.some((task) => subagentCallTargetsAgent(task, target))) {
+		if (Array.isArray(step.parallel) && step.parallel.some((task) => subagentCallTargets(task, predicate))) {
 			return true;
 		}
 	}
 	return false;
 }
 
+function subagentCallTargetsAgent(input: unknown, target: string): boolean {
+	return subagentCallTargets(input, (candidate) => matchesSubagentName(candidate, target));
+}
+
+function subagentManagementAction(input: unknown): string | undefined {
+	if (!isRecord(input) || typeof input.action !== "string") {
+		return undefined;
+	}
+	const action = input.action.trim();
+	return action || undefined;
+}
+
+function subagentCallTargetsEmbeddedAgent(input: unknown): boolean {
+	return subagentCallTargets(input, isEmbeddedSubagentTarget);
+}
+
 function rushDeveloperDelegationReason(): string {
 	return "TLH Rush may not delegate implementation to developer. Rush must edit directly; use code-reviewer, repo-scout, diff-summarizer, librarian, or oracle only when Rush prompt rules allow it.";
+}
+
+function embeddedDelegationBlockedReason(selection: Exclude<TlhPrimaryAgentSelection, "architect" | "disabled">): string {
+	if (selection === "rush") {
+		return "TLH Rush may not delegate to trusted embedded subagents. Rush may use only bundled TLH minor agents.";
+	}
+	if (selection === "product") {
+		return "TLH product may not delegate to trusted embedded subagents. Product mode is limited to bundled TLH minor agents.";
+	}
+	return "TLH bug-hunter may not delegate to trusted embedded subagents. Bug-hunter is limited to bundled TLH minor agents.";
 }
 
 function createTlhPrimaryAgentRuntime(
@@ -580,8 +614,12 @@ function createTlhPrimaryAgentRuntime(
 			if (!isEnabledPrimaryAgentSelection(selection)) {
 				return undefined;
 			}
-			if (selection === "rush" && subagentCallTargetsAgent(event.input, "developer")) {
+			const managementAction = subagentManagementAction(event.input);
+			if (!managementAction && selection === "rush" && subagentCallTargetsAgent(event.input, "developer")) {
 				return { block: true, reason: rushDeveloperDelegationReason() };
+			}
+			if (!managementAction && selection !== "architect" && selection !== "disabled" && subagentCallTargetsEmbeddedAgent(event.input)) {
+				return { block: true, reason: embeddedDelegationBlockedReason(selection) };
 			}
 			const reason = validateSubagentToolInput(event.input);
 			return reason ? { block: true, reason } : undefined;

--- a/extensions/the-last-harness/prompts.ts
+++ b/extensions/the-last-harness/prompts.ts
@@ -99,7 +99,7 @@ export function loadSubagentMetadata(): SubagentMetadata[] {
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-function formatAllowedSubagents(subagents: SubagentMetadata[]): string {
+function formatAllowedSubagents(primary: AgentPrompt | undefined, subagents: SubagentMetadata[]): string {
 	const allowed = new Set(ALLOWED_SUBAGENTS);
 	const lines = subagents
 		.filter((agent) => allowed.has(agent.name))
@@ -107,7 +107,11 @@ function formatAllowedSubagents(subagents: SubagentMetadata[]): string {
 	if (lines.length === 0) {
 		return "";
 	}
-	return `## TLH Allowed Minor Subagents\n\nYou may delegate only to these minor agents via the subagent tool:\n\n${lines.join("\n")}`;
+	const bundledList = lines.join("\n");
+	if (primary?.name === "architect") {
+		return `## TLH Allowed Minor Subagents\n\nYou may delegate to these bundled TLH minor agents via the subagent tool:\n\n${bundledList}\n\nYou may also delegate to a trusted \`embedded.<slug>\` only when the user explicitly names or asks for that trusted agent. Do not proactively choose embedded agents on the user's behalf.`;
+	}
+	return `## TLH Allowed Minor Subagents\n\nYou may delegate only to these bundled TLH minor agents via the subagent tool:\n\n${bundledList}\n\nDo not delegate outside this bundled TLH minor-agent list.`;
 }
 
 export function buildTlhSystemPrompt(
@@ -117,7 +121,7 @@ export function buildTlhSystemPrompt(
 ): string {
 	const prompts = [HARNESS_PROMPT.trim()];
 	if (primaryEnabled) {
-		prompts.push(primary?.systemPrompt.trim(), formatAllowedSubagents(subagents));
+		prompts.push(primary?.systemPrompt.trim(), formatAllowedSubagents(primary, subagents));
 	}
 	return prompts.filter(Boolean).join("\n\n");
 }

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -204,7 +204,8 @@ test("extension wires switch-primary-agent and active-primary safety", () => {
 	assert.doesNotMatch(primaryRuntimeSource, /pi\.registerCommand\("harness"/);
 	assert.match(toolCall, /applyProviderAwareSubagentModels\(event\.input, subagentsByName, ctx\.modelRegistry\.getAvailable\(\), ctx\.model\?\.provider\)/);
 	assert.match(toolCall, /const selection = currentPrimaryAgentSelection\(\)/);
-	assert.match(toolCall, /if \(selection === "rush" && subagentCallTargetsAgent\(event\.input, "developer"\)\)/);
+	assert.match(toolCall, /const managementAction = subagentManagementAction\(event\.input\)/);
+	assert.match(toolCall, /if \(!managementAction && selection === "rush" && subagentCallTargetsAgent\(event\.input, "developer"\)\)/);
 	assert.match(toolCall, /const reason = validateSubagentToolInput\(event\.input\)/);
 	assert(
 		toolCall.indexOf("applyProviderAwareSubagentModels") < toolCall.indexOf("!isEnabledPrimaryAgentSelection(selection)"),

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 
+import { ALLOWED_SUBAGENTS } from "../extensions/the-last-harness-subagent-safety.mjs";
+
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const extensionsDir = fileURLToPath(new URL("../extensions/", import.meta.url));
 const PI_EXTENSION_FILE_ENTRYPOINT_EXTENSIONS = new Set([".ts", ".js"]);
@@ -28,6 +30,12 @@ function sourceSection(source, startMarker, endMarker) {
 	const end = source.indexOf(endMarker, start);
 	assert.notEqual(end, -1, `missing end marker: ${endMarker}`);
 	return source.slice(start, end);
+}
+
+function promptSection(prompt, heading) {
+	const start = prompt.indexOf(heading);
+	assert.notEqual(start, -1, `missing heading: ${heading}`);
+	return prompt.slice(start);
 }
 
 function discoverPiExtensionEntrypoints(extensionDirectory) {
@@ -121,6 +129,41 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 		assert.doesNotMatch(prompt, /## TLH Ticket Integration Disabled/);
 		assert.doesNotMatch(prompt, /non-ticket/i);
 		assert.doesNotMatch(prompt, /ticket integration is disabled/i);
+	}
+});
+
+test("allowed-subagents prompt keeps bundled minor-agent listings and scopes embedded guidance to architect", () => {
+	const primaryAgents = loadPrimaryAgents();
+	const subagentMetadata = loadSubagentMetadata();
+	const bundledLines = subagentMetadata
+		.filter((agent) => ALLOWED_SUBAGENTS.includes(agent.name))
+		.map((agent) => `- ${agent.name}: ${agent.description}`);
+	const architect = primaryAgents.get("architect");
+	assert.ok(architect, "architect primary prompt should load");
+
+	const architectSection = promptSection(
+		buildTlhSystemPrompt(architect, subagentMetadata, true),
+		"## TLH Allowed Minor Subagents",
+	);
+	assert.match(architectSection, /You may delegate to these bundled TLH minor agents via the subagent tool:/);
+	assert.match(
+		architectSection,
+		/You may also delegate to a trusted `embedded\.<slug>` only when the user explicitly names or asks for that trusted agent\./,
+	);
+	for (const line of bundledLines) {
+		assert.ok(architectSection.includes(line), `architect prompt should list bundled minor agent: ${line}`);
+	}
+
+	for (const selection of ["rush", "product", "bug-hunter"]) {
+		const primary = primaryAgents.get(selection);
+		assert.ok(primary, `${selection} primary prompt should load`);
+		const section = promptSection(buildTlhSystemPrompt(primary, subagentMetadata, true), "## TLH Allowed Minor Subagents");
+		assert.match(section, /You may delegate only to these bundled TLH minor agents via the subagent tool:/);
+		assert.match(section, /Do not delegate outside this bundled TLH minor-agent list\./);
+		assert.doesNotMatch(section, /embedded\.<slug>/);
+		for (const line of bundledLines) {
+			assert.ok(section.includes(line), `${selection} prompt should list bundled minor agent: ${line}`);
+		}
 	}
 });
 

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -199,6 +199,23 @@ test("enabled primary mode allows approved delegation targets and forces safe to
 	assert.equal(event.input.context, "fresh");
 });
 
+test("architect allows strict embedded subagent targets in single, parallel, and chain calls", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+	const ctx = createToolCallContext([
+		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
+	]);
+
+	for (const event of [
+		{ toolName: "subagent", input: { agent: "embedded.repo-helper", prompt: "Inspect the repo" } },
+		{ toolName: "subagent", input: { tasks: [{ agent: "embedded.parallel-helper", prompt: "Inspect one area" }] } },
+		{ toolName: "subagent", input: { chain: [{ agent: "embedded.chain-helper", prompt: "Continue the work" }] } },
+	]) {
+		assert.equal(await toolCall(event, ctx), undefined);
+		assert.equal(event.input.agentScope, "user");
+		assert.equal(event.input.context, "fresh");
+	}
+});
+
 test("enabled primary mode blocks disallowed nested delegation targets after forcing safe defaults", async () => {
 	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
 	const event = {
@@ -215,7 +232,7 @@ test("enabled primary mode blocks disallowed nested delegation targets after for
 	assert.deepEqual(await toolCall(event, ctx), {
 		block: true,
 		reason:
-			"TLH primary agents may delegate only to: developer, code-reviewer, repo-scout, diff-summarizer, librarian, web-scout, oracle. Disallowed target(s): planner.",
+			"TLH primary agents may delegate only to: developer, code-reviewer, repo-scout, diff-summarizer, librarian, web-scout, oracle, or embedded.<slug>. Disallowed target(s): planner.",
 	});
 	assert.equal(event.input.agentScope, "user");
 	assert.equal(event.input.context, "fresh");
@@ -227,8 +244,8 @@ test("enabled primary mode allows safe management calls and blocks non-user mana
 		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
 	]);
 	const listEvent = { toolName: "subagent", input: { action: "list" } };
-	const getEvent = { toolName: "subagent", input: { action: "get", agentScope: "" } };
-	const blockedEvent = { toolName: "subagent", input: { action: "get", agentScope: "project" } };
+	const getEvent = { toolName: "subagent", input: { action: "get", agent: "developer", agentScope: "" } };
+	const blockedEvent = { toolName: "subagent", input: { action: "get", agent: "developer", agentScope: "project" } };
 
 	assert.equal(await toolCall(listEvent, ctx), undefined);
 	assert.equal(listEvent.input.agentScope, "user");
@@ -297,6 +314,55 @@ test("/switch-primary-agent default writes tlh.primaryAgent with a backup", asyn
 		});
 	} finally {
 		rmSync(fixture.dir, { recursive: true, force: true });
+	}
+});
+
+test("enabled non-architect primaries block embedded subagent delegation", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+
+	for (const [selection, input, reason] of [
+		[
+			"rush",
+			{ agent: "embedded.repo-helper", prompt: "Inspect the repo" },
+			"TLH Rush may not delegate to trusted embedded subagents. Rush may use only bundled TLH minor agents.",
+		],
+		[
+			"product",
+			{ tasks: [{ agent: "embedded.parallel-helper", prompt: "Inspect one area" }] },
+			"TLH product may not delegate to trusted embedded subagents. Product mode is limited to bundled TLH minor agents.",
+		],
+		[
+			"bug-hunter",
+			{ chain: [{ parallel: [{ agent: "embedded.chain-helper", prompt: "Continue the work" }] }] },
+			"TLH bug-hunter may not delegate to trusted embedded subagents. Bug-hunter is limited to bundled TLH minor agents.",
+		],
+	]) {
+		const event = { toolName: "subagent", input };
+		const ctx = createToolCallContext([
+			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: selection } },
+		]);
+		assert.deepEqual(await toolCall(event, ctx), { block: true, reason });
+		assert.equal(event.input.agentScope, undefined);
+		assert.equal(event.input.context, undefined);
+	}
+});
+
+test("enabled non-architect primaries allow embedded and bundled subagent inspection via get", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+
+	for (const [selection, input] of [
+		["rush", { action: "get", agent: "embedded.repo-helper" }],
+		["rush", { action: "get", agent: "developer" }],
+		["product", { action: "get", agent: "embedded.parallel-helper" }],
+		["bug-hunter", { action: "get", agent: "code-reviewer" }],
+	]) {
+		const event = { toolName: "subagent", input };
+		const ctx = createToolCallContext([
+			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: selection } },
+		]);
+		assert.equal(await toolCall(event, ctx), undefined);
+		assert.equal(event.input.agentScope, "user");
+		assert.equal(event.input.context, undefined);
 	}
 });
 

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
 	ALLOWED_SUBAGENTS,
 	SUBAGENT_CHILD_ENV,
+	isAllowedSubagentTarget,
+	isEmbeddedSubagentTarget,
 	registerTlhStartupMode,
 	validateSubagentToolInput,
 } from "../extensions/the-last-harness-subagent-safety.mjs";
@@ -48,6 +50,17 @@ test("validateSubagentToolInput allows web-scout as a permitted delegation targe
 	assert.equal(single.context, "fresh");
 });
 
+test("embedded target helpers accept strict embedded.<slug> names only", () => {
+	assert.equal(isEmbeddedSubagentTarget("embedded.scout"), true);
+	assert.equal(isEmbeddedSubagentTarget("embedded.scout-2"), true);
+	assert.equal(isEmbeddedSubagentTarget("embedded.scout.extra"), false);
+	assert.equal(isEmbeddedSubagentTarget("embedded.Scout"), false);
+	assert.equal(isEmbeddedSubagentTarget("embedded._scout"), false);
+	assert.equal(isAllowedSubagentTarget("developer"), true);
+	assert.equal(isAllowedSubagentTarget("embedded.scout"), true);
+	assert.equal(isAllowedSubagentTarget("embedded.scout.extra"), false);
+});
+
 test("validateSubagentToolInput allows approved execution and forces fresh user context", () => {
 	const single = { agent: "developer", prompt: "implement the ticket" };
 	assertAllowed(single);
@@ -76,14 +89,30 @@ test("validateSubagentToolInput allows approved execution and forces fresh user 
 	assert.equal(batched.context, "fresh");
 });
 
+test("validateSubagentToolInput allows strict embedded targets in single, parallel, and chain execution", () => {
+	for (const input of [
+		{ agent: "embedded.repo-helper", prompt: "inspect the repo" },
+		{ tasks: [{ agent: "embedded.parallel-helper", prompt: "inspect one area" }] },
+		{ chain: [{ agent: "embedded.chain-helper", prompt: "continue the work" }] },
+	]) {
+		assertAllowed(input);
+		assert.equal(input.agentScope, "user");
+		assert.equal(input.context, "fresh");
+	}
+});
+
 test("validateSubagentToolInput allows approved management calls and forces user scope where needed", () => {
 	const list = { action: "list" };
 	assertAllowed(list);
 	assert.equal(list.agentScope, "user");
 
-	const get = { action: "get", agentScope: "" };
-	assertAllowed(get);
-	assert.equal(get.agentScope, "user");
+	const bundledGet = { action: "get", agent: "developer", agentScope: "" };
+	assertAllowed(bundledGet);
+	assert.equal(bundledGet.agentScope, "user");
+
+	const embeddedGet = { action: "get", agent: "embedded.repo-helper" };
+	assertAllowed(embeddedGet);
+	assert.equal(embeddedGet.agentScope, "user");
 
 	for (const action of ["status", "interrupt", "doctor"]) {
 		assertAllowed({ action });
@@ -97,6 +126,9 @@ test("validateSubagentToolInput blocks unsafe actions and non-user scopes", () =
 	assert.match(validateSubagentToolInput({ agent: "librarian", agentScope: "project" }), /may not use agentScope: "project"/);
 	assert.match(validateSubagentToolInput({ agent: "oracle", context: "resume" }), /may not use context: "resume"/);
 	assert.match(validateSubagentToolInput({ action: "list", agentScope: "system" }), /may not use agentScope: "system"/);
+	assert.match(validateSubagentToolInput({ action: "get", chainName: "review-flow" }), /may not use subagent chain management via chainName/);
+	assert.match(validateSubagentToolInput({ action: "get" }), /must specify agent/);
+	assert.match(validateSubagentToolInput({ action: "get", agent: "embedded.repo.helper" }), /Disallowed target: embedded\.repo\.helper/);
 });
 
 test("validateSubagentToolInput uses generic primary-agent wording", () => {
@@ -114,6 +146,8 @@ test("validateSubagentToolInput uses generic primary-agent wording", () => {
 
 test("validateSubagentToolInput rejects disallowed agents", () => {
 	assert.match(validateSubagentToolInput({ agent: "architect" }), /Disallowed target\(s\): architect/);
+	assert.match(validateSubagentToolInput({ agent: "embedded.repo.helper" }), /Disallowed target\(s\): embedded\.repo\.helper/);
+	assert.match(validateSubagentToolInput({ agent: "embedded.Repo-helper" }), /Disallowed target\(s\): embedded\.Repo-helper/);
 	assert.match(
 		validateSubagentToolInput({ tasks: [{ agent: "developer" }, { agent: "planner" }] }),
 		/Disallowed target\(s\): planner/,


### PR DESCRIPTION
## Summary
- Allow TLH architect to run trusted user-owned embedded subagents named `embedded.<slug>` when explicitly requested
- Keep Rush, product, and bug-hunter limited to bundled TLH minor agents
- Document embedded subagent setup, trust boundaries, and removal steps
- Align generated primary-agent prompt guidance with runtime behavior

## Validation
- `npm run validate`

## Review
- code-reviewer: no blockers after cleanup
- oracle: no merge blockers; clarified runtime-vs-prompt enforcement boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced users can now add and use trusted, user-owned embedded subagents in the isolated profile.
  * The architect agent can delegate to embedded subagents when explicitly requested.

* **Documentation**
  * Added comprehensive guide on setting up, registering, and managing embedded subagents.
  * Updated delegation rules to explain embedded subagent support and constraints.

* **Tests**
  * Added test coverage for embedded subagent delegation, validation, and safety enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->