### PR TITLE
Update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.19.0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Check out tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.19.0'
 


### PR DESCRIPTION
## Summary
- update CI and release workflows from `actions/checkout@v4` to `actions/checkout@v5`
- update CI and release workflows from `actions/setup-node@v4` to `actions/setup-node@v5`
- keep the job Node version pinned at `22.19.0`

## Validation
- parsed both workflow YAML files successfully
- reviewed that the diff is limited to the intended action version bumps

This addresses GitHub's Node.js 20 action-runtime deprecation warning by moving these actions to their Node 24 runtime line.