### PR TITLE
Add /review slash command

### DIFF
--- a/.tickets/tlha-z6ff.md
+++ b/.tickets/tlha-z6ff.md
@@ -1,0 +1,23 @@
+---
+id: tlha-z6ff
+status: open
+deps: []
+links: []
+created: 2026-05-30T16:05:25Z
+type: bug
+priority: 2
+assignee: Diego Petrucci
+tags: [update, evals, installer]
+---
+# Separate repo-only file package-source eval path from user update flow
+
+Review of the /review branch found the repo-only live eval path invokes `tlh update --track custom --package-source file:$PWD`, while `tlh update` is a user-facing command whose help exposes custom tracks/package sources. If `file:` package sources are intended only for repository evals/internal installer reruns, the public update surface and docs should make that boundary explicit and prevent users from relying on unsupported custom/file update behavior.
+
+## Design
+
+Prefer keeping arbitrary `file:`/custom package-source update behavior out of the public `tlh update` contract unless explicitly designed. Repo-only evals can rerun the local installer directly or use a private/internal flag/path; public help/docs should not advertise unsupported `custom` update flows. If custom update support is intentionally kept, define safety/path/trust semantics before enabling it.
+
+## Acceptance Criteria
+
+Repo-only live evals no longer require public `tlh update --track custom --package-source file:...` support; user-facing `tlh update` help/docs do not advertise unsupported custom/file update behavior, or custom update support is deliberately implemented with documented safety semantics; tests cover the chosen boundary so `file:` eval-only behavior is not accidentally exposed as a supported user workflow.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to The Last Harness will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added `/review` slash command: interactive mode picker plus `uncommitted`, `branch`, `commit`, `pr`, and `folder` modes; PR mode integrates with the `gh` CLI and prompts before switching branches; review runs in an isolated `code-reviewer` subagent and the architect presents a digested summary; large diffs (>~200 KB) emit a one-time warning but never block.
+
 ## [0.14.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Added
 
-- Added `/review` slash command: interactive mode picker plus `uncommitted`, `branch`, `commit`, `pr`, and `folder` modes; PR mode integrates with the `gh` CLI and prompts before switching branches; review runs in an isolated `code-reviewer` subagent and the architect presents a digested summary; large diffs (>~200 KB) emit a one-time warning but never block.
+- Added `/review` slash command: interactive mode picker plus `uncommitted`, `branch`, `commit`, `pr`, and `folder` modes; branch mode prompts for its base branch (defaulting to `main` but allowing stacked bases), PR mode integrates with the `gh` CLI and prompts before switching branches, and review runs in an isolated `code-reviewer` subagent while the architect presents a digested summary.
 
 ## [0.14.0] - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,54 @@ Opt out persistently by adding this to `~/.the-last-harness/agent/settings.json`
 
 That settings opt-out is preserved by `tlh update` and installer reruns.
 
+## Reviewing changes (/review)
+
+Run a code review on a chosen scope (uncommitted changes, a branch comparison, a single commit, a PR, or a folder snapshot) via an isolated `code-reviewer` subagent.
+
+Run `/review` with no arguments to open an interactive mode picker. If you choose `commit`, `pr`, or `folder`, tlh prompts for the required SHA, PR number/URL, or paths before dispatching the review. Or pass a mode directly:
+
+```
+/review uncommitted              # staged + unstaged changes vs HEAD, plus untracked non-gitignored files
+/review branch                   # commits on this branch vs main
+/review branch release/1.2       # commits on this branch vs release/1.2
+/review commit abc1234           # a single commit
+/review pr 123                   # a pull request by number or URL
+/review folder src/              # files in one or more folders
+```
+
+`/review branch` defaults to `main` when you omit the base branch. `/review uncommitted` also includes untracked files that are not gitignored.
+
+Append `--extra "..."` to pass additional context or focus instructions to the reviewer:
+
+```
+/review uncommitted --extra "focus on error handling"
+```
+
+### PR mode
+
+PR mode requires the [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`). Cross-repository PRs are not supported yet; fetch the branch locally and use `/review branch <base>` instead.
+
+If you are not already on the PR's head branch when you run `/review pr <n>`:
+
+- **Dirty working tree**: the command refuses and tells you to stash or commit first.
+- **Clean working tree**: the command shows a confirmation prompt before switching.
+
+If you confirm the switch, you are left on the PR branch. Return to your prior branch with `git checkout -`.
+
+### Folder mode
+
+Folder mode collects a snapshot of files under the given paths. It includes tracked files plus untracked files that aren't gitignored — so newly added files show up even before a first commit. Binary files are skipped with a `[skipped binary: ...]` marker.
+
+### How the architect handles review results
+
+`/review` delegates to a fresh, isolated `code-reviewer` subagent — no chat history bleeds in from the current session. When the subagent returns, the architect critically evaluates the findings: it pushes back on weak or speculative observations, confirms strong ones, and presents a digested summary with its own judgment rather than a raw transcript.
+
+There is no `/end-review` command. After the summary is delivered, you are back in normal architect mode; follow-ups such as asking the architect to apply fixes go through the standard clarify → plan → tickets → developer loop.
+
+### Large diffs
+
+`/review` prints a one-time warning when the gathered diff or snapshot exceeds ~200 KB, but always proceeds. Consider narrowing the scope if a review feels noisy.
+
 ## Docs dump
 
 - Install, update, and uninstall guidance: [`docs/install.md`](docs/install.md)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Run a code review on a chosen scope (uncommitted changes, a branch comparison, a
 Run `/review` with no arguments to open the interactive mode picker. This is the only supported command shape.
 
 - Choose `uncommitted` to review staged + unstaged changes vs `HEAD`, plus untracked non-gitignored files.
-- Choose `branch` to review commits on the current branch vs `main`.
+- Choose `branch` to get an editor prompt for the base branch. Leave it blank to review against `main`, or enter another base such as `feature/parent` for stacked branch reviews.
 - Choose `commit`, `pr`, or `folder` to get an editor prompt for the required SHA, PR number/URL, or paths.
 
-Typed shortcuts such as `/review uncommitted`, `/review branch main`, `/review pr 123`, `/review folder src/`, and `/review ... --extra "..."` are rejected with picker-only guidance rather than dispatched directly.
+Typed shortcuts such as `/review uncommitted`, `/review branch feature/parent`, `/review pr 123`, `/review folder src/`, and `/review ... --extra "..."` are rejected with picker-only guidance rather than dispatched directly.
 
 `/review` requires the interactive TLH TUI. In no-TUI contexts, it fails with a clear picker-required message.
 
@@ -164,10 +164,6 @@ Folder mode collects a snapshot of files under the given paths. It includes trac
 `/review` delegates to a fresh, isolated `code-reviewer` subagent — no chat history bleeds in from the current session. When the subagent returns, the architect critically evaluates the findings: it pushes back on weak or speculative observations, confirms strong ones, and presents a digested summary with its own judgment rather than a raw transcript.
 
 There is no `/end-review` command. After the summary is delivered, you are back in normal architect mode; follow-ups such as asking the architect to apply fixes go through the standard clarify → plan → tickets → developer loop.
-
-### Large diffs
-
-`/review` prints a one-time warning when the gathered diff or snapshot exceeds ~200 KB, but always proceeds. Consider narrowing the scope if a review feels noisy.
 
 ## Docs dump
 

--- a/README.md
+++ b/README.md
@@ -134,35 +134,26 @@ That settings opt-out is preserved by `tlh update` and installer reruns.
 
 Run a code review on a chosen scope (uncommitted changes, a branch comparison, a single commit, a PR, or a folder snapshot) via an isolated `code-reviewer` subagent.
 
-Run `/review` with no arguments to open an interactive mode picker. If you choose `commit`, `pr`, or `folder`, tlh prompts for the required SHA, PR number/URL, or paths before dispatching the review. Or pass a mode directly:
+Run `/review` with no arguments to open the interactive mode picker. This is the only supported command shape.
 
-```text
-/review uncommitted              # staged + unstaged changes vs HEAD, plus untracked non-gitignored files
-/review branch                   # commits on this branch vs main
-/review branch release/1.2       # commits on this branch vs release/1.2
-/review commit abc1234           # a single commit
-/review pr 123                   # a pull request by number or URL
-/review folder src/              # files in one or more folders
-```
+- Choose `uncommitted` to review staged + unstaged changes vs `HEAD`, plus untracked non-gitignored files.
+- Choose `branch` to review commits on the current branch vs `main`.
+- Choose `commit`, `pr`, or `folder` to get an editor prompt for the required SHA, PR number/URL, or paths.
 
-`/review branch` defaults to `main` when you omit the base branch. `/review uncommitted` also includes untracked files that are not gitignored.
+Typed shortcuts such as `/review uncommitted`, `/review branch main`, `/review pr 123`, `/review folder src/`, and `/review ... --extra "..."` are rejected with picker-only guidance rather than dispatched directly.
 
-Append `--extra "..."` to pass additional context or focus instructions to the reviewer:
-
-```text
-/review uncommitted --extra "focus on error handling"
-```
+`/review` requires the interactive TLH TUI. In no-TUI contexts, it fails with a clear picker-required message.
 
 ### PR mode
 
-PR mode requires the [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`). Cross-repository PRs are not supported yet; fetch the branch locally and use `/review branch <base>` instead.
+PR mode requires the [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`). Cross-repository PRs are not supported yet; fetch the branch locally and use `/review` with branch mode instead.
 
-If you are not already on the PR's head branch when you run `/review pr <n>`:
+If you choose PR mode while you are not already on the PR's head branch:
 
 - **Dirty working tree**: the command refuses and tells you to stash or commit first.
 - **Clean working tree**: the command shows a confirmation prompt before switching.
 
-If you confirm the switch, you are left on the PR branch. Return to your prior branch with `git checkout -`.
+If you confirm the switch, tlh uses `gh pr checkout <number>` and leaves you on the PR branch. Return to your prior branch with `git checkout -`.
 
 ### Folder mode
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Run a code review on a chosen scope (uncommitted changes, a branch comparison, a
 
 Run `/review` with no arguments to open an interactive mode picker. If you choose `commit`, `pr`, or `folder`, tlh prompts for the required SHA, PR number/URL, or paths before dispatching the review. Or pass a mode directly:
 
-```
+```text
 /review uncommitted              # staged + unstaged changes vs HEAD, plus untracked non-gitignored files
 /review branch                   # commits on this branch vs main
 /review branch release/1.2       # commits on this branch vs release/1.2
@@ -149,7 +149,7 @@ Run `/review` with no arguments to open an interactive mode picker. If you choos
 
 Append `--extra "..."` to pass additional context or focus instructions to the reviewer:
 
-```
+```text
 /review uncommitted --extra "focus on error handling"
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Run a code review on a chosen scope (uncommitted changes, a branch comparison, a
 
 Run `/review` with no arguments to open the interactive mode picker. This is the only supported command shape.
 
+`/review` is architect-only. If the active primary agent is Rush, product, bug-hunter, or disabled, switch back to architect with `/switch-primary-agent architect` (or `Shift+Tab`) and rerun `/review`.
+
 - Choose `uncommitted` to review staged + unstaged changes vs `HEAD`, plus untracked non-gitignored files.
 - Choose `branch` to get an editor prompt for the base branch. Leave it blank to review against `main`, or enter another base such as `feature/parent` for stacked branch reviews.
 - Choose `commit`, `pr`, or `folder` to get an editor prompt for the required SHA, PR number/URL, or paths.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -86,6 +86,17 @@ After all tasks are complete:
 2. Evaluate findings; delegate fixes to `developer` if needed.
 3. Summarize implemented work, tradeoffs, validation, and remaining risks for the user.
 
+## /review handoff
+
+When the incoming user turn's first line is exactly `[/review]`, skip the normal clarify → plan → tickets flow and run this protocol instead:
+
+- When `[/review]` arrives as the first user turn of a session, treat it as the session's purpose — do not run session-startup discovery (`repo-scout`, `diff-summarizer`) first.
+- Delegate the review immediately to the `code-reviewer` subagent in a **fresh (isolated) context** via the `subagent` tool, passing the full envelope contents as the task input.
+- Do not relay raw subagent findings back to the user.
+- When the subagent returns, critically evaluate its findings: push back on weak or speculative observations, confirm strong ones, and apply your own judgment.
+- Present a digested summary to the user with your own take — not a transcript of subagent output.
+- There is no `/end-review` command. After delivering the summary, return to normal architect mode. Handle follow-up requests (e.g. "apply these fixes") with the normal clarify → plan → tickets → developer loop.
+
 ## Cleanup
 
 1. During cleanup after final review and before the final handoff, delete any `tk` tickets created for the current workflow or session once they are closed.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -95,7 +95,6 @@ When the incoming user turn's first line is exactly `[/review]`, skip the normal
 - Do not relay raw subagent findings back to the user.
 - When the subagent returns, critically evaluate its findings: push back on weak or speculative observations, confirm strong ones, and apply your own judgment.
 - Present a digested summary to the user with your own take — not a transcript of subagent output.
-- There is no `/end-review` command. After delivering the summary, return to normal architect mode. Handle follow-up requests (e.g. "apply these fixes") with the normal clarify → plan → tickets → developer loop.
 
 ## Cleanup
 

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -3,6 +3,7 @@ import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-cod
 import { createTlhAutocompleteProvider } from "./the-last-harness/autocomplete.js";
 import { registerTlhChangelogCommand } from "./the-last-harness/changelog.js";
 import { registerEffortCommand } from "./the-last-harness/effort.js";
+import { registerReviewCommand } from "./the-last-harness/review.js";
 import { createTlhFooter } from "./the-last-harness/footer.js";
 import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
@@ -22,6 +23,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 	}
 
 	registerEffortCommand(pi);
+	registerReviewCommand(pi);
 	registerTlhChangelogCommand(pi);
 	registerUsageCommand(pi);
 

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -525,9 +525,6 @@ async function isBinaryFile(filePath: string): Promise<boolean> {
 		const buf = Buffer.alloc(8192);
 		const { bytesRead } = await handle.read(buf, 0, 8192, 0);
 		return buf.subarray(0, bytesRead).includes(0);
-	} catch {
-		// Unreadable file — treat as non-binary so the caller surfaces the read error
-		return false;
 	} finally {
 		await handle?.close();
 	}
@@ -625,20 +622,39 @@ async function buildSnapshotParts(cwd: string, filePaths: string[], label: strin
 	for (const filePath of filePaths) {
 		const relPath = relative(cwd, filePath);
 		const renderedPath = renderDelimitedPath(relPath);
-		const pathStat = await lstat(filePath);
+
+		let pathStat: Stats;
+		try {
+			pathStat = await lstat(filePath);
+		} catch {
+			parts.push(`[skipped lstat failure: ${renderedPath}]`);
+			continue;
+		}
+
 		const nonRegularMarker = getNonRegularSnapshotMarker(relPath, pathStat);
 		if (nonRegularMarker) {
 			parts.push(nonRegularMarker);
 			continue;
 		}
 
-		const bin = await isBinaryFile(filePath);
+		let bin: boolean;
+		try {
+			bin = await isBinaryFile(filePath);
+		} catch {
+			parts.push(`[skipped binary detection failure: ${renderedPath}]`);
+			continue;
+		}
 		if (bin) {
 			parts.push(`[skipped binary: ${renderedPath}]`);
 			continue;
 		}
-		const content = escapeContentDelimiters(await readFile(filePath, "utf8"));
-		parts.push(`--- ${label}: ${renderedPath} ---\n${content}`);
+
+		try {
+			const content = escapeContentDelimiters(await readFile(filePath, "utf8"));
+			parts.push(`--- ${label}: ${renderedPath} ---\n${content}`);
+		} catch {
+			parts.push(`[skipped read failure: ${renderedPath}]`);
+		}
 	}
 
 	return parts;

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -10,8 +10,10 @@ import { Container, matchesKey, SelectList, Text } from "@earendil-works/pi-tui"
 const REVIEW_TITLE = "Choose a review mode";
 const REVIEW_PICKER_HINT = "↑/↓ to move  Enter to confirm  Esc to cancel";
 const REVIEW_DEFAULT_BRANCH_BASE = "main";
-const REVIEW_COMMAND_HELP =
-	"Usage: /review [uncommitted|branch [base=main]|commit <sha>|pr <n-or-url>|folder <paths...>] [--extra '...']\nNote: uncommitted mode also includes untracked non-gitignored files.";
+const REVIEW_PICKER_ONLY_GUIDANCE =
+	"/review is picker-only. Run /review with no arguments, then choose a mode in the picker. Typed shortcuts like `/review pr 123` and `--extra` are no longer supported.";
+const REVIEW_TUI_REQUIRED_MESSAGE =
+	"/review requires the interactive TUI picker. Re-run /review in the TLH UI.";
 
 export const REVIEW_MODES = ["uncommitted", "branch", "commit", "pr", "folder"] as const;
 export type ReviewMode = (typeof REVIEW_MODES)[number];
@@ -36,7 +38,10 @@ const REVIEW_UNTRACKED_END_DELIMITER = "--- end untracked files ---";
 export type BranchDecisionAction = "proceed" | "abort-dirty" | "switch" | "abort-cancelled";
 
 export type ParsedReviewArgs =
-	| { mode: null; pickerRequested: true }
+	| { pickerRequested: true }
+	| { pickerRequested: false; message: string };
+
+export type ReviewDispatchArgs =
 	| { mode: "uncommitted"; extra: string | undefined }
 	| { mode: "branch"; base: string | undefined; extra: string | undefined }
 	| { mode: "commit"; sha: string | undefined; extra: string | undefined }
@@ -62,14 +67,10 @@ export function decideBranchAction(params: {
 	return userConfirm ? "switch" : "abort-cancelled";
 }
 
-function isReviewMode(value: string): value is ReviewMode {
-	return (REVIEW_MODES as readonly string[]).includes(value);
-}
-
 /**
  * Tokenise a raw args string from the command handler, respecting single- and
- * double-quoted groups so that --extra "some phrase" is collapsed into one token.
- * Unquoted whitespace, including newlines from picker follow-up prompts, splits tokens.
+ * double-quoted groups so that quoted picker follow-up input stays grouped.
+ * Unquoted whitespace, including newlines from editor prompts, splits tokens.
  */
 function tokenizeArgs(raw: string): string[] {
 	if (!raw.trim()) return [];
@@ -100,56 +101,19 @@ function tokenizeArgs(raw: string): string[] {
 }
 
 /**
- * Parse an argv array (positional and flag tokens, not including the command
- * name) into a structured ParsedReviewArgs result.
- *
- * Bare /review with no args (empty argv) returns { mode: null, pickerRequested: true }.
- * An unrecognised mode also returns pickerRequested: true so the caller can
- * show the picker instead of erroring.
- *
- * Supported shapes:
- *   /review uncommitted [--extra '...']
- *   /review branch [base=main] [--extra '...']
- *   /review commit [sha] [--extra '...']
- *   /review pr [n-or-url] [--extra '...']
- *   /review folder [path...] [--extra '...']
+ * /review is picker-only. Bare /review requests the picker; any typed
+ * arguments are rejected with explicit guidance so users do not think the
+ * command silently ignored meaningful input.
  */
 export function parseReviewArgs(argv: string[]): ParsedReviewArgs {
-	const args = [...argv];
-
-	// Extract --extra <value> from any position before processing positionals.
-	let extra: string | undefined;
-	const extraIdx = args.indexOf("--extra");
-	if (extraIdx !== -1) {
-		const extraValue = args[extraIdx + 1];
-		args.splice(extraIdx, extraValue !== undefined ? 2 : 1);
-		extra = extraValue;
+	if (argv.length === 0) {
+		return { pickerRequested: true };
 	}
 
-	const rawMode = args[0]?.toLowerCase();
-
-	if (!rawMode) {
-		return { mode: null, pickerRequested: true };
-	}
-
-	if (!isReviewMode(rawMode)) {
-		// Unknown positional — show picker rather than throw so callers get a
-		// recoverable path.
-		return { mode: null, pickerRequested: true };
-	}
-
-	switch (rawMode) {
-		case "uncommitted":
-			return { mode: "uncommitted", extra };
-		case "branch":
-			return { mode: "branch", base: args[1] ?? REVIEW_DEFAULT_BRANCH_BASE, extra };
-		case "commit":
-			return { mode: "commit", sha: args[1], extra };
-		case "pr":
-			return { mode: "pr", nOrUrl: args[1], extra };
-		case "folder":
-			return { mode: "folder", paths: args.slice(1), extra };
-	}
+	return {
+		pickerRequested: false,
+		message: REVIEW_PICKER_ONLY_GUIDANCE,
+	};
 }
 
 /**
@@ -179,7 +143,7 @@ export interface ReviewGatheredContext {
  * for PR mode and also fills `ctx.checkout` when it switches branches.
  */
 export function buildReviewEnvelope(
-	parsed: ParsedReviewArgs & { mode: ReviewMode },
+	parsed: ReviewDispatchArgs,
 	ctx?: ReviewGatheredContext,
 ): string {
 	const { mode, extra } = parsed;
@@ -235,8 +199,8 @@ export function buildReviewEnvelope(
 
 // --- Helpers for picker integration ---
 
-/** Construct a full ParsedReviewArgs for a mode chosen interactively with defaults applied. */
-function makePickedArgs(mode: ReviewMode): ParsedReviewArgs & { mode: ReviewMode } {
+/** Construct full dispatch args for a mode chosen interactively with defaults applied. */
+function makePickedArgs(mode: ReviewMode): ReviewDispatchArgs {
 	switch (mode) {
 		case "uncommitted":
 			return { mode: "uncommitted", extra: undefined };
@@ -263,7 +227,7 @@ async function promptForReviewInput(
 async function completePickedArgs(
 	ctx: ExtensionCommandContext,
 	mode: ReviewMode,
-): Promise<(ParsedReviewArgs & { mode: ReviewMode }) | undefined> {
+): Promise<ReviewDispatchArgs | undefined> {
 	if (mode === "uncommitted" || mode === "branch") {
 		return makePickedArgs(mode);
 	}
@@ -336,6 +300,22 @@ function detectNotGitRepo(stderr: string): boolean {
 	return /not a git repository/i.test(stderr);
 }
 
+async function resolveRepoRoot(
+	pi: ExtensionAPI,
+	cwd: string,
+	context: string,
+): Promise<{ ok: true; root: string } | { ok: false; message: string }> {
+	const repoRootResult = await pi.exec("git", ["rev-parse", "--show-toplevel"], { cwd });
+	if (repoRootResult.code !== 0) {
+		const message = detectNotGitRepo(repoRootResult.stderr)
+			? "Not inside a git repository. Run /review from a directory that contains a .git folder."
+			: `Could not determine repository root for ${context}: ${repoRootResult.stderr.trim() || "git rev-parse --show-toplevel failed"}`;
+		return { ok: false, message };
+	}
+
+	return { ok: true, root: repoRootResult.stdout.trim() };
+}
+
 /**
  * Reject values that look like git/gh flags (start with '-').
  * pi.exec is argv-based (no shell injection), but a leading dash could still
@@ -375,8 +355,13 @@ async function gatherUncommitted(pi: ExtensionAPI, cmdCtx: ExtensionCommandConte
 		return { ok: false, message };
 	}
 
+	const repoRootResult = await resolveRepoRoot(pi, cwd, "the untracked file scan");
+	if (!repoRootResult.ok) {
+		return repoRootResult;
+	}
+
 	// Include untracked, non-gitignored files so the reviewer can see newly added content.
-	const untrackedResult = await pi.exec("git", ["ls-files", "-z", "--others", "--exclude-standard", "--", "."], { cwd });
+	const untrackedResult = await pi.exec("git", ["ls-files", "-z", "--others", "--exclude-standard", "--", "."], { cwd: repoRootResult.root });
 	if (untrackedResult.code !== 0) {
 		const message = detectNotGitRepo(untrackedResult.stderr)
 			? "Not inside a git repository. Run /review from a directory that contains a .git folder."
@@ -385,8 +370,8 @@ async function gatherUncommitted(pi: ExtensionAPI, cmdCtx: ExtensionCommandConte
 	}
 
 	const untrackedFiles = parseNullDelimitedGitPaths(untrackedResult.stdout)
-		.map((filePath) => resolve(cwd, filePath));
-	const untrackedParts = await buildSnapshotParts(cwd, untrackedFiles, "untracked file");
+		.map((filePath) => resolve(repoRootResult.root, filePath));
+	const untrackedParts = await buildSnapshotParts(repoRootResult.root, untrackedFiles, "untracked file");
 	const body = appendUntrackedSnapshot(diffResult.stdout, untrackedParts);
 
 	return {
@@ -418,7 +403,7 @@ async function gatherBranch(
 		}
 		return {
 			ok: false,
-			message: "HEAD is detached. Check out a branch before running /review branch.",
+			message: "HEAD is detached. Check out a branch before running /review.",
 		};
 	}
 
@@ -467,7 +452,7 @@ async function gatherCommit(
 	if (!sha) {
 		return {
 			ok: false,
-			message: "commit mode requires a SHA, e.g. /review commit abc1234",
+			message: "Commit review requires a SHA. Re-run /review and choose commit.",
 		};
 	}
 
@@ -681,7 +666,7 @@ async function gatherFolder(
 	if (paths.length === 0) {
 		return {
 			ok: false,
-			message: "folder mode requires at least one path, e.g. /review folder src/",
+			message: "Folder review requires at least one path. Re-run /review and choose folder.",
 		};
 	}
 
@@ -812,7 +797,7 @@ async function gatherPr(
 	if (!nOrUrl || !nOrUrl.trim()) {
 		return {
 			ok: false,
-			message: "pr mode requires a PR number or URL, e.g. /review pr 123",
+			message: "PR review requires a PR number or URL. Re-run /review and choose PR.",
 		};
 	}
 
@@ -860,7 +845,7 @@ async function gatherPr(
 		return {
 			ok: false,
 			message:
-				"Cross-repository PRs are not supported yet. Fetch the branch locally first and re-run with /review branch <base>.",
+				"Cross-repository PRs are not supported yet. Fetch the branch locally first, then re-run /review and choose branch mode.",
 		};
 	}
 
@@ -872,7 +857,7 @@ async function gatherPr(
 		return {
 			ok: false,
 			message:
-				"Not inside a git repository. Run /review pr from a directory that contains the PR's repo.",
+				"Not inside a git repository. Run /review from a directory that contains the PR's repo.",
 		};
 	}
 	const currentBranch = branchResult.stdout.trim();
@@ -900,7 +885,7 @@ async function gatherPr(
 				return {
 					ok: false,
 					message:
-						`Branch switch confirmation requires the TUI. You're on '${currentBranch}'; PR head is '${headRefName}'. Run \`git checkout ${headRefName}\` then re-run /review pr ${prNumber}.`,
+						`Branch switch confirmation requires the TUI. You're on '${currentBranch}'; PR head is '${headRefName}'. Run \`gh pr checkout ${prNumber}\` manually, then re-run /review and choose PR mode.`,
 				};
 			}
 			userConfirm = await showBranchSwitchConfirm(cmdCtx, currentBranch, headRefName, baseRefName);
@@ -912,7 +897,7 @@ async function gatherPr(
 			return {
 				ok: false,
 				message:
-					`Working tree has uncommitted changes. Commit or stash them, then re-run /review pr ${prNumber}.\nCurrent branch: ${currentBranch}\nPR head:        ${headRefName}`,
+					`Working tree has uncommitted changes. Commit or stash them, then re-run /review and choose PR mode.\nCurrent branch: ${currentBranch}\nPR head:        ${headRefName}`,
 			};
 		}
 
@@ -921,12 +906,12 @@ async function gatherPr(
 		}
 
 		// action === "switch" — perform the checkout
-		const checkoutResult = await pi.exec("git", ["checkout", headRefName], { cwd });
+		const checkoutResult = await pi.exec("gh", ["pr", "checkout", String(prNumber)], { cwd });
 		if (checkoutResult.code !== 0) {
 			const firstLine = checkoutResult.stderr.split("\n")[0]?.trim() ?? "";
 			return {
 				ok: false,
-				message: `git checkout ${headRefName} failed: ${firstLine}`,
+				message: `gh pr checkout ${prNumber} failed: ${firstLine}`,
 			};
 		}
 
@@ -961,7 +946,7 @@ async function gatherPr(
 async function dispatchReviewMode(
 	pi: ExtensionAPI,
 	cmdCtx: ExtensionCommandContext,
-	parsed: ParsedReviewArgs & { mode: ReviewMode },
+	parsed: ReviewDispatchArgs,
 ): Promise<void> {
 	// --- Gather phase (all modes) ---
 	let result: GatherResult;
@@ -1015,22 +1000,7 @@ async function dispatchReviewMode(
 
 // --- Argument completions ---
 
-function getReviewArgumentCompletions(prefix: string) {
-	const trimmed = prefix.trim().toLowerCase();
-	const parts = trimmed.split(/\s+/).filter(Boolean);
-
-	// Only suggest modes when the user is still typing the first positional
-	// and has not started a flag.
-	if (parts.length <= 1 && !trimmed.includes("--")) {
-		const partialMode = parts[0] ?? "";
-		const completions = REVIEW_MODES.filter((mode) => mode.startsWith(partialMode)).map((mode) => ({
-			value: mode,
-			label: mode,
-			description: REVIEW_MODE_DESCRIPTIONS[mode],
-		}));
-		return completions.length > 0 ? completions : null;
-	}
-
+function getReviewArgumentCompletions() {
 	return null;
 }
 
@@ -1038,33 +1008,33 @@ function getReviewArgumentCompletions(prefix: string) {
 
 export function registerReviewCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("review", {
-		description: "Review code changes (uncommitted, branch, commit, pr, or folder)",
+		description: "Review code changes via an interactive mode picker",
 		getArgumentCompletions: getReviewArgumentCompletions,
 		handler: async (args, ctx) => {
 			const argv = tokenizeArgs(args);
 			const parsed = parseReviewArgs(argv);
 
-			if (parsed.mode === null) {
-				// No mode given — show interactive picker.
-				if (!ctx.hasUI) {
-					ctx.ui.notify(REVIEW_COMMAND_HELP, "info");
-					return;
-				}
-				const mode = await showReviewPicker(ctx);
-				if (mode === undefined) {
-					// User cancelled — clean no-op.
-					return;
-				}
-				const completedArgs = await completePickedArgs(ctx, mode);
-				if (completedArgs === undefined) {
-					// User cancelled or left required follow-up input blank.
-					return;
-				}
-				await dispatchReviewMode(pi, ctx, completedArgs);
+			if (!parsed.pickerRequested) {
+				ctx.ui.notify(parsed.message, "error");
 				return;
 			}
 
-			await dispatchReviewMode(pi, ctx, parsed);
+			if (!ctx.hasUI) {
+				ctx.ui.notify(REVIEW_TUI_REQUIRED_MESSAGE, "error");
+				return;
+			}
+
+			const mode = await showReviewPicker(ctx);
+			if (mode === undefined) {
+				// User cancelled — clean no-op.
+				return;
+			}
+			const completedArgs = await completePickedArgs(ctx, mode);
+			if (completedArgs === undefined) {
+				// User cancelled or left required follow-up input blank.
+				return;
+			}
+			await dispatchReviewMode(pi, ctx, completedArgs);
 		},
 	});
 }

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -1,0 +1,901 @@
+import { open, readdir, readFile, stat, type FileHandle } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+import { DynamicBorder, getSelectListTheme, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { Container, matchesKey, SelectList, Text } from "@earendil-works/pi-tui";
+
+// --- Constants ---
+
+const REVIEW_TITLE = "Choose a review mode";
+const REVIEW_PICKER_HINT = "↑/↓ to move  Enter to confirm  Esc to cancel";
+const REVIEW_COMMAND_HELP =
+	"Usage: /review [uncommitted|branch [base]|commit [sha]|pr [n-or-url]|folder [paths...]] [--extra '...']";
+
+export const REVIEW_MODES = ["uncommitted", "branch", "commit", "pr", "folder"] as const;
+export type ReviewMode = (typeof REVIEW_MODES)[number];
+
+/** Byte-length threshold for the diff/snapshot body; warn-only, never blocks. */
+export const REVIEW_LARGE_BODY_BYTES = 200 * 1024; // 200 KB
+
+const REVIEW_MODE_DESCRIPTIONS: Record<ReviewMode, string> = {
+	uncommitted: "Review staged and unstaged changes in the working tree",
+	branch: "Review commits on the current branch vs a base (default: main)",
+	commit: "Review a single commit by SHA",
+	pr: "Review a pull request by number or URL",
+	folder: "Review files in one or more folders",
+};
+
+// --- Types ---
+
+/** Action returned by the pure branch-mismatch decision helper. */
+export type BranchDecisionAction = "proceed" | "abort-dirty" | "switch" | "abort-cancelled";
+
+export type ParsedReviewArgs =
+	| { mode: null; pickerRequested: true }
+	| { mode: "uncommitted"; extra: string | undefined }
+	| { mode: "branch"; base: string | undefined; extra: string | undefined }
+	| { mode: "commit"; sha: string | undefined; extra: string | undefined }
+	| { mode: "pr"; nOrUrl: string | undefined; extra: string | undefined }
+	| { mode: "folder"; paths: string[]; extra: string | undefined };
+
+// --- Pure helpers ---
+
+/**
+ * Pure branch-mismatch decision function for PR mode.
+ * Maps the current state + user confirmation to an action.
+ * Has no knowledge of git, gh, or any I/O.
+ */
+export function decideBranchAction(params: {
+	currentBranch: string;
+	prHead: string;
+	isDirty: boolean;
+	userConfirm: boolean;
+}): BranchDecisionAction {
+	const { currentBranch, prHead, isDirty, userConfirm } = params;
+	if (currentBranch === prHead) return "proceed";
+	if (isDirty) return "abort-dirty";
+	return userConfirm ? "switch" : "abort-cancelled";
+}
+
+function isReviewMode(value: string): value is ReviewMode {
+	return (REVIEW_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * Tokenise a raw args string from the command handler, respecting single- and
+ * double-quoted groups so that --extra "some phrase" is collapsed into one token.
+ */
+function tokenizeArgs(raw: string): string[] {
+	if (!raw.trim()) return [];
+
+	const tokens: string[] = [];
+	let current = "";
+	let inSingleQuote = false;
+	let inDoubleQuote = false;
+
+	for (const ch of raw) {
+		if (ch === "'" && !inDoubleQuote) {
+			inSingleQuote = !inSingleQuote;
+		} else if (ch === '"' && !inSingleQuote) {
+			inDoubleQuote = !inDoubleQuote;
+		} else if (ch === " " && !inSingleQuote && !inDoubleQuote) {
+			if (current) {
+				tokens.push(current);
+				current = "";
+			}
+		} else {
+			current += ch;
+		}
+	}
+	if (current) {
+		tokens.push(current);
+	}
+	return tokens;
+}
+
+/**
+ * Parse an argv array (positional and flag tokens, not including the command
+ * name) into a structured ParsedReviewArgs result.
+ *
+ * Bare /review with no args (empty argv) returns { mode: null, pickerRequested: true }.
+ * An unrecognised mode also returns pickerRequested: true so the caller can
+ * show the picker instead of erroring.
+ *
+ * Supported shapes:
+ *   /review uncommitted [--extra '...']
+ *   /review branch [base] [--extra '...']
+ *   /review commit [sha] [--extra '...']
+ *   /review pr [n-or-url] [--extra '...']
+ *   /review folder [path...] [--extra '...']
+ */
+export function parseReviewArgs(argv: string[]): ParsedReviewArgs {
+	const args = [...argv];
+
+	// Extract --extra <value> from any position before processing positionals.
+	let extra: string | undefined;
+	const extraIdx = args.indexOf("--extra");
+	if (extraIdx !== -1) {
+		const extraValue = args[extraIdx + 1];
+		args.splice(extraIdx, extraValue !== undefined ? 2 : 1);
+		extra = extraValue;
+	}
+
+	const rawMode = args[0]?.toLowerCase();
+
+	if (!rawMode) {
+		return { mode: null, pickerRequested: true };
+	}
+
+	if (!isReviewMode(rawMode)) {
+		// Unknown positional — show picker rather than throw so callers get a
+		// recoverable path.
+		return { mode: null, pickerRequested: true };
+	}
+
+	switch (rawMode) {
+		case "uncommitted":
+			return { mode: "uncommitted", extra };
+		case "branch":
+			return { mode: "branch", base: args[1], extra };
+		case "commit":
+			return { mode: "commit", sha: args[1], extra };
+		case "pr":
+			return { mode: "pr", nOrUrl: args[1], extra };
+		case "folder":
+			return { mode: "folder", paths: args.slice(1), extra };
+	}
+}
+
+/**
+ * Optional context gathered at command time (filled progressively by T2/T3).
+ * All fields are optional so T2 and T3 can each contribute without ordering
+ * constraints between them.
+ */
+export interface ReviewGatheredContext {
+	/** The branch checked out when the command ran. */
+	currentBranch?: string;
+	/** Set by T3 when a branch checkout was performed to satisfy the review. */
+	checkout?: { performed: boolean; priorBranch: string };
+	/** The diff text (uncommitted/branch/commit) or folder snapshot, or the output of `gh pr diff`. */
+	body?: string;
+	/** Describes the content type of `body`. */
+	bodyKind?: "diff" | "snapshot";
+}
+
+/**
+ * Build the canonical [/review] envelope string to send as a user message.
+ *
+ * The first line is always exactly `[/review]` so the architect can detect it.
+ * Structured metadata follows, then the `extra` block, then a fenced section
+ * holding the diff or snapshot body.
+ *
+ * T2 populates `ctx.body` / `ctx.bodyKind` for local modes; T3 does the same
+ * for PR mode and also fills `ctx.checkout` when it switches branches.
+ */
+export function buildReviewEnvelope(
+	parsed: ParsedReviewArgs & { mode: ReviewMode },
+	ctx?: ReviewGatheredContext,
+): string {
+	const { mode, extra } = parsed;
+	const lines: string[] = [];
+
+	// ── Line 1: hard-coded trigger token ──────────────────────────────────────
+	lines.push("[/review]");
+
+	// ── Metadata ──────────────────────────────────────────────────────────────
+	lines.push(`mode: ${mode}`);
+
+	// Mode-specific refs
+	if (parsed.mode === "branch" && parsed.base) {
+		lines.push(`base: ${parsed.base}`);
+	} else if (parsed.mode === "commit" && parsed.sha) {
+		lines.push(`sha: ${parsed.sha}`);
+	} else if (parsed.mode === "pr" && parsed.nOrUrl) {
+		lines.push(`pr: ${parsed.nOrUrl}`);
+	} else if (parsed.mode === "folder" && parsed.paths.length > 0) {
+		lines.push(`paths: ${parsed.paths.join(" ")}`);
+	}
+
+	// Branch context
+	if (ctx?.currentBranch !== undefined) {
+		lines.push(`current-branch: ${ctx.currentBranch}`);
+	}
+
+	// Checkout notice (set by T3 when it had to switch branches)
+	if (ctx?.checkout?.performed) {
+		lines.push(`checkout: switched-from ${ctx.checkout.priorBranch}`);
+		lines.push(`note: previously on ${ctx.checkout.priorBranch}; run \`git checkout -\` to return.`);
+	}
+
+	// ── Extra block ───────────────────────────────────────────────────────────
+	if (extra === undefined) {
+		lines.push("extra: (none)");
+	} else {
+		lines.push("extra:");
+		lines.push(extra);
+	}
+
+	// ── Body fenced section ───────────────────────────────────────────────────
+	const hasBody = ctx?.body !== undefined;
+	const fenceKind = hasBody ? (ctx?.bodyKind ?? "diff") : "(pending)";
+	const bodyText = hasBody ? (ctx?.body as string) : "(no body gathered)";
+
+	lines.push(`--- begin ${fenceKind} ---`);
+	lines.push(bodyText);
+	lines.push(`--- end ${fenceKind} ---`);
+
+	return lines.join("\n");
+}
+
+// --- Helpers for picker integration ---
+
+/** Construct a full ParsedReviewArgs for a mode chosen interactively (no mode-specific args). */
+function makePickedArgs(mode: ReviewMode): ParsedReviewArgs & { mode: ReviewMode } {
+	switch (mode) {
+		case "uncommitted":
+			return { mode: "uncommitted", extra: undefined };
+		case "branch":
+			return { mode: "branch", base: undefined, extra: undefined };
+		case "commit":
+			return { mode: "commit", sha: undefined, extra: undefined };
+		case "pr":
+			return { mode: "pr", nOrUrl: undefined, extra: undefined };
+		case "folder":
+			return { mode: "folder", paths: [], extra: undefined };
+	}
+}
+
+// --- Interactive picker ---
+
+async function showReviewPicker(ctx: ExtensionCommandContext): Promise<ReviewMode | undefined> {
+	if (!ctx.hasUI) {
+		return undefined;
+	}
+
+	const items = REVIEW_MODES.map((mode) => ({
+		value: mode,
+		label: mode,
+		description: REVIEW_MODE_DESCRIPTIONS[mode],
+	}));
+
+	const selected = await ctx.ui.custom<ReviewMode | undefined>((_tui, theme, _kb, done) => {
+		const selectTheme = getSelectListTheme();
+		const selectList = new SelectList(items, items.length, selectTheme);
+
+		selectList.onSelect = (item) => done(item.value as ReviewMode);
+		selectList.onCancel = () => done(undefined);
+
+		const container = new Container();
+		const border = new DynamicBorder((segment: string) => theme.fg("accent", segment));
+
+		container.addChild(border);
+		container.addChild(new Text(theme.fg("accent", theme.bold(REVIEW_TITLE)), 1, 0));
+		container.addChild(selectList);
+		container.addChild(new Text(theme.fg("dim", REVIEW_PICKER_HINT), 1, 0));
+		container.addChild(border);
+
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput: (data: string) => {
+				selectList.handleInput(data);
+			},
+		};
+	});
+
+	return selected;
+}
+
+// --- Gather helpers ---
+
+type GatherResult = { ok: true; ctx: ReviewGatheredContext } | { ok: false; message: string };
+
+function detectNotGitRepo(stderr: string): boolean {
+	return /not a git repository/i.test(stderr);
+}
+
+/**
+ * Reject values that look like git/gh flags (start with '-').
+ * pi.exec is argv-based (no shell injection), but a leading dash could still
+ * cause the value to be interpreted as a git or gh option rather than a ref,
+ * SHA, or PR identifier.
+ */
+function rejectFlagLike(value: string, fieldName: string): { ok: true } | { ok: false; message: string } {
+	if (value.startsWith("-")) {
+		return { ok: false, message: `${fieldName} cannot start with '-' (got '${value}'). If this is intentional, run the underlying command manually.` };
+	}
+	return { ok: true };
+}
+
+/**
+ * Gather staged + unstaged changes vs HEAD for the uncommitted mode.
+ */
+async function gatherUncommitted(pi: ExtensionAPI, cmdCtx: ExtensionCommandContext): Promise<GatherResult> {
+	const cwd = cmdCtx.cwd;
+
+	// Resolve current branch (also validates we are inside a git repo)
+	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+	if (branchResult.code !== 0) {
+		const message = detectNotGitRepo(branchResult.stderr)
+			? "Not inside a git repository. Run /review from a directory that contains a .git folder."
+			: `Could not determine current branch: ${branchResult.stderr.trim()}`;
+		return { ok: false, message };
+	}
+	const currentBranch = branchResult.stdout.trim();
+
+	// Gather full diff (staged + unstaged vs HEAD)
+	const diffResult = await pi.exec("git", ["diff", "HEAD"], { cwd });
+	if (diffResult.code !== 0) {
+		const message = detectNotGitRepo(diffResult.stderr)
+			? "Not inside a git repository. Run /review from a directory that contains a .git folder."
+			: `git diff HEAD failed: ${diffResult.stderr.trim()}`;
+		return { ok: false, message };
+	}
+
+	return {
+		ok: true,
+		ctx: { currentBranch, body: diffResult.stdout, bodyKind: "diff" },
+	};
+}
+
+/**
+ * Gather git diff <base>...HEAD (three-dot, vs merge-base) for the branch mode.
+ */
+async function gatherBranch(
+	pi: ExtensionAPI,
+	cmdCtx: ExtensionCommandContext,
+	base: string | undefined,
+): Promise<GatherResult> {
+	if (!base) {
+		return {
+			ok: false,
+			message: "branch mode requires a base branch name, e.g. /review branch main",
+		};
+	}
+
+	const cwd = cmdCtx.cwd;
+
+	// Refuse if HEAD is detached
+	const symRefResult = await pi.exec("git", ["symbolic-ref", "-q", "HEAD"], { cwd });
+	if (symRefResult.code !== 0) {
+		if (detectNotGitRepo(symRefResult.stderr)) {
+			return {
+				ok: false,
+				message:
+					"Not inside a git repository. Run /review from a directory that contains a .git folder.",
+			};
+		}
+		return {
+			ok: false,
+			message: "HEAD is detached. Check out a branch before running /review branch.",
+		};
+	}
+
+	// Resolve current branch
+	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+	const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
+
+	// Reject flag-like values before passing to git
+	const baseCheck = rejectFlagLike(base, "base");
+	if (!baseCheck.ok) {
+		return { ok: false, message: baseCheck.message };
+	}
+
+	// Validate that the base ref resolves
+	const verifyResult = await pi.exec("git", ["rev-parse", "--verify", base], { cwd });
+	if (verifyResult.code !== 0) {
+		return {
+			ok: false,
+			message: `Branch base '${base}' does not resolve to a valid ref. Make sure the branch or commit exists locally.`,
+		};
+	}
+
+	// Compute three-dot diff vs merge-base
+	const diffResult = await pi.exec("git", ["diff", `${base}...HEAD`], { cwd });
+	if (diffResult.code !== 0) {
+		return {
+			ok: false,
+			message: `git diff ${base}...HEAD failed: ${diffResult.stderr.trim()}`,
+		};
+	}
+
+	return {
+		ok: true,
+		ctx: { currentBranch, body: diffResult.stdout, bodyKind: "diff" },
+	};
+}
+
+/**
+ * Gather git show --format=fuller <sha> (commit header + diff) for the commit mode.
+ */
+async function gatherCommit(
+	pi: ExtensionAPI,
+	cmdCtx: ExtensionCommandContext,
+	sha: string | undefined,
+): Promise<GatherResult> {
+	if (!sha) {
+		return {
+			ok: false,
+			message: "commit mode requires a SHA, e.g. /review commit abc1234",
+		};
+	}
+
+	const cwd = cmdCtx.cwd;
+
+	// Reject flag-like values before passing to git
+	const shaCheck = rejectFlagLike(sha, "sha");
+	if (!shaCheck.ok) {
+		return { ok: false, message: shaCheck.message };
+	}
+
+	// Validate that the ref resolves to an actual commit object
+	const verifyResult = await pi.exec("git", ["rev-parse", "--verify", `${sha}^{commit}`], { cwd });
+	if (verifyResult.code !== 0) {
+		if (detectNotGitRepo(verifyResult.stderr)) {
+			return {
+				ok: false,
+				message:
+					"Not inside a git repository. Run /review from a directory that contains a .git folder.",
+			};
+		}
+		return {
+			ok: false,
+			message: `Commit '${sha}' does not resolve to a valid commit. Check that the SHA is correct and reachable.`,
+		};
+	}
+
+	// Gather the full commit diff including the message header
+	const showResult = await pi.exec("git", ["show", "--format=fuller", sha], { cwd });
+	if (showResult.code !== 0) {
+		return {
+			ok: false,
+			message: `git show failed for '${sha}': ${showResult.stderr.trim()}`,
+		};
+	}
+
+	// Resolve current branch (best-effort; irrelevant if we are reviewing an old commit)
+	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+	const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
+
+	return {
+		ok: true,
+		ctx: { currentBranch, body: showResult.stdout, bodyKind: "diff" },
+	};
+}
+
+/**
+ * Return true when a file is likely binary.
+ * Heuristic: read the first 8 KB and check for a NUL (0x00) byte.
+ */
+async function isBinaryFile(filePath: string): Promise<boolean> {
+	let handle: FileHandle | undefined;
+	try {
+		handle = await open(filePath, "r");
+		const buf = Buffer.alloc(8192);
+		const { bytesRead } = await handle.read(buf, 0, 8192, 0);
+		return buf.subarray(0, bytesRead).includes(0);
+	} catch {
+		// Unreadable file — treat as non-binary so the caller surfaces the read error
+		return false;
+	} finally {
+		await handle?.close();
+	}
+}
+
+/**
+ * Recursively collect all regular files under a directory.
+ *
+ * Subdirectories named `node_modules` or starting with `.` are skipped
+ * to avoid generating useless snapshots from tooling/VCS directories.
+ * This filter applies only to entries discovered during recursion — the
+ * user-specified top-level path is always walked regardless of its name.
+ */
+async function walkDir(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			// Skip well-known noisy directories during recursion.
+			if (entry.name === "node_modules" || entry.name.startsWith(".")) {
+				continue;
+			}
+			files.push(...(await walkDir(full)));
+		} else if (entry.isFile()) {
+			files.push(full);
+		}
+	}
+	return files;
+}
+
+/**
+ * Build a snapshot payload from the given paths for the folder mode.
+ * Directories are walked; binary files are skipped with an annotation.
+ */
+async function gatherFolder(
+	pi: ExtensionAPI,
+	cmdCtx: ExtensionCommandContext,
+	paths: string[],
+): Promise<GatherResult> {
+	if (paths.length === 0) {
+		return {
+			ok: false,
+			message: "folder mode requires at least one path, e.g. /review folder src/",
+		};
+	}
+
+	const cwd = cmdCtx.cwd;
+	const absPaths = paths.map((p) => resolve(cwd, p));
+
+	// Validate all paths exist before doing any work
+	for (let i = 0; i < absPaths.length; i++) {
+		try {
+			await stat(absPaths[i]);
+		} catch {
+			return {
+				ok: false,
+				message: `Path does not exist: ${paths[i]}`,
+			};
+		}
+	}
+
+	// Resolve current branch (best-effort; folder mode may be used outside a git repo)
+	let currentBranch: string | undefined;
+	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+	if (branchResult.code === 0) {
+		currentBranch = branchResult.stdout.trim();
+	}
+
+	const parts: string[] = [];
+
+	for (const absPath of absPaths) {
+		const pathStat = await stat(absPath);
+		let filePaths: string[];
+
+		if (pathStat.isDirectory()) {
+			// Prefer git ls-files to respect .gitignore naturally;
+			// --others --exclude-standard includes untracked-but-not-gitignored files
+			const lsResult = await pi.exec("git", ["ls-files", "--cached", "--others", "--exclude-standard", "--", "."], { cwd: absPath });
+			if (lsResult.code === 0 && lsResult.stdout.trim()) {
+				filePaths = lsResult.stdout
+					.trim()
+					.split("\n")
+					.filter(Boolean)
+					.map((f) => join(absPath, f));
+			} else {
+				// Fall back to plain recursive walk when not in a git repo
+				filePaths = await walkDir(absPath);
+			}
+		} else {
+			filePaths = [absPath];
+		}
+
+		for (const filePath of filePaths) {
+			const relPath = relative(cwd, filePath);
+			const bin = await isBinaryFile(filePath);
+			if (bin) {
+				parts.push(`[skipped binary: ${relPath}]`);
+				continue;
+			}
+			const content = await readFile(filePath, "utf8");
+			parts.push(`--- file: ${relPath} ---\n${content}`);
+		}
+	}
+
+	return {
+		ok: true,
+		ctx: {
+			currentBranch,
+			body: parts.join("\n"),
+			bodyKind: "snapshot",
+		},
+	};
+}
+
+/**
+ * Show a confirm prompt asking the user whether to switch to the PR head branch.
+ * Returns true if confirmed, false if cancelled.
+ */
+async function showBranchSwitchConfirm(
+	cmdCtx: ExtensionCommandContext,
+	currentBranch: string,
+	headRefName: string,
+	baseRefName: string,
+): Promise<boolean> {
+	const confirmed = await cmdCtx.ui.custom<boolean>((_tui, theme, _kb, done) => {
+		const container = new Container();
+		const border = new DynamicBorder((segment: string) => theme.fg("accent", segment));
+
+		container.addChild(border);
+		container.addChild(new Text(theme.fg("accent", theme.bold("Switch Branch to Run Review")), 1, 0));
+		container.addChild(new Text(`Current branch: ${currentBranch}`, 1, 0));
+		container.addChild(new Text(`PR head:        ${headRefName}`, 1, 0));
+		container.addChild(new Text(`PR base:        ${baseRefName}`, 1, 0));
+		container.addChild(new Text("", 1, 0));
+		container.addChild(new Text(`Switch to ${headRefName} to run the review? (y/n)`, 1, 0));
+		container.addChild(new Text(theme.fg("dim", "Enter or y to confirm  n or Esc to cancel"), 1, 0));
+		container.addChild(border);
+
+		return {
+			render: (width: number) => container.render(width),
+			invalidate: () => container.invalidate(),
+			handleInput: (data: string) => {
+				if (matchesKey(data, "enter") || matchesKey(data, "y")) {
+					done(true);
+				} else if (matchesKey(data, "n") || matchesKey(data, "escape")) {
+					done(false);
+				}
+			},
+		};
+	});
+
+	return confirmed;
+}
+
+/**
+ * Gather PR diff for the pr mode.
+ *
+ * Steps:
+ * 1. Validate nOrUrl argument.
+ * 2. Reject flag-like nOrUrl.
+ * 3. Check gh CLI availability.
+ * 4. Resolve PR metadata with `gh pr view`.
+ * 5. Resolve current branch.
+ * 6. Branch-mismatch decision tree.
+ * 7. Gather diff with `gh pr diff`.
+ */
+async function gatherPr(
+	pi: ExtensionAPI,
+	cmdCtx: ExtensionCommandContext,
+	nOrUrl: string | undefined,
+): Promise<GatherResult> {
+	const cwd = cmdCtx.cwd;
+
+	// 1. Argument validation
+	if (!nOrUrl || !nOrUrl.trim()) {
+		return {
+			ok: false,
+			message: "pr mode requires a PR number or URL, e.g. /review pr 123",
+		};
+	}
+
+	// 2. Reject flag-like nOrUrl
+	const nOrUrlCheck = rejectFlagLike(nOrUrl, "pr");
+	if (!nOrUrlCheck.ok) {
+		return { ok: false, message: nOrUrlCheck.message };
+	}
+
+	// 3. gh CLI availability check
+	const ghCheckResult = await pi.exec("gh", ["--version"], { cwd });
+	if (ghCheckResult.code !== 0) {
+		return {
+			ok: false,
+			message:
+				"PR mode requires the GitHub CLI. Install: https://cli.github.com — then run `gh auth login`.",
+		};
+	}
+
+	// 4. PR metadata resolution
+	const prViewResult = await pi.exec(
+		"gh",
+		["pr", "view", nOrUrl, "--json", "number,headRefName,baseRefName,isCrossRepository,headRepository"],
+		{ cwd },
+	);
+	if (prViewResult.code !== 0) {
+		const firstLine = prViewResult.stderr.split("\n")[0]?.trim() ?? "";
+		return {
+			ok: false,
+			message: `Could not resolve PR '${nOrUrl}': ${firstLine}`,
+		};
+	}
+
+	let prData: { number: number; headRefName: string; baseRefName: string; isCrossRepository: boolean };
+	try {
+		prData = JSON.parse(prViewResult.stdout) as typeof prData;
+	} catch {
+		return {
+			ok: false,
+			message: `Could not parse PR metadata for '${nOrUrl}'.`,
+		};
+	}
+
+	if (prData.isCrossRepository === true) {
+		return {
+			ok: false,
+			message:
+				"Cross-repository PRs are not supported yet. Fetch the branch locally first and re-run with /review branch <base>.",
+		};
+	}
+
+	const { number: prNumber, headRefName, baseRefName } = prData;
+
+	// 5. Current branch resolution
+	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+	if (branchResult.code !== 0) {
+		return {
+			ok: false,
+			message:
+				"Not inside a git repository. Run /review pr from a directory that contains the PR's repo.",
+		};
+	}
+	const currentBranch = branchResult.stdout.trim();
+
+	// 6. Branch-mismatch decision tree
+	let effectiveBranch = currentBranch;
+	let checkoutCtx: ReviewGatheredContext["checkout"] | undefined;
+
+	if (currentBranch !== headRefName) {
+		// Check whether the working tree is dirty
+		const statusResult = await pi.exec("git", ["status", "--porcelain"], { cwd });
+		const isDirty = statusResult.code === 0 && statusResult.stdout.trim().length > 0;
+
+		// Working tree is clean — confirm before switching
+		let userConfirm = false;
+		if (!isDirty) {
+			if (!cmdCtx.hasUI) {
+				return {
+					ok: false,
+					message:
+						`Branch switch confirmation requires the TUI. You're on '${currentBranch}'; PR head is '${headRefName}'. Run \`git checkout ${headRefName}\` then re-run /review pr ${prNumber}.`,
+				};
+			}
+			userConfirm = await showBranchSwitchConfirm(cmdCtx, currentBranch, headRefName, baseRefName);
+		}
+
+		const action = decideBranchAction({ currentBranch, prHead: headRefName, isDirty, userConfirm });
+
+		if (action === "abort-dirty") {
+			return {
+				ok: false,
+				message:
+					`Working tree has uncommitted changes. Commit or stash them, then re-run /review pr ${prNumber}.\nCurrent branch: ${currentBranch}\nPR head:        ${headRefName}`,
+			};
+		}
+
+		if (action === "abort-cancelled") {
+			return { ok: false, message: "Review cancelled — branch was not switched." };
+		}
+
+		// action === "switch" — perform the checkout
+		const checkoutResult = await pi.exec("git", ["checkout", headRefName], { cwd });
+		if (checkoutResult.code !== 0) {
+			const firstLine = checkoutResult.stderr.split("\n")[0]?.trim() ?? "";
+			return {
+				ok: false,
+				message: `git checkout ${headRefName} failed: ${firstLine}`,
+			};
+		}
+
+		effectiveBranch = headRefName;
+		checkoutCtx = { performed: true, priorBranch: currentBranch };
+	}
+
+	// 7. Diff gathering
+	const diffResult = await pi.exec("gh", ["pr", "diff", String(prNumber)], { cwd });
+	if (diffResult.code !== 0) {
+		const firstLine = diffResult.stderr.split("\n")[0]?.trim() ?? "";
+		return {
+			ok: false,
+			message: `gh pr diff failed for PR #${prNumber}: ${firstLine}`,
+		};
+	}
+
+	const ctx: ReviewGatheredContext = {
+		currentBranch: effectiveBranch,
+		body: diffResult.stdout,
+		bodyKind: "diff",
+	};
+	if (checkoutCtx !== undefined) {
+		ctx.checkout = checkoutCtx;
+	}
+
+	return { ok: true, ctx };
+}
+
+// --- Mode handler ---
+
+async function dispatchReviewMode(
+	pi: ExtensionAPI,
+	cmdCtx: ExtensionCommandContext,
+	parsed: ParsedReviewArgs & { mode: ReviewMode },
+): Promise<void> {
+	// --- Gather phase (all modes) ---
+	let result: GatherResult;
+
+	if (parsed.mode === "pr") {
+		result = await gatherPr(pi, cmdCtx, parsed.nOrUrl);
+	} else {
+		switch (parsed.mode) {
+			case "uncommitted":
+				result = await gatherUncommitted(pi, cmdCtx);
+				break;
+			case "branch":
+				result = await gatherBranch(pi, cmdCtx, parsed.base);
+				break;
+			case "commit":
+				result = await gatherCommit(pi, cmdCtx, parsed.sha);
+				break;
+			case "folder":
+				result = await gatherFolder(pi, cmdCtx, parsed.paths);
+				break;
+		}
+	}
+
+	// --- Uniform error handling ---
+	if (!result.ok) {
+		cmdCtx.ui.notify(result.message, "error");
+		return;
+	}
+
+	// --- PR-specific post-gather notification ---
+	if (parsed.mode === "pr" && result.ctx.checkout?.performed) {
+		cmdCtx.ui.notify(
+			`Switched from '${result.ctx.checkout.priorBranch}' to '${result.ctx.currentBranch}'. Use \`git checkout -\` to return.`,
+			"info",
+		);
+	}
+
+	// --- Large payload warning (warn-only, never blocks) ---
+	const bodyBytes = result.ctx.body?.length ?? 0;
+	if (bodyBytes > REVIEW_LARGE_BODY_BYTES) {
+		cmdCtx.ui.notify(
+			`Large review payload (~${Math.round(bodyBytes / 1024)} KB); proceeding anyway — consider narrowing scope.`,
+			"warning",
+		);
+	}
+
+	// --- Send envelope ---
+	const envelope = buildReviewEnvelope(parsed, result.ctx);
+	pi.sendUserMessage(envelope);
+}
+
+// --- Argument completions ---
+
+function getReviewArgumentCompletions(prefix: string) {
+	const trimmed = prefix.trim().toLowerCase();
+	const parts = trimmed.split(/\s+/).filter(Boolean);
+
+	// Only suggest modes when the user is still typing the first positional
+	// and has not started a flag.
+	if (parts.length <= 1 && !trimmed.includes("--")) {
+		const partialMode = parts[0] ?? "";
+		const completions = REVIEW_MODES.filter((mode) => mode.startsWith(partialMode)).map((mode) => ({
+			value: mode,
+			label: mode,
+			description: REVIEW_MODE_DESCRIPTIONS[mode],
+		}));
+		return completions.length > 0 ? completions : null;
+	}
+
+	return null;
+}
+
+// --- Command registration ---
+
+export function registerReviewCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("review", {
+		description: "Review code changes (uncommitted, branch, commit, pr, or folder)",
+		getArgumentCompletions: getReviewArgumentCompletions,
+		handler: async (args, ctx) => {
+			const argv = tokenizeArgs(args);
+			const parsed = parseReviewArgs(argv);
+
+			if (parsed.mode === null) {
+				// No mode given — show interactive picker.
+				if (!ctx.hasUI) {
+					ctx.ui.notify(REVIEW_COMMAND_HELP, "info");
+					return;
+				}
+				const mode = await showReviewPicker(ctx);
+				if (mode === undefined) {
+					// User cancelled — clean no-op.
+					return;
+				}
+				await dispatchReviewMode(pi, ctx, makePickedArgs(mode));
+				return;
+			}
+
+			await dispatchReviewMode(pi, ctx, parsed);
+		},
+	});
+}

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -1,4 +1,5 @@
-import { open, readdir, readFile, stat, type FileHandle } from "node:fs/promises";
+import type { Stats } from "node:fs";
+import { lstat, open, readdir, readFile, type FileHandle } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
 import { DynamicBorder, getSelectListTheme, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
@@ -8,8 +9,9 @@ import { Container, matchesKey, SelectList, Text } from "@earendil-works/pi-tui"
 
 const REVIEW_TITLE = "Choose a review mode";
 const REVIEW_PICKER_HINT = "↑/↓ to move  Enter to confirm  Esc to cancel";
+const REVIEW_DEFAULT_BRANCH_BASE = "main";
 const REVIEW_COMMAND_HELP =
-	"Usage: /review [uncommitted|branch [base]|commit [sha]|pr [n-or-url]|folder [paths...]] [--extra '...']";
+	"Usage: /review [uncommitted|branch [base=main]|commit <sha>|pr <n-or-url>|folder <paths...>] [--extra '...']\nNote: uncommitted mode also includes untracked non-gitignored files.";
 
 export const REVIEW_MODES = ["uncommitted", "branch", "commit", "pr", "folder"] as const;
 export type ReviewMode = (typeof REVIEW_MODES)[number];
@@ -18,12 +20,15 @@ export type ReviewMode = (typeof REVIEW_MODES)[number];
 export const REVIEW_LARGE_BODY_BYTES = 200 * 1024; // 200 KB
 
 const REVIEW_MODE_DESCRIPTIONS: Record<ReviewMode, string> = {
-	uncommitted: "Review staged and unstaged changes in the working tree",
+	uncommitted: "Review staged/unstaged changes plus untracked non-gitignored files",
 	branch: "Review commits on the current branch vs a base (default: main)",
 	commit: "Review a single commit by SHA",
 	pr: "Review a pull request by number or URL",
 	folder: "Review files in one or more folders",
 };
+
+const REVIEW_UNTRACKED_BEGIN_DELIMITER = "--- begin untracked files ---";
+const REVIEW_UNTRACKED_END_DELIMITER = "--- end untracked files ---";
 
 // --- Types ---
 
@@ -64,6 +69,7 @@ function isReviewMode(value: string): value is ReviewMode {
 /**
  * Tokenise a raw args string from the command handler, respecting single- and
  * double-quoted groups so that --extra "some phrase" is collapsed into one token.
+ * Unquoted whitespace, including newlines from picker follow-up prompts, splits tokens.
  */
 function tokenizeArgs(raw: string): string[] {
 	if (!raw.trim()) return [];
@@ -78,7 +84,7 @@ function tokenizeArgs(raw: string): string[] {
 			inSingleQuote = !inSingleQuote;
 		} else if (ch === '"' && !inSingleQuote) {
 			inDoubleQuote = !inDoubleQuote;
-		} else if (ch === " " && !inSingleQuote && !inDoubleQuote) {
+		} else if (/\s/.test(ch) && !inSingleQuote && !inDoubleQuote) {
 			if (current) {
 				tokens.push(current);
 				current = "";
@@ -103,7 +109,7 @@ function tokenizeArgs(raw: string): string[] {
  *
  * Supported shapes:
  *   /review uncommitted [--extra '...']
- *   /review branch [base] [--extra '...']
+ *   /review branch [base=main] [--extra '...']
  *   /review commit [sha] [--extra '...']
  *   /review pr [n-or-url] [--extra '...']
  *   /review folder [path...] [--extra '...']
@@ -136,7 +142,7 @@ export function parseReviewArgs(argv: string[]): ParsedReviewArgs {
 		case "uncommitted":
 			return { mode: "uncommitted", extra };
 		case "branch":
-			return { mode: "branch", base: args[1], extra };
+			return { mode: "branch", base: args[1] ?? REVIEW_DEFAULT_BRANCH_BASE, extra };
 		case "commit":
 			return { mode: "commit", sha: args[1], extra };
 		case "pr":
@@ -218,7 +224,7 @@ export function buildReviewEnvelope(
 	// ── Body fenced section ───────────────────────────────────────────────────
 	const hasBody = ctx?.body !== undefined;
 	const fenceKind = hasBody ? (ctx?.bodyKind ?? "diff") : "(pending)";
-	const bodyText = hasBody ? (ctx?.body as string) : "(no body gathered)";
+	const bodyText = hasBody ? escapeEnvelopeFenceLines(ctx?.body as string, fenceKind) : "(no body gathered)";
 
 	lines.push(`--- begin ${fenceKind} ---`);
 	lines.push(bodyText);
@@ -229,13 +235,13 @@ export function buildReviewEnvelope(
 
 // --- Helpers for picker integration ---
 
-/** Construct a full ParsedReviewArgs for a mode chosen interactively (no mode-specific args). */
+/** Construct a full ParsedReviewArgs for a mode chosen interactively with defaults applied. */
 function makePickedArgs(mode: ReviewMode): ParsedReviewArgs & { mode: ReviewMode } {
 	switch (mode) {
 		case "uncommitted":
 			return { mode: "uncommitted", extra: undefined };
 		case "branch":
-			return { mode: "branch", base: undefined, extra: undefined };
+			return { mode: "branch", base: REVIEW_DEFAULT_BRANCH_BASE, extra: undefined };
 		case "commit":
 			return { mode: "commit", sha: undefined, extra: undefined };
 		case "pr":
@@ -243,6 +249,42 @@ function makePickedArgs(mode: ReviewMode): ParsedReviewArgs & { mode: ReviewMode
 		case "folder":
 			return { mode: "folder", paths: [], extra: undefined };
 	}
+}
+
+async function promptForReviewInput(
+	ctx: ExtensionCommandContext,
+	title: string,
+): Promise<string | undefined> {
+	const response = await ctx.ui.editor(title);
+	const trimmed = response?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+async function completePickedArgs(
+	ctx: ExtensionCommandContext,
+	mode: ReviewMode,
+): Promise<(ParsedReviewArgs & { mode: ReviewMode }) | undefined> {
+	if (mode === "uncommitted" || mode === "branch") {
+		return makePickedArgs(mode);
+	}
+
+	if (mode === "commit") {
+		const sha = await promptForReviewInput(ctx, "Review commit: enter commit SHA");
+		return sha ? { mode: "commit", sha, extra: undefined } : undefined;
+	}
+
+	if (mode === "pr") {
+		const nOrUrl = await promptForReviewInput(ctx, "Review PR: enter PR number or URL");
+		return nOrUrl ? { mode: "pr", nOrUrl, extra: undefined } : undefined;
+	}
+
+	const rawPaths = await promptForReviewInput(ctx, "Review folder: enter one or more paths (quote paths with spaces)");
+	if (!rawPaths) {
+		return undefined;
+	}
+
+	const paths = tokenizeArgs(rawPaths);
+	return paths.length > 0 ? { mode: "folder", paths, extra: undefined } : undefined;
 }
 
 // --- Interactive picker ---
@@ -309,6 +351,7 @@ function rejectFlagLike(value: string, fieldName: string): { ok: true } | { ok: 
 
 /**
  * Gather staged + unstaged changes vs HEAD for the uncommitted mode.
+ * Also appends untracked, non-gitignored file contents so brand-new files are reviewable.
  */
 async function gatherUncommitted(pi: ExtensionAPI, cmdCtx: ExtensionCommandContext): Promise<GatherResult> {
 	const cwd = cmdCtx.cwd;
@@ -332,9 +375,23 @@ async function gatherUncommitted(pi: ExtensionAPI, cmdCtx: ExtensionCommandConte
 		return { ok: false, message };
 	}
 
+	// Include untracked, non-gitignored files so the reviewer can see newly added content.
+	const untrackedResult = await pi.exec("git", ["ls-files", "-z", "--others", "--exclude-standard", "--", "."], { cwd });
+	if (untrackedResult.code !== 0) {
+		const message = detectNotGitRepo(untrackedResult.stderr)
+			? "Not inside a git repository. Run /review from a directory that contains a .git folder."
+			: `git ls-files for untracked files failed: ${untrackedResult.stderr.trim()}`;
+		return { ok: false, message };
+	}
+
+	const untrackedFiles = parseNullDelimitedGitPaths(untrackedResult.stdout)
+		.map((filePath) => resolve(cwd, filePath));
+	const untrackedParts = await buildSnapshotParts(cwd, untrackedFiles, "untracked file");
+	const body = appendUntrackedSnapshot(diffResult.stdout, untrackedParts);
+
 	return {
 		ok: true,
-		ctx: { currentBranch, body: diffResult.stdout, bodyKind: "diff" },
+		ctx: { currentBranch, body, bodyKind: "diff" },
 	};
 }
 
@@ -346,13 +403,7 @@ async function gatherBranch(
 	cmdCtx: ExtensionCommandContext,
 	base: string | undefined,
 ): Promise<GatherResult> {
-	if (!base) {
-		return {
-			ok: false,
-			message: "branch mode requires a base branch name, e.g. /review branch main",
-		};
-	}
-
+	const effectiveBase = base?.trim() || REVIEW_DEFAULT_BRANCH_BASE;
 	const cwd = cmdCtx.cwd;
 
 	// Refuse if HEAD is detached
@@ -376,26 +427,26 @@ async function gatherBranch(
 	const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
 
 	// Reject flag-like values before passing to git
-	const baseCheck = rejectFlagLike(base, "base");
+	const baseCheck = rejectFlagLike(effectiveBase, "base");
 	if (!baseCheck.ok) {
 		return { ok: false, message: baseCheck.message };
 	}
 
 	// Validate that the base ref resolves
-	const verifyResult = await pi.exec("git", ["rev-parse", "--verify", base], { cwd });
+	const verifyResult = await pi.exec("git", ["rev-parse", "--verify", effectiveBase], { cwd });
 	if (verifyResult.code !== 0) {
 		return {
 			ok: false,
-			message: `Branch base '${base}' does not resolve to a valid ref. Make sure the branch or commit exists locally.`,
+			message: `Branch base '${effectiveBase}' does not resolve to a valid ref. Make sure the branch or commit exists locally.`,
 		};
 	}
 
 	// Compute three-dot diff vs merge-base
-	const diffResult = await pi.exec("git", ["diff", `${base}...HEAD`], { cwd });
+	const diffResult = await pi.exec("git", ["diff", `${effectiveBase}...HEAD`], { cwd });
 	if (diffResult.code !== 0) {
 		return {
 			ok: false,
-			message: `git diff ${base}...HEAD failed: ${diffResult.stderr.trim()}`,
+			message: `git diff ${effectiveBase}...HEAD failed: ${diffResult.stderr.trim()}`,
 		};
 	}
 
@@ -483,7 +534,7 @@ async function isBinaryFile(filePath: string): Promise<boolean> {
 }
 
 /**
- * Recursively collect all regular files under a directory.
+ * Recursively collect all non-directory entries under a directory.
  *
  * Subdirectories named `node_modules` or starting with `.` are skipped
  * to avoid generating useless snapshots from tooling/VCS directories.
@@ -501,11 +552,105 @@ async function walkDir(dir: string): Promise<string[]> {
 				continue;
 			}
 			files.push(...(await walkDir(full)));
-		} else if (entry.isFile()) {
+		} else {
 			files.push(full);
 		}
 	}
 	return files;
+}
+
+function parseNullDelimitedGitPaths(stdout: string): string[] {
+	return stdout.split("\0").filter((filePath) => filePath.length > 0);
+}
+
+function escapeDelimitedContentLine(line: string): string {
+	return `\\${line}`;
+}
+
+function escapeContentDelimiters(content: string): string {
+	return content
+		.split("\n")
+		.map((line) => {
+			if (
+				line === "--- begin snapshot ---"
+				|| line === "--- end snapshot ---"
+				|| line === REVIEW_UNTRACKED_BEGIN_DELIMITER
+				|| line === REVIEW_UNTRACKED_END_DELIMITER
+				|| /^--- (?:file|untracked file): .* ---$/.test(line)
+			) {
+				return escapeDelimitedContentLine(line);
+			}
+			return line;
+		})
+		.join("\n");
+}
+
+function escapeEnvelopeFenceLines(body: string, fenceKind: string): string {
+	const beginFence = `--- begin ${fenceKind} ---`;
+	const endFence = `--- end ${fenceKind} ---`;
+	return body
+		.split("\n")
+		.map((line) => (line === beginFence || line === endFence ? escapeDelimitedContentLine(line) : line))
+		.join("\n");
+}
+
+function renderDelimitedPath(relPath: string): string {
+	return JSON.stringify(relPath)
+		.replace(/[\u007f-\u009f\u2028\u2029]/g, (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`)
+		.replace(/\[/g, "\\u005b")
+		.replace(/\]/g, "\\u005d");
+}
+
+function getNonRegularSnapshotMarker(relPath: string, pathStat: Stats): string | undefined {
+	const renderedPath = renderDelimitedPath(relPath);
+	if (pathStat.isSymbolicLink()) {
+		return `[skipped symlink: ${renderedPath}]`;
+	}
+	if (pathStat.isDirectory()) {
+		return `[skipped directory: ${renderedPath}]`;
+	}
+	if (!pathStat.isFile()) {
+		return `[skipped non-regular entry: ${renderedPath}]`;
+	}
+	return undefined;
+}
+
+/**
+ * Build snapshot entries for a set of file paths.
+ * Binary files are skipped with an annotation instead of inline content.
+ */
+async function buildSnapshotParts(cwd: string, filePaths: string[], label: string): Promise<string[]> {
+	const parts: string[] = [];
+
+	for (const filePath of filePaths) {
+		const relPath = relative(cwd, filePath);
+		const renderedPath = renderDelimitedPath(relPath);
+		const pathStat = await lstat(filePath);
+		const nonRegularMarker = getNonRegularSnapshotMarker(relPath, pathStat);
+		if (nonRegularMarker) {
+			parts.push(nonRegularMarker);
+			continue;
+		}
+
+		const bin = await isBinaryFile(filePath);
+		if (bin) {
+			parts.push(`[skipped binary: ${renderedPath}]`);
+			continue;
+		}
+		const content = escapeContentDelimiters(await readFile(filePath, "utf8"));
+		parts.push(`--- ${label}: ${renderedPath} ---\n${content}`);
+	}
+
+	return parts;
+}
+
+function appendUntrackedSnapshot(diffBody: string, untrackedParts: string[]): string {
+	if (untrackedParts.length === 0) {
+		return diffBody;
+	}
+
+	const untrackedBody = [REVIEW_UNTRACKED_BEGIN_DELIMITER, ...untrackedParts, REVIEW_UNTRACKED_END_DELIMITER].join("\n");
+	return diffBody.trim().length > 0 ? `${diffBody}\n\n${untrackedBody}` : untrackedBody;
 }
 
 /**
@@ -530,7 +675,7 @@ async function gatherFolder(
 	// Validate all paths exist before doing any work
 	for (let i = 0; i < absPaths.length; i++) {
 		try {
-			await stat(absPaths[i]);
+			await lstat(absPaths[i]);
 		} catch {
 			return {
 				ok: false,
@@ -548,38 +693,34 @@ async function gatherFolder(
 
 	const parts: string[] = [];
 
-	for (const absPath of absPaths) {
-		const pathStat = await stat(absPath);
+	for (let i = 0; i < absPaths.length; i++) {
+		const absPath = absPaths[i];
+		const pathStat = await lstat(absPath);
 		let filePaths: string[];
 
 		if (pathStat.isDirectory()) {
 			// Prefer git ls-files to respect .gitignore naturally;
-			// --others --exclude-standard includes untracked-but-not-gitignored files
-			const lsResult = await pi.exec("git", ["ls-files", "--cached", "--others", "--exclude-standard", "--", "."], { cwd: absPath });
-			if (lsResult.code === 0 && lsResult.stdout.trim()) {
-				filePaths = lsResult.stdout
-					.trim()
-					.split("\n")
-					.filter(Boolean)
-					.map((f) => join(absPath, f));
-			} else {
-				// Fall back to plain recursive walk when not in a git repo
+			// --others --exclude-standard includes untracked-but-not-gitignored files.
+			// If git reports zero files for this directory, keep that empty result instead of
+			// walking the tree and accidentally snapshotting ignored files.
+			const lsResult = await pi.exec("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", "."], { cwd: absPath });
+			if (lsResult.code === 0) {
+				filePaths = parseNullDelimitedGitPaths(lsResult.stdout)
+					.map((filePath) => join(absPath, filePath));
+			} else if (detectNotGitRepo(lsResult.stderr)) {
+				// Fall back to a plain recursive walk only when outside git entirely.
 				filePaths = await walkDir(absPath);
+			} else {
+				return {
+					ok: false,
+					message: `git ls-files failed for folder path '${paths[i]}': ${lsResult.stderr.trim()}`,
+				};
 			}
 		} else {
 			filePaths = [absPath];
 		}
 
-		for (const filePath of filePaths) {
-			const relPath = relative(cwd, filePath);
-			const bin = await isBinaryFile(filePath);
-			if (bin) {
-				parts.push(`[skipped binary: ${relPath}]`);
-				continue;
-			}
-			const content = await readFile(filePath, "utf8");
-			parts.push(`--- file: ${relPath} ---\n${content}`);
-		}
+		parts.push(...(await buildSnapshotParts(cwd, filePaths, "file")));
 	}
 
 	return {
@@ -727,7 +868,14 @@ async function gatherPr(
 	if (currentBranch !== headRefName) {
 		// Check whether the working tree is dirty
 		const statusResult = await pi.exec("git", ["status", "--porcelain"], { cwd });
-		const isDirty = statusResult.code === 0 && statusResult.stdout.trim().length > 0;
+		if (statusResult.code !== 0) {
+			const firstLine = statusResult.stderr.split("\n")[0]?.trim() ?? "git status failed";
+			return {
+				ok: false,
+				message: `Could not determine whether the working tree is clean before switching branches: ${firstLine}`,
+			};
+		}
+		const isDirty = statusResult.stdout.trim().length > 0;
 
 		// Working tree is clean — confirm before switching
 		let userConfirm = false;
@@ -891,7 +1039,12 @@ export function registerReviewCommand(pi: ExtensionAPI): void {
 					// User cancelled — clean no-op.
 					return;
 				}
-				await dispatchReviewMode(pi, ctx, makePickedArgs(mode));
+				const completedArgs = await completePickedArgs(ctx, mode);
+				if (completedArgs === undefined) {
+					// User cancelled or left required follow-up input blank.
+					return;
+				}
+				await dispatchReviewMode(pi, ctx, completedArgs);
 				return;
 			}
 

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -2,8 +2,10 @@ import type { Stats } from "node:fs";
 import { lstat, open, readdir, readFile, type FileHandle } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
-import { DynamicBorder, getSelectListTheme, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { DynamicBorder, getAgentDir, getSelectListTheme, SettingsManager, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { Container, matchesKey, SelectList, Text } from "@earendil-works/pi-tui";
+
+import { primaryAgentSelectionFromBranch, resolvePrimaryAgentConfig } from "../the-last-harness-primary-agent.mjs";
 
 // --- Constants ---
 
@@ -14,6 +16,44 @@ const REVIEW_PICKER_ONLY_GUIDANCE =
 	"/review is picker-only. Run /review with no arguments, then choose a mode in the picker. Typed shortcuts like `/review pr 123` and `--extra` are no longer supported.";
 const REVIEW_TUI_REQUIRED_MESSAGE =
 	"/review requires the interactive TUI picker. Re-run /review in the TLH UI.";
+
+type ReviewPrimaryAgentSelection = "architect" | "rush" | "product" | "bug-hunter" | "disabled";
+type ReviewSettings = {
+	tlh?: {
+		primaryAgent?: {
+			enabled?: boolean;
+			selected?: string;
+		};
+	};
+};
+
+const REVIEW_REQUIRED_PRIMARY: ReviewPrimaryAgentSelection = "architect";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getTlhGlobalSettings(cwd: string): ReviewSettings {
+	try {
+		const settings = SettingsManager.create(cwd, getAgentDir()).getGlobalSettings() as unknown;
+		return isRecord(settings) ? (settings as ReviewSettings) : {};
+	} catch {
+		return {};
+	}
+}
+
+function currentReviewPrimaryAgentSelection(ctx: ExtensionCommandContext): ReviewPrimaryAgentSelection {
+	const defaultResolution = resolvePrimaryAgentConfig(getTlhGlobalSettings(ctx.cwd).tlh?.primaryAgent) as {
+		selection: ReviewPrimaryAgentSelection;
+	};
+	const branchEntries = typeof ctx.sessionManager?.getBranch === "function" ? ctx.sessionManager.getBranch() : [];
+	const sessionResolution = primaryAgentSelectionFromBranch(branchEntries) as { selection?: ReviewPrimaryAgentSelection };
+	return sessionResolution.selection ?? defaultResolution.selection;
+}
+
+function reviewPrimaryBlockedMessage(activePrimary: ReviewPrimaryAgentSelection): string {
+	return `/review only works while the architect primary agent is active. Current primary agent: ${activePrimary}. Switch to architect with /switch-primary-agent architect (or Shift+Tab), then rerun /review.`;
+}
 
 export const REVIEW_MODES = ["uncommitted", "branch", "commit", "pr", "folder"] as const;
 export type ReviewMode = (typeof REVIEW_MODES)[number];
@@ -1012,6 +1052,12 @@ export function registerReviewCommand(pi: ExtensionAPI): void {
 		description: "Review code changes via an interactive mode picker",
 		getArgumentCompletions: getReviewArgumentCompletions,
 		handler: async (args, ctx) => {
+			const activePrimary = currentReviewPrimaryAgentSelection(ctx);
+			if (activePrimary !== REVIEW_REQUIRED_PRIMARY) {
+				ctx.ui.notify(reviewPrimaryBlockedMessage(activePrimary), "error");
+				return;
+			}
+
 			const argv = tokenizeArgs(args);
 			const parsed = parseReviewArgs(argv);
 

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -18,12 +18,9 @@ const REVIEW_TUI_REQUIRED_MESSAGE =
 export const REVIEW_MODES = ["uncommitted", "branch", "commit", "pr", "folder"] as const;
 export type ReviewMode = (typeof REVIEW_MODES)[number];
 
-/** Byte-length threshold for the diff/snapshot body; warn-only, never blocks. */
-export const REVIEW_LARGE_BODY_BYTES = 200 * 1024; // 200 KB
-
 const REVIEW_MODE_DESCRIPTIONS: Record<ReviewMode, string> = {
 	uncommitted: "Review staged/unstaged changes plus untracked non-gitignored files",
-	branch: "Review commits on the current branch vs a base (default: main)",
+	branch: "Review commits on the current branch vs a chosen base (prompted; blank defaults to main)",
 	commit: "Review a single commit by SHA",
 	pr: "Review a pull request by number or URL",
 	folder: "Review files in one or more folders",
@@ -200,22 +197,11 @@ export function buildReviewEnvelope(
 // --- Helpers for picker integration ---
 
 /** Construct full dispatch args for a mode chosen interactively with defaults applied. */
-function makePickedArgs(mode: ReviewMode): ReviewDispatchArgs {
-	switch (mode) {
-		case "uncommitted":
-			return { mode: "uncommitted", extra: undefined };
-		case "branch":
-			return { mode: "branch", base: REVIEW_DEFAULT_BRANCH_BASE, extra: undefined };
-		case "commit":
-			return { mode: "commit", sha: undefined, extra: undefined };
-		case "pr":
-			return { mode: "pr", nOrUrl: undefined, extra: undefined };
-		case "folder":
-			return { mode: "folder", paths: [], extra: undefined };
-	}
+function makePickedArgs(mode: "uncommitted"): ReviewDispatchArgs {
+	return { mode, extra: undefined };
 }
 
-async function promptForReviewInput(
+async function promptForRequiredReviewInput(
 	ctx: ExtensionCommandContext,
 	title: string,
 ): Promise<string | undefined> {
@@ -224,25 +210,48 @@ async function promptForReviewInput(
 	return trimmed ? trimmed : undefined;
 }
 
+async function promptForBranchBase(
+	ctx: ExtensionCommandContext,
+): Promise<string | undefined> {
+	const response = await ctx.ui.editor(
+		"Review branch: enter base branch (blank defaults to main)",
+		REVIEW_DEFAULT_BRANCH_BASE,
+	);
+	if (response === undefined) {
+		return undefined;
+	}
+
+	const trimmed = response.trim();
+	return trimmed || REVIEW_DEFAULT_BRANCH_BASE;
+}
+
 async function completePickedArgs(
 	ctx: ExtensionCommandContext,
 	mode: ReviewMode,
 ): Promise<ReviewDispatchArgs | undefined> {
-	if (mode === "uncommitted" || mode === "branch") {
+	if (mode === "uncommitted") {
 		return makePickedArgs(mode);
 	}
 
+	if (mode === "branch") {
+		const base = await promptForBranchBase(ctx);
+		return base ? { mode: "branch", base, extra: undefined } : undefined;
+	}
+
 	if (mode === "commit") {
-		const sha = await promptForReviewInput(ctx, "Review commit: enter commit SHA");
+		const sha = await promptForRequiredReviewInput(ctx, "Review commit: enter commit SHA");
 		return sha ? { mode: "commit", sha, extra: undefined } : undefined;
 	}
 
 	if (mode === "pr") {
-		const nOrUrl = await promptForReviewInput(ctx, "Review PR: enter PR number or URL");
+		const nOrUrl = await promptForRequiredReviewInput(ctx, "Review PR: enter PR number or URL");
 		return nOrUrl ? { mode: "pr", nOrUrl, extra: undefined } : undefined;
 	}
 
-	const rawPaths = await promptForReviewInput(ctx, "Review folder: enter one or more paths (quote paths with spaces)");
+	const rawPaths = await promptForRequiredReviewInput(
+		ctx,
+		"Review folder: enter one or more paths (quote paths with spaces)",
+	);
 	if (!rawPaths) {
 		return undefined;
 	}
@@ -389,6 +398,13 @@ async function gatherBranch(
 	base: string | undefined,
 ): Promise<GatherResult> {
 	const effectiveBase = base?.trim() || REVIEW_DEFAULT_BRANCH_BASE;
+
+	// Reject flag-like values before passing anything to git.
+	const baseCheck = rejectFlagLike(effectiveBase, "base");
+	if (!baseCheck.ok) {
+		return { ok: false, message: baseCheck.message };
+	}
+
 	const cwd = cmdCtx.cwd;
 
 	// Refuse if HEAD is detached
@@ -410,12 +426,6 @@ async function gatherBranch(
 	// Resolve current branch
 	const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
 	const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
-
-	// Reject flag-like values before passing to git
-	const baseCheck = rejectFlagLike(effectiveBase, "base");
-	if (!baseCheck.ok) {
-		return { ok: false, message: baseCheck.message };
-	}
 
 	// Validate that the base ref resolves
 	const verifyResult = await pi.exec("git", ["rev-parse", "--verify", effectiveBase], { cwd });
@@ -981,15 +991,6 @@ async function dispatchReviewMode(
 		cmdCtx.ui.notify(
 			`Switched from '${result.ctx.checkout.priorBranch}' to '${result.ctx.currentBranch}'. Use \`git checkout -\` to return.`,
 			"info",
-		);
-	}
-
-	// --- Large payload warning (warn-only, never blocks) ---
-	const bodyBytes = result.ctx.body?.length ?? 0;
-	if (bodyBytes > REVIEW_LARGE_BODY_BYTES) {
-		cmdCtx.ui.notify(
-			`Large review payload (~${Math.round(bodyBytes / 1024)} KB); proceeding anyway — consider narrowing scope.`,
-			"warning",
 		);
 	}
 

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -113,82 +113,25 @@ function assertStandaloneLineCount(message, expectedLine, expectedCount) {
 
 // ─── (a) parseReviewArgs ───────────────────────────────────────────────────────
 
-test("parseReviewArgs: empty argv returns pickerRequested", () => {
-	assert.deepEqual(parseReviewArgs([]), { mode: null, pickerRequested: true });
+test("parseReviewArgs: empty argv requests the picker", () => {
+	assert.deepEqual(parseReviewArgs([]), { pickerRequested: true });
 });
 
-test("parseReviewArgs: uncommitted mode with no extra", () => {
-	assert.deepEqual(parseReviewArgs(["uncommitted"]), { mode: "uncommitted", extra: undefined });
-});
-
-test("parseReviewArgs: branch mode with base", () => {
-	assert.deepEqual(parseReviewArgs(["branch", "main"]), { mode: "branch", base: "main", extra: undefined });
-});
-
-test("parseReviewArgs: branch mode without base defaults to main", () => {
-	assert.deepEqual(parseReviewArgs(["branch"]), { mode: "branch", base: "main", extra: undefined });
-});
-
-test("parseReviewArgs: commit mode with sha", () => {
-	assert.deepEqual(parseReviewArgs(["commit", "abc123"]), { mode: "commit", sha: "abc123", extra: undefined });
-});
-
-test("parseReviewArgs: pr mode with number string", () => {
-	assert.deepEqual(parseReviewArgs(["pr", "42"]), { mode: "pr", nOrUrl: "42", extra: undefined });
-});
-
-test("parseReviewArgs: pr mode with full URL", () => {
-	assert.deepEqual(parseReviewArgs(["pr", "https://github.com/o/r/pull/9"]), {
-		mode: "pr",
-		nOrUrl: "https://github.com/o/r/pull/9",
-		extra: undefined,
-	});
-});
-
-test("parseReviewArgs: folder mode with multiple paths", () => {
-	assert.deepEqual(parseReviewArgs(["folder", "src", "docs"]), {
-		mode: "folder",
-		paths: ["src", "docs"],
-		extra: undefined,
-	});
-});
-
-test("parseReviewArgs: folder mode without paths yields empty array", () => {
-	assert.deepEqual(parseReviewArgs(["folder"]), { mode: "folder", paths: [], extra: undefined });
-});
-
-test("parseReviewArgs: uncommitted mode with --extra flag", () => {
-	assert.deepEqual(parseReviewArgs(["uncommitted", "--extra", "focus on perf"]), {
-		mode: "uncommitted",
-		extra: "focus on perf",
-	});
-});
-
-test("parseReviewArgs: branch mode with base and --extra flag", () => {
-	assert.deepEqual(parseReviewArgs(["branch", "main", "--extra", "x"]), {
-		mode: "branch",
-		base: "main",
-		extra: "x",
-	});
-});
-
-test("parseReviewArgs: branch mode without base still defaults to main when --extra is present", () => {
-	assert.deepEqual(parseReviewArgs(["branch", "--extra", "focus on regressions"]), {
-		mode: "branch",
-		base: "main",
-		extra: "focus on regressions",
-	});
-});
-
-test("parseReviewArgs: --extra before mode positional is captured regardless of position", () => {
-	assert.deepEqual(parseReviewArgs(["--extra", "x", "uncommitted"]), {
-		mode: "uncommitted",
-		extra: "x",
-	});
-});
-
-test("parseReviewArgs: unknown mode falls back to pickerRequested", () => {
-	assert.deepEqual(parseReviewArgs(["wat"]), { mode: null, pickerRequested: true });
+test("parseReviewArgs: typed review args are rejected with picker-only guidance", () => {
+	for (const argv of [
+		["uncommitted"],
+		["branch", "main"],
+		["commit", "abc123"],
+		["pr", "42"],
+		["folder", "src"],
+		["uncommitted", "--extra", "focus on perf"],
+	]) {
+		assert.deepEqual(parseReviewArgs(argv), {
+			pickerRequested: false,
+			message:
+				"/review is picker-only. Run /review with no arguments, then choose a mode in the picker. Typed shortcuts like `/review pr 123` and `--extra` are no longer supported.",
+		});
+	}
 });
 
 // ─── (b) buildReviewEnvelope ───────────────────────────────────────────────────
@@ -333,38 +276,65 @@ test("decideBranchAction: clean mismatch with no confirmation returns abort-canc
 
 // ─── (d) command gather regressions ───────────────────────────────────────────
 
-test("/review branch defaults base to main when omitted", async (t) => {
-	const cwd = makeTempDir(t, "tlh-review-branch-default-");
+test("/review rejects typed shortcuts and does not open the picker", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-typed-shortcuts-");
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => {
+			throw new Error("picker should not open when typed args are provided");
+		},
 		exec: async (command, args) => {
-			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
-				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
-			}
-			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
-				return { code: 0, stdout: "feature/review\n", stderr: "" };
-			}
-			if (command === "git" && args.join(" ") === "rev-parse --verify main") {
-				return { code: 0, stdout: "abc123\n", stderr: "" };
-			}
-			if (command === "git" && args.join(" ") === "diff main...HEAD") {
-				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
-			}
 			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
 		},
 	});
 
-	await harness.handler("branch", harness.ctx);
+	for (const input of [
+		"uncommitted",
+		"branch main",
+		"commit abc123",
+		"pr 123",
+		"folder src",
+		"uncommitted --extra \"focus on error handling\"",
+	]) {
+		await harness.handler(input, harness.ctx);
+	}
 
-	assert.equal(harness.notifications.length, 0);
-	assert.equal(harness.sentMessages.length, 1);
-	assert.match(harness.sentMessages[0], /mode: branch/);
-	assert.match(harness.sentMessages[0], /base: main/);
-	assert.equal(
-		harness.execCalls.some(({ command, args }) => command === "git" && args.join(" ") === "diff main...HEAD"),
-		true,
+	assert.equal(harness.customCallCount, 0);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(
+		harness.notifications,
+		Array.from({ length: 6 }, () => ({
+			message:
+				"/review is picker-only. Run /review with no arguments, then choose a mode in the picker. Typed shortcuts like `/review pr 123` and `--extra` are no longer supported.",
+			level: "error",
+		})),
 	);
+});
+
+test("/review without TUI fails clearly because the picker is required", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-no-tui-");
+
+	const harness = createReviewHarness({
+		cwd,
+		hasUI: false,
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 0);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "/review requires the interactive TUI picker. Re-run /review in the TLH UI.",
+			level: "error",
+		},
+	]);
 });
 
 test("/review picker-selected branch uses main by default without extra prompts", async (t) => {
@@ -399,52 +369,21 @@ test("/review picker-selected branch uses main by default without extra prompts"
 });
 
 
-test("/review branch rejects a leading-dash base before using it as a git ref", async (t) => {
-	const cwd = makeTempDir(t, "tlh-review-branch-leading-dash-");
-
-	const harness = createReviewHarness({
-		cwd,
-		exec: async (command, args) => {
-			assert.equal(args.includes("-main"), false, "should reject before passing -main to git");
-			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
-				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
-			}
-			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
-				return { code: 0, stdout: "feature/review\n", stderr: "" };
-			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
-		},
-	});
-
-	await harness.handler("branch -main", harness.ctx);
-
-	assert.equal(harness.sentMessages.length, 0);
-	assert.deepEqual(harness.notifications, [
-		{
-			message: "base cannot start with '-' (got '-main'). If this is intentional, run the underlying command manually.",
-			level: "error",
-		},
-	]);
-	assert.equal(
-		harness.execCalls.some(({ args }) => args.includes("-main")),
-		false,
-		"should not pass the leading-dash base to git",
-	);
-});
-
-
-test("/review commit rejects a leading-dash sha before git use", async (t) => {
+test("/review picker-selected commit rejects a leading-dash sha before git use", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-commit-leading-dash-");
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "commit",
+		editor: () => "-abc123",
 		exec: async (command, args) => {
 			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
 		},
 	});
 
-	await harness.handler("commit -abc123", harness.ctx);
+	await harness.handler("", harness.ctx);
 
+	assert.equal(harness.customCallCount, 1);
 	assert.equal(harness.execCalls.length, 0);
 	assert.equal(harness.sentMessages.length, 0);
 	assert.deepEqual(harness.notifications, [
@@ -456,18 +395,21 @@ test("/review commit rejects a leading-dash sha before git use", async (t) => {
 });
 
 
-test("/review pr rejects a leading-dash ref before gh use", async (t) => {
+test("/review picker-selected pr rejects a leading-dash ref before gh use", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-pr-leading-dash-");
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "pr",
+		editor: () => "-42",
 		exec: async (command, args) => {
 			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
 		},
 	});
 
-	await harness.handler("pr -42", harness.ctx);
+	await harness.handler("", harness.ctx);
 
+	assert.equal(harness.customCallCount, 1);
 	assert.equal(harness.execCalls.length, 0);
 	assert.equal(harness.sentMessages.length, 0);
 	assert.deepEqual(harness.notifications, [
@@ -619,21 +561,25 @@ test("/review uncommitted appends untracked non-gitignored file content", async 
 
 	const harness = createReviewHarness({
 		cwd,
-		exec: async (command, args) => {
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
 			}
 			if (command === "git" && args.join(" ") === "diff HEAD") {
 				return { code: 0, stdout: "diff --git a/app.ts b/app.ts\n", stderr: "" };
 			}
-			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${cwd}\n`, stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && options.cwd === cwd) {
 				return { code: 0, stdout: "new-file.ts\0", stderr: "" };
 			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
 		},
 	});
 
-	await harness.handler("uncommitted", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.notifications.length, 0);
 	assert.equal(harness.sentMessages.length, 1);
@@ -647,6 +593,53 @@ test("/review uncommitted appends untracked non-gitignored file content", async 
 	);
 });
 
+test("/review uncommitted scans untracked files from the repo root when invoked from a subdirectory", async (t) => {
+	const repoRoot = makeTempDir(t, "tlh-review-uncommitted-root-");
+	const cwd = join(repoRoot, "packages", "app");
+	mkdirSync(cwd, { recursive: true });
+	writeFileSync(join(repoRoot, "outside.ts"), "export const outside = true;\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD" && options.cwd === cwd) {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD" && options.cwd === cwd) {
+				return { code: 0, stdout: "diff --git a/app.ts b/app.ts\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${repoRoot}\n`, stderr: "" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --others --exclude-standard -- ." &&
+				options.cwd === repoRoot
+			) {
+				return { code: 0, stdout: "outside.ts\0", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /--- untracked file: "outside\.ts" ---\nexport const outside = true;/);
+	assert.doesNotMatch(harness.sentMessages[0], /--- untracked file: "\.\.\/outside\.ts" ---/);
+	assert.ok(
+		harness.execCalls.some(({ command, args, cwd: callCwd }) =>
+			command === "git" && args.join(" ") === "rev-parse --show-toplevel" && callCwd === cwd),
+		"should resolve the repository root from the invocation cwd",
+	);
+	assert.ok(
+		harness.execCalls.some(({ command, args, cwd: callCwd }) =>
+			command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && callCwd === repoRoot),
+		"should scan untracked files from the repository root",
+	);
+});
+
 test("/review uncommitted preserves exact git-reported paths with leading or trailing spaces", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-untracked-spaces-");
 	writeFileSync(join(cwd, " leading.ts"), "export const leading = true;\n");
@@ -654,21 +647,25 @@ test("/review uncommitted preserves exact git-reported paths with leading or tra
 
 	const harness = createReviewHarness({
 		cwd,
-		exec: async (command, args) => {
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
 			}
 			if (command === "git" && args.join(" ") === "diff HEAD") {
 				return { code: 0, stdout: "", stderr: "" };
 			}
-			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${cwd}\n`, stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && options.cwd === cwd) {
 				return { code: 0, stdout: " leading.ts\0trailing .ts\0", stderr: "" };
 			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
 		},
 	});
 
-	await harness.handler("uncommitted", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assert.ok(harness.sentMessages[0].includes("--- untracked file: \" leading.ts\" ---"));
@@ -682,21 +679,25 @@ test("/review uncommitted renders newline/control/delimiter-like untracked paths
 
 	const harness = createReviewHarness({
 		cwd,
-		exec: async (command, args) => {
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
 			}
 			if (command === "git" && args.join(" ") === "diff HEAD") {
 				return { code: 0, stdout: "", stderr: "" };
 			}
-			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${cwd}\n`, stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && options.cwd === cwd) {
 				return { code: 0, stdout: `${weirdPath}\0`, stderr: "" };
 			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
 		},
 	});
 
-	await harness.handler("uncommitted", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assertRenderedPathLine(harness.sentMessages[0], /^--- untracked file: (".*") ---$/, weirdPath);
@@ -712,21 +713,25 @@ test("/review uncommitted skips symlinked untracked files instead of reading tar
 
 	const harness = createReviewHarness({
 		cwd,
-		exec: async (command, args) => {
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
 			}
 			if (command === "git" && args.join(" ") === "diff HEAD") {
 				return { code: 0, stdout: "", stderr: "" };
 			}
-			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${cwd}\n`, stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && options.cwd === cwd) {
 				return { code: 0, stdout: "outside-link.txt\0", stderr: "" };
 			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
 		},
 	});
 
-	await harness.handler("uncommitted", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assertRenderedPathLine(harness.sentMessages[0], /^\[skipped symlink: (".*")\]$/, "outside-link.txt");
@@ -743,21 +748,25 @@ test("/review uncommitted renders escaped symlink skip markers for newline/delim
 
 	const harness = createReviewHarness({
 		cwd,
-		exec: async (command, args) => {
+		custom: () => "uncommitted",
+		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
 			}
 			if (command === "git" && args.join(" ") === "diff HEAD") {
 				return { code: 0, stdout: "", stderr: "" };
 			}
-			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+			if (command === "git" && args.join(" ") === "rev-parse --show-toplevel" && options.cwd === cwd) {
+				return { code: 0, stdout: `${cwd}\n`, stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- ." && options.cwd === cwd) {
 				return { code: 0, stdout: `${weirdLinkPath}\0`, stderr: "" };
 			}
-			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
 		},
 	});
 
-	await harness.handler("uncommitted", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assertRenderedPathLine(harness.sentMessages[0], /^\[skipped symlink: (".*")\]$/, weirdLinkPath);
@@ -772,6 +781,8 @@ test("/review folder keeps empty git ls-files results instead of walking ignored
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "folder",
+		editor: () => "ignored-only",
 		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "main\n", stderr: "" };
@@ -787,7 +798,7 @@ test("/review folder keeps empty git ls-files results instead of walking ignored
 		},
 	});
 
-	await harness.handler("folder ignored-only", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.notifications.length, 0);
 	assert.equal(harness.sentMessages.length, 1);
@@ -803,6 +814,8 @@ test("/review folder still falls back to a plain walk outside git", async (t) =>
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "folder",
+		editor: () => "docs",
 		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
@@ -818,7 +831,7 @@ test("/review folder still falls back to a plain walk outside git", async (t) =>
 		},
 	});
 
-	await harness.handler("folder docs", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.notifications.length, 0);
 	assert.equal(harness.sentMessages.length, 1);
@@ -832,6 +845,8 @@ test("/review folder escapes snapshot fence lines found in file content", async 
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "folder",
+		editor: () => "docs",
 		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
@@ -847,7 +862,7 @@ test("/review folder escapes snapshot fence lines found in file content", async 
 		},
 	});
 
-	await harness.handler("folder docs", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assert.match(harness.sentMessages[0], /\\--- end snapshot ---/);
@@ -877,6 +892,8 @@ test("/review folder skips per-file lstat and binary-check failures while contin
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "folder",
+		editor: () => "docs",
 		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 0, stdout: "main\n", stderr: "" };
@@ -892,7 +909,7 @@ test("/review folder skips per-file lstat and binary-check failures while contin
 		},
 	});
 
-	await harness.handler("folder docs", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.notifications.length, 0);
 	assert.equal(harness.sentMessages.length, 1);
@@ -913,6 +930,8 @@ test("/review folder renders newline/control/delimiter-like snapshot paths as es
 
 	const harness = createReviewHarness({
 		cwd,
+		custom: () => "folder",
+		editor: () => "docs",
 		exec: async (command, args, options) => {
 			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
 				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
@@ -928,21 +947,94 @@ test("/review folder renders newline/control/delimiter-like snapshot paths as es
 		},
 	});
 
-	await harness.handler("folder docs", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 1);
 	assertRenderedPathLine(harness.sentMessages[0], /^--- file: (".*") ---$/, `docs/${weirdName}`);
 	assertNoStandaloneLine(harness.sentMessages[0], "--- begin untracked files ---");
 });
 
+test("/review pr uses gh pr checkout before diff when switching to the PR head", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-checkout-");
+	const customResponses = ["pr", true];
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => customResponses.shift(),
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						headRefName: "feature/review",
+						baseRefName: "main",
+						isCrossRepository: false,
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "main\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "status --porcelain") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr checkout 123") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr diff 123") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "Switched from 'main' to 'feature/review'. Use `git checkout -` to return.",
+			level: "info",
+		},
+	]);
+	assert.ok(
+		harness.execCalls.some(({ command, args }) => command === "gh" && args.join(" ") === "pr checkout 123"),
+		"should use gh pr checkout for the branch switch",
+	);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "git" && args[0] === "checkout"),
+		false,
+	);
+	assert.ok(
+		harness.execCalls.findIndex(({ command, args }) => command === "gh" && args.join(" ") === "pr checkout 123") <
+			harness.execCalls.findIndex(({ command, args }) => command === "gh" && args.join(" ") === "pr diff 123"),
+		"should switch branches before gathering the PR diff",
+	);
+});
+
 test("/review pr aborts before checkout when git status dirty-check fails", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-pr-");
+	const customResponses = ["pr"];
 
 	const harness = createReviewHarness({
 		cwd,
 		custom: () => {
-			throw new Error("branch switch confirmation should not be shown when git status fails");
+			if (customResponses.length === 0) {
+				throw new Error("branch switch confirmation should not be shown when git status fails");
+			}
+			return customResponses.shift();
 		},
+		editor: () => "123",
 		exec: async (command, args) => {
 			if (command === "gh" && args.join(" ") === "--version") {
 				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
@@ -973,12 +1065,16 @@ test("/review pr aborts before checkout when git status dirty-check fails", asyn
 		},
 	});
 
-	await harness.handler("pr 123", harness.ctx);
+	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.sentMessages.length, 0);
-	assert.equal(harness.customCallCount, 0);
+	assert.equal(harness.customCallCount, 1);
 	assert.equal(
 		harness.execCalls.some(({ command, args }) => command === "git" && args[0] === "checkout"),
+		false,
+	);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "gh" && args.join(" ") === "pr checkout 123"),
 		false,
 	);
 	assert.deepEqual(harness.notifications, [

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReviewEnvelope, decideBranchAction, parseReviewArgs } from "../extensions/the-last-harness/review.ts";
+
+// ─── (a) parseReviewArgs ───────────────────────────────────────────────────────
+
+test("parseReviewArgs: empty argv returns pickerRequested", () => {
+	assert.deepEqual(parseReviewArgs([]), { mode: null, pickerRequested: true });
+});
+
+test("parseReviewArgs: uncommitted mode with no extra", () => {
+	assert.deepEqual(parseReviewArgs(["uncommitted"]), { mode: "uncommitted", extra: undefined });
+});
+
+test("parseReviewArgs: branch mode with base", () => {
+	assert.deepEqual(parseReviewArgs(["branch", "main"]), { mode: "branch", base: "main", extra: undefined });
+});
+
+test("parseReviewArgs: branch mode without base yields undefined base", () => {
+	assert.deepEqual(parseReviewArgs(["branch"]), { mode: "branch", base: undefined, extra: undefined });
+});
+
+test("parseReviewArgs: commit mode with sha", () => {
+	assert.deepEqual(parseReviewArgs(["commit", "abc123"]), { mode: "commit", sha: "abc123", extra: undefined });
+});
+
+test("parseReviewArgs: pr mode with number string", () => {
+	assert.deepEqual(parseReviewArgs(["pr", "42"]), { mode: "pr", nOrUrl: "42", extra: undefined });
+});
+
+test("parseReviewArgs: pr mode with full URL", () => {
+	assert.deepEqual(parseReviewArgs(["pr", "https://github.com/o/r/pull/9"]), {
+		mode: "pr",
+		nOrUrl: "https://github.com/o/r/pull/9",
+		extra: undefined,
+	});
+});
+
+test("parseReviewArgs: folder mode with multiple paths", () => {
+	assert.deepEqual(parseReviewArgs(["folder", "src", "docs"]), {
+		mode: "folder",
+		paths: ["src", "docs"],
+		extra: undefined,
+	});
+});
+
+test("parseReviewArgs: folder mode without paths yields empty array", () => {
+	assert.deepEqual(parseReviewArgs(["folder"]), { mode: "folder", paths: [], extra: undefined });
+});
+
+test("parseReviewArgs: uncommitted mode with --extra flag", () => {
+	assert.deepEqual(parseReviewArgs(["uncommitted", "--extra", "focus on perf"]), {
+		mode: "uncommitted",
+		extra: "focus on perf",
+	});
+});
+
+test("parseReviewArgs: branch mode with base and --extra flag", () => {
+	assert.deepEqual(parseReviewArgs(["branch", "main", "--extra", "x"]), {
+		mode: "branch",
+		base: "main",
+		extra: "x",
+	});
+});
+
+test("parseReviewArgs: --extra before mode positional is captured regardless of position", () => {
+	assert.deepEqual(parseReviewArgs(["--extra", "x", "uncommitted"]), {
+		mode: "uncommitted",
+		extra: "x",
+	});
+});
+
+test("parseReviewArgs: unknown mode falls back to pickerRequested", () => {
+	assert.deepEqual(parseReviewArgs(["wat"]), { mode: null, pickerRequested: true });
+});
+
+// ─── (b) buildReviewEnvelope ───────────────────────────────────────────────────
+
+test("buildReviewEnvelope: first line is exactly [/review]", () => {
+	const envelope = buildReviewEnvelope({ mode: "uncommitted", extra: undefined });
+	const firstLine = envelope.split("\n")[0];
+	assert.equal(firstLine, "[/review]");
+});
+
+test("buildReviewEnvelope: branch+base with currentBranch ctx and no body contains expected metadata and pending fence", () => {
+	const envelope = buildReviewEnvelope(
+		{ mode: "branch", base: "main", extra: undefined },
+		{ currentBranch: "feature/x" },
+	);
+	const lines = envelope.split("\n");
+
+	assert.ok(lines.includes("mode: branch"), "contains mode: branch");
+	assert.ok(lines.includes("base: main"), "contains base: main");
+	assert.ok(lines.includes("current-branch: feature/x"), "contains current-branch: feature/x");
+	assert.ok(lines.includes("extra: (none)"), "contains extra: (none) when extra is undefined");
+	assert.ok(lines.includes("--- begin (pending) ---"), "contains begin pending fence");
+	assert.ok(lines.includes("--- end (pending) ---"), "contains end pending fence");
+});
+
+test("buildReviewEnvelope: diff body is included verbatim inside diff fence", () => {
+	const body = "DIFF\nBODY";
+	const envelope = buildReviewEnvelope(
+		{ mode: "uncommitted", extra: undefined },
+		{ body, bodyKind: "diff" },
+	);
+	assert.ok(envelope.includes("--- begin diff ---"), "contains begin diff fence");
+	assert.ok(envelope.includes("--- end diff ---"), "contains end diff fence");
+	assert.ok(envelope.includes(body), "body is present verbatim");
+	// Ensure body appears between the fences
+	const beginIdx = envelope.indexOf("--- begin diff ---");
+	const endIdx = envelope.indexOf("--- end diff ---");
+	const bodyIdx = envelope.indexOf(body);
+	assert.ok(beginIdx < bodyIdx && bodyIdx < endIdx, "body is between fence markers");
+});
+
+test("buildReviewEnvelope: snapshot body uses snapshot fence", () => {
+	const envelope = buildReviewEnvelope(
+		{ mode: "folder", paths: ["src"], extra: undefined },
+		{ body: "SNAP", bodyKind: "snapshot" },
+	);
+	assert.ok(envelope.includes("--- begin snapshot ---"), "contains begin snapshot fence");
+	assert.ok(envelope.includes("--- end snapshot ---"), "contains end snapshot fence");
+	assert.ok(envelope.includes("SNAP"), "snapshot body is present");
+});
+
+test("buildReviewEnvelope: checkout ctx produces switched-from line", () => {
+	const envelope = buildReviewEnvelope(
+		{ mode: "pr", nOrUrl: "42", extra: undefined },
+		{ checkout: { performed: true, priorBranch: "main" } },
+	);
+	const lines = envelope.split("\n");
+	assert.ok(lines.includes("checkout: switched-from main"), "contains checkout: switched-from main");
+});
+
+test("buildReviewEnvelope: extra value appears after extra: label (not the none literal)", () => {
+	const envelope = buildReviewEnvelope(
+		{ mode: "uncommitted", extra: "watch perf" },
+	);
+	const lines = envelope.split("\n");
+	const extraLabelIdx = lines.indexOf("extra:");
+	assert.notEqual(extraLabelIdx, -1, "extra: label line is present");
+	assert.equal(lines[extraLabelIdx + 1], "watch perf", "extra value is on the next line");
+	assert.ok(!envelope.includes("extra: (none)"), "does not contain the none literal");
+});
+
+test("buildReviewEnvelope: multi-line extra is preserved verbatim", () => {
+	const multiLineExtra = "line one\nline two\nline three";
+	const envelope = buildReviewEnvelope(
+		{ mode: "uncommitted", extra: multiLineExtra },
+	);
+	assert.ok(envelope.includes(multiLineExtra), "multi-line extra is preserved verbatim");
+});
+
+// ─── (c) decideBranchAction ────────────────────────────────────────────────────
+
+// Regression: ensure the pure helper still produces all four expected outcomes
+// after the gather-layer changes introduced by the review-fixes pass.
+test("decideBranchAction regression: all four outcomes are stable", () => {
+	// Same branch → always proceed regardless of dirty/confirm
+	assert.equal(
+		decideBranchAction({ currentBranch: "feat", prHead: "feat", isDirty: true, userConfirm: false }),
+		"proceed",
+	);
+	// Mismatched + dirty → abort-dirty regardless of confirm
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feat", isDirty: true, userConfirm: true }),
+		"abort-dirty",
+	);
+	// Mismatched + clean + confirmed → switch
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feat", isDirty: false, userConfirm: true }),
+		"switch",
+	);
+	// Mismatched + clean + not confirmed → abort-cancelled
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feat", isDirty: false, userConfirm: false }),
+		"abort-cancelled",
+	);
+});
+
+test("decideBranchAction: on-head branch returns proceed", () => {
+	assert.equal(
+		decideBranchAction({ currentBranch: "feature/x", prHead: "feature/x", isDirty: false, userConfirm: false }),
+		"proceed",
+	);
+});
+
+test("decideBranchAction: mismatched branch with dirty tree returns abort-dirty", () => {
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feature/x", isDirty: true, userConfirm: false }),
+		"abort-dirty",
+	);
+});
+
+test("decideBranchAction: clean mismatch with user confirmation returns switch", () => {
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feature/x", isDirty: false, userConfirm: true }),
+		"switch",
+	);
+});
+
+test("decideBranchAction: clean mismatch with no confirmation returns abort-cancelled", () => {
+	assert.equal(
+		decideBranchAction({ currentBranch: "main", prHead: "feature/x", isDirty: false, userConfirm: false }),
+		"abort-cancelled",
+	);
+});

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -857,6 +857,10 @@ test("/review folder escapes snapshot fence lines found in file content", async 
 
 test("/review folder skips per-file lstat and binary-check failures while continuing", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-folder-problematic-");
+	if (process.getuid?.() === 0) {
+		t.skip("skipping unreadable-file permission test when running as root");
+		return;
+	}
 	const docsDir = join(cwd, "docs");
 	const unreadablePath = join(docsDir, "secret.txt");
 	mkdirSync(docsDir, { recursive: true });

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1,7 +1,115 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { buildReviewEnvelope, decideBranchAction, parseReviewArgs } from "../extensions/the-last-harness/review.ts";
+import {
+	buildReviewEnvelope,
+	decideBranchAction,
+	parseReviewArgs,
+	registerReviewCommand,
+} from "../extensions/the-last-harness/review.ts";
+
+/**
+ * @param {{
+ * 	cwd: string;
+ * 	exec: (command: string, args: string[], options: { cwd?: string }) => Promise<{ code: number; stdout: string; stderr: string }>;
+ * 	hasUI?: boolean;
+ * 	custom?: () => Promise<unknown> | unknown;
+ * 	editor?: (title: string, prefill?: string) => Promise<string | undefined> | string | undefined;
+ * }} params
+ */
+function createReviewHarness({ cwd, exec, hasUI = true, custom, editor }) {
+	let handler;
+	/** @type {Array<{ command: string; args: string[]; cwd?: string }>} */
+	const execCalls = [];
+	/** @type {Array<{ message: string; level: string }>} */
+	const notifications = [];
+	/** @type {string[]} */
+	const sentMessages = [];
+	/** @type {Array<{ title: string; prefill?: string }>} */
+	const editorCalls = [];
+	let customCallCount = 0;
+
+	registerReviewCommand({
+		registerCommand(name, command) {
+			if (name === "review") {
+				handler = command.handler;
+			}
+		},
+		exec: async (command, args, options) => {
+			execCalls.push({ command, args, cwd: options?.cwd });
+			return exec(command, args, options ?? {});
+		},
+		sendUserMessage(message) {
+			sentMessages.push(message);
+		},
+	});
+
+	assert.equal(typeof handler, "function", "review command should register a handler");
+
+	return {
+		handler,
+		execCalls,
+		notifications,
+		sentMessages,
+		editorCalls,
+		get customCallCount() {
+			return customCallCount;
+		},
+		ctx: {
+			cwd,
+			hasUI,
+			ui: {
+				notify(message, level) {
+					notifications.push({ message, level });
+				},
+				custom: async () => {
+					customCallCount += 1;
+					return custom ? custom() : true;
+				},
+				editor: async (title, prefill) => {
+					editorCalls.push({ title, prefill });
+					return editor ? editor(title, prefill) : undefined;
+				},
+			},
+		},
+	};
+}
+
+function makeTempDir(t, prefix) {
+	const cwd = mkdtempSync(join(tmpdir(), prefix));
+	t.after(() => {
+		rmSync(cwd, { force: true, recursive: true });
+	});
+	return cwd;
+}
+
+function assertRenderedPathLine(message, linePattern, expectedPath) {
+	const line = message.split("\n").find((candidate) => linePattern.test(candidate));
+	assert.ok(line, `expected a line matching ${linePattern}`);
+
+	const match = line.match(linePattern);
+	assert.ok(match, `expected a line matching ${linePattern}`);
+	assert.equal(JSON.parse(match[1]), expectedPath);
+}
+
+function assertNoStandaloneLine(message, unexpectedLine) {
+	assert.equal(
+		message.split("\n").includes(unexpectedLine),
+		false,
+		`should not render '${unexpectedLine}' as a standalone line`,
+	);
+}
+
+function assertStandaloneLineCount(message, expectedLine, expectedCount) {
+	assert.equal(
+		message.split("\n").filter((line) => line === expectedLine).length,
+		expectedCount,
+		`expected ${expectedCount} standalone '${expectedLine}' line(s)`,
+	);
+}
 
 // ─── (a) parseReviewArgs ───────────────────────────────────────────────────────
 
@@ -17,8 +125,8 @@ test("parseReviewArgs: branch mode with base", () => {
 	assert.deepEqual(parseReviewArgs(["branch", "main"]), { mode: "branch", base: "main", extra: undefined });
 });
 
-test("parseReviewArgs: branch mode without base yields undefined base", () => {
-	assert.deepEqual(parseReviewArgs(["branch"]), { mode: "branch", base: undefined, extra: undefined });
+test("parseReviewArgs: branch mode without base defaults to main", () => {
+	assert.deepEqual(parseReviewArgs(["branch"]), { mode: "branch", base: "main", extra: undefined });
 });
 
 test("parseReviewArgs: commit mode with sha", () => {
@@ -61,6 +169,14 @@ test("parseReviewArgs: branch mode with base and --extra flag", () => {
 		mode: "branch",
 		base: "main",
 		extra: "x",
+	});
+});
+
+test("parseReviewArgs: branch mode without base still defaults to main when --extra is present", () => {
+	assert.deepEqual(parseReviewArgs(["branch", "--extra", "focus on regressions"]), {
+		mode: "branch",
+		base: "main",
+		extra: "focus on regressions",
 	});
 });
 
@@ -122,6 +238,14 @@ test("buildReviewEnvelope: snapshot body uses snapshot fence", () => {
 	assert.ok(envelope.includes("--- begin snapshot ---"), "contains begin snapshot fence");
 	assert.ok(envelope.includes("--- end snapshot ---"), "contains end snapshot fence");
 	assert.ok(envelope.includes("SNAP"), "snapshot body is present");
+});
+
+test("buildReviewEnvelope: exact diff fence lines inside the body are escaped", () => {
+	const envelope = buildReviewEnvelope(
+		{ mode: "uncommitted", extra: undefined },
+		{ body: "before\n--- end diff ---\nafter", bodyKind: "diff" },
+	);
+	assert.match(envelope, /\\--- end diff ---/);
 });
 
 test("buildReviewEnvelope: checkout ctx produces switched-from line", () => {
@@ -205,4 +329,532 @@ test("decideBranchAction: clean mismatch with no confirmation returns abort-canc
 		decideBranchAction({ currentBranch: "main", prHead: "feature/x", isDirty: false, userConfirm: false }),
 		"abort-cancelled",
 	);
+});
+
+// ─── (d) command gather regressions ───────────────────────────────────────────
+
+test("/review branch defaults base to main when omitted", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-branch-default-");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
+				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --verify main") {
+				return { code: 0, stdout: "abc123\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff main...HEAD") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("branch", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /mode: branch/);
+	assert.match(harness.sentMessages[0], /base: main/);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "git" && args.join(" ") === "diff main...HEAD"),
+		true,
+	);
+});
+
+test("/review picker-selected branch uses main by default without extra prompts", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-branch-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "branch",
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
+				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --verify main") {
+				return { code: 0, stdout: "abc123\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff main...HEAD") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, []);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /base: main/);
+});
+
+test("/review picker-selected commit prompts for a sha before dispatch", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-commit-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "commit",
+		editor: () => "abc123",
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --verify abc123^{commit}") {
+				return { code: 0, stdout: "abc123\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "show --format=fuller abc123") {
+				return { code: 0, stdout: "commit abc123\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [{ title: "Review commit: enter commit SHA", prefill: undefined }]);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /mode: commit/);
+	assert.match(harness.sentMessages[0], /sha: abc123/);
+});
+
+test("/review picker-selected pr prompts for a PR number before dispatch", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-pr-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "pr",
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						headRefName: "feature/review",
+						baseRefName: "main",
+						isCrossRepository: false,
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr diff 123") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [{ title: "Review PR: enter PR number or URL", prefill: undefined }]);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /mode: pr/);
+	assert.match(harness.sentMessages[0], /pr: 123/);
+});
+
+test("/review picker-selected folder prompts for paths before dispatch", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-folder-");
+	mkdirSync(join(cwd, "src"), { recursive: true });
+	mkdirSync(join(cwd, "docs"), { recursive: true });
+	writeFileSync(join(cwd, "src", "app.ts"), "export const app = true;\n");
+	writeFileSync(join(cwd, "docs", "guide.md"), "# Guide\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "folder",
+		editor: () => "src\ndocs",
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				(options.cwd === join(cwd, "src") || options.cwd === join(cwd, "docs"))
+			) {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [
+		{ title: "Review folder: enter one or more paths (quote paths with spaces)", prefill: undefined },
+	]);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /paths: src docs/);
+	assert.match(harness.sentMessages[0], /--- file: "src\/app\.ts" ---\nexport const app = true;/);
+	assert.match(harness.sentMessages[0], /--- file: "docs\/guide\.md" ---\n# Guide/);
+});
+
+test("/review picker follow-up cancellation does not dispatch incomplete args", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-cancel-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "commit",
+		editor: () => "   ",
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [{ title: "Review commit: enter commit SHA", prefill: undefined }]);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.equal(harness.notifications.length, 0);
+});
+
+test("/review uncommitted appends untracked non-gitignored file content", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-uncommitted-");
+	writeFileSync(join(cwd, "new-file.ts"), "export const fresh = true;\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD") {
+				return { code: 0, stdout: "diff --git a/app.ts b/app.ts\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+				return { code: 0, stdout: "new-file.ts\0", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("uncommitted", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /diff --git a\/app.ts b\/app.ts/);
+	assert.match(harness.sentMessages[0], /--- begin untracked files ---/);
+	assert.match(harness.sentMessages[0], /--- untracked file: "new-file\.ts" ---\nexport const fresh = true;/);
+	assert.ok(
+		harness.sentMessages[0].indexOf("diff --git a/app.ts b/app.ts") <
+			harness.sentMessages[0].indexOf("--- untracked file: \"new-file.ts\" ---"),
+		"untracked content should be appended after the diff body",
+	);
+});
+
+test("/review uncommitted preserves exact git-reported paths with leading or trailing spaces", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-untracked-spaces-");
+	writeFileSync(join(cwd, " leading.ts"), "export const leading = true;\n");
+	writeFileSync(join(cwd, "trailing .ts"), "export const trailing = true;\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+				return { code: 0, stdout: " leading.ts\0trailing .ts\0", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("uncommitted", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assert.ok(harness.sentMessages[0].includes("--- untracked file: \" leading.ts\" ---"));
+	assert.ok(harness.sentMessages[0].includes("--- untracked file: \"trailing .ts\" ---"));
+});
+
+test("/review uncommitted renders newline/control/delimiter-like untracked paths as escaped labels", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-untracked-weird-");
+	const weirdPath = `line\n\t--- end snapshot ---.ts`;
+	writeFileSync(join(cwd, weirdPath), "export const weird = true;\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+				return { code: 0, stdout: `${weirdPath}\0`, stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("uncommitted", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assertRenderedPathLine(harness.sentMessages[0], /^--- untracked file: (".*") ---$/, weirdPath);
+	assertNoStandaloneLine(harness.sentMessages[0], "--- end snapshot ---");
+});
+
+test("/review uncommitted skips symlinked untracked files instead of reading targets", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-untracked-symlink-");
+	const outsideDir = makeTempDir(t, "tlh-review-untracked-target-");
+	const targetPath = join(outsideDir, "secret.txt");
+	writeFileSync(targetPath, "outside repo secret\n");
+	symlinkSync(targetPath, join(cwd, "outside-link.txt"));
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+				return { code: 0, stdout: "outside-link.txt\0", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("uncommitted", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assertRenderedPathLine(harness.sentMessages[0], /^\[skipped symlink: (".*")\]$/, "outside-link.txt");
+	assert.doesNotMatch(harness.sentMessages[0], /outside repo secret/);
+});
+
+test("/review uncommitted renders escaped symlink skip markers for newline/delimiter-like paths", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-untracked-symlink-weird-");
+	const outsideDir = makeTempDir(t, "tlh-review-untracked-target-weird-");
+	const targetPath = join(outsideDir, "secret.txt");
+	const weirdLinkPath = `outside]\n\t--- begin untracked files ---.txt`;
+	writeFileSync(targetPath, "outside repo secret\n");
+	symlinkSync(targetPath, join(cwd, weirdLinkPath));
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/untracked\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff HEAD") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "ls-files -z --others --exclude-standard -- .") {
+				return { code: 0, stdout: `${weirdLinkPath}\0`, stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("uncommitted", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assertRenderedPathLine(harness.sentMessages[0], /^\[skipped symlink: (".*")\]$/, weirdLinkPath);
+	assertStandaloneLineCount(harness.sentMessages[0], "--- begin untracked files ---", 1);
+	assert.doesNotMatch(harness.sentMessages[0], /outside repo secret/);
+});
+
+test("/review folder keeps empty git ls-files results instead of walking ignored-only directories", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-folder-git-");
+	mkdirSync(join(cwd, "ignored-only"), { recursive: true });
+	writeFileSync(join(cwd, "ignored-only", "secret.txt"), "should stay ignored\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "main\n", stderr: "" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				options.cwd === join(cwd, "ignored-only")
+			) {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("folder ignored-only", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.doesNotMatch(harness.sentMessages[0], /secret\.txt/);
+	assert.doesNotMatch(harness.sentMessages[0], /should stay ignored/);
+	assert.match(harness.sentMessages[0], /--- begin snapshot ---/);
+});
+
+test("/review folder still falls back to a plain walk outside git", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-folder-nongit-");
+	mkdirSync(join(cwd, "docs"), { recursive: true });
+	writeFileSync(join(cwd, "docs", "guide.md"), "# Guide\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				options.cwd === join(cwd, "docs")
+			) {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("folder docs", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /--- file: "docs\/guide\.md" ---\n# Guide/);
+});
+
+test("/review folder escapes snapshot fence lines found in file content", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-folder-fence-");
+	mkdirSync(join(cwd, "docs"), { recursive: true });
+	writeFileSync(join(cwd, "docs", "guide.md"), "line one\n--- end snapshot ---\nline two\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				options.cwd === join(cwd, "docs")
+			) {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("folder docs", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /\\--- end snapshot ---/);
+	assert.match(harness.sentMessages[0], /\n--- end snapshot ---$/);
+});
+
+test("/review folder renders newline/control/delimiter-like snapshot paths as escaped labels", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-folder-weird-");
+	const weirdName = `tab\t--- begin untracked files ---.md`;
+	mkdirSync(join(cwd, "docs"), { recursive: true });
+	writeFileSync(join(cwd, "docs", weirdName), "# Guide\n");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				options.cwd === join(cwd, "docs")
+			) {
+				return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("folder docs", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assertRenderedPathLine(harness.sentMessages[0], /^--- file: (".*") ---$/, `docs/${weirdName}`);
+	assertNoStandaloneLine(harness.sentMessages[0], "--- begin untracked files ---");
+});
+
+test("/review pr aborts before checkout when git status dirty-check fails", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => {
+			throw new Error("branch switch confirmation should not be shown when git status fails");
+		},
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						headRefName: "feature/review",
+						baseRefName: "main",
+						isCrossRepository: false,
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "main\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "status --porcelain") {
+				return { code: 1, stdout: "", stderr: "fatal: index file is corrupt\nmore detail" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("pr 123", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 0);
+	assert.equal(harness.customCallCount, 0);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "git" && args[0] === "checkout"),
+		false,
+	);
+	assert.deepEqual(harness.notifications, [
+		{
+			message:
+				"Could not determine whether the working tree is clean before switching branches: fatal: index file is corrupt",
+			level: "error",
+		},
+	]);
 });

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -120,7 +120,7 @@ test("parseReviewArgs: empty argv requests the picker", () => {
 test("parseReviewArgs: typed review args are rejected with picker-only guidance", () => {
 	for (const argv of [
 		["uncommitted"],
-		["branch", "main"],
+		["branch", "feature/parent"],
 		["commit", "abc123"],
 		["pr", "42"],
 		["folder", "src"],
@@ -291,7 +291,7 @@ test("/review rejects typed shortcuts and does not open the picker", async (t) =
 
 	for (const input of [
 		"uncommitted",
-		"branch main",
+		"branch feature/parent",
 		"commit abc123",
 		"pr 123",
 		"folder src",
@@ -337,12 +337,13 @@ test("/review without TUI fails clearly because the picker is required", async (
 	]);
 });
 
-test("/review picker-selected branch uses main by default without extra prompts", async (t) => {
+test("/review picker-selected branch prompts for a base and defaults blank input to main", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-picker-branch-");
 
 	const harness = createReviewHarness({
 		cwd,
 		custom: () => "branch",
+		editor: () => "   ",
 		exec: async (command, args) => {
 			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
 				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
@@ -363,11 +364,109 @@ test("/review picker-selected branch uses main by default without extra prompts"
 	await harness.handler("", harness.ctx);
 
 	assert.equal(harness.customCallCount, 1);
-	assert.deepEqual(harness.editorCalls, []);
+	assert.deepEqual(harness.editorCalls, [
+		{
+			title: "Review branch: enter base branch (blank defaults to main)",
+			prefill: "main",
+		},
+	]);
 	assert.equal(harness.sentMessages.length, 1);
 	assert.match(harness.sentMessages[0], /base: main/);
 });
 
+test("/review picker-selected branch uses a non-empty prompted base", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-branch-custom-base-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "branch",
+		editor: () => "feature/parent",
+		exec: async (command, args) => {
+			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
+				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --verify feature/parent") {
+				return { code: 0, stdout: "def456\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "diff feature/parent...HEAD") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [
+		{
+			title: "Review branch: enter base branch (blank defaults to main)",
+			prefill: "main",
+		},
+	]);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /base: feature\/parent/);
+});
+
+test("/review picker-selected branch cancellation aborts without dispatch", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-picker-branch-cancel-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "branch",
+		editor: () => undefined,
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [
+		{
+			title: "Review branch: enter base branch (blank defaults to main)",
+			prefill: "main",
+		},
+	]);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.equal(harness.notifications.length, 0);
+});
+
+test("/review picker-selected branch rejects a leading-dash base before git use", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-branch-leading-dash-");
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => "branch",
+		editor: () => "-feature/parent",
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.customCallCount, 1);
+	assert.deepEqual(harness.editorCalls, [
+		{
+			title: "Review branch: enter base branch (blank defaults to main)",
+			prefill: "main",
+		},
+	]);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "base cannot start with '-' (got '-feature/parent'). If this is intentional, run the underlying command manually.",
+			level: "error",
+		},
+	]);
+});
 
 test("/review picker-selected commit rejects a leading-dash sha before git use", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-commit-leading-dash-");

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -11,6 +11,29 @@ import {
 	registerReviewCommand,
 } from "../extensions/the-last-harness/review.ts";
 
+const reviewEnvRoot = mkdtempSync(join(tmpdir(), "tlh-review-agent-env-"));
+const reviewEnvHome = join(reviewEnvRoot, "home");
+const reviewEnvAgent = join(reviewEnvRoot, "agent");
+const previousReviewPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+const previousReviewHome = process.env.HOME;
+mkdirSync(reviewEnvHome, { recursive: true });
+mkdirSync(reviewEnvAgent, { recursive: true });
+process.env.PI_CODING_AGENT_DIR = reviewEnvAgent;
+process.env.HOME = reviewEnvHome;
+process.on("exit", () => {
+	rmSync(reviewEnvRoot, { force: true, recursive: true });
+	if (previousReviewPiAgentDir === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = previousReviewPiAgentDir;
+	}
+	if (previousReviewHome === undefined) {
+		delete process.env.HOME;
+	} else {
+		process.env.HOME = previousReviewHome;
+	}
+});
+
 /**
  * @param {{
  * 	cwd: string;
@@ -18,9 +41,10 @@ import {
  * 	hasUI?: boolean;
  * 	custom?: () => Promise<unknown> | unknown;
  * 	editor?: (title: string, prefill?: string) => Promise<string | undefined> | string | undefined;
+ * 	branchEntries?: unknown[];
  * }} params
  */
-function createReviewHarness({ cwd, exec, hasUI = true, custom, editor }) {
+function createReviewHarness({ cwd, exec, hasUI = true, custom, editor, branchEntries = [] }) {
 	let handler;
 	/** @type {Array<{ command: string; args: string[]; cwd?: string }>} */
 	const execCalls = [];
@@ -61,6 +85,9 @@ function createReviewHarness({ cwd, exec, hasUI = true, custom, editor }) {
 		ctx: {
 			cwd,
 			hasUI,
+			sessionManager: {
+				getBranch: () => branchEntries,
+			},
 			ui: {
 				notify(message, level) {
 					notifications.push({ message, level });
@@ -84,6 +111,40 @@ function makeTempDir(t, prefix) {
 		rmSync(cwd, { force: true, recursive: true });
 	});
 	return cwd;
+}
+
+function makePrimaryFixture(t, prefix) {
+	const dir = makeTempDir(t, prefix);
+	const home = join(dir, "home");
+	const agent = join(dir, "agent");
+	const cwd = join(dir, "workspace");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(agent, { recursive: true });
+	mkdirSync(cwd, { recursive: true });
+	return { dir, home, agent, cwd };
+}
+
+async function withEnv(env, fn) {
+	const previous = new Map();
+	for (const key of Object.keys(env)) {
+		previous.set(key, process.env[key]);
+		if (env[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = env[key];
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
 }
 
 function assertRenderedPathLine(message, linePattern, expectedPath) {
@@ -332,6 +393,64 @@ test("/review without TUI fails clearly because the picker is required", async (
 	assert.deepEqual(harness.notifications, [
 		{
 			message: "/review requires the interactive TUI picker. Re-run /review in the TLH UI.",
+			level: "error",
+		},
+	]);
+});
+
+
+test("/review still opens the picker when the architect primary agent is active", async (t) => {
+	const fixture = makePrimaryFixture(t, "tlh-review-architect-primary-");
+	const harness = createReviewHarness({
+		cwd: fixture.cwd,
+		branchEntries: [
+			{ type: "custom", customType: "tlh-primary-agent-state", data: { selected: "architect" } },
+		],
+		custom: () => undefined,
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		await harness.handler("", harness.ctx);
+	});
+
+	assert.equal(harness.customCallCount, 1);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, []);
+});
+
+
+test("/review blocks non-architect primary mode before opening the picker or gathering diffs", async (t) => {
+	const fixture = makePrimaryFixture(t, "tlh-review-rush-primary-");
+	writeFileSync(
+		join(fixture.agent, "settings.json"),
+		`${JSON.stringify({ tlh: { primaryAgent: { enabled: true, selected: "rush" } } }, null, 2)}\n`,
+	);
+
+	const harness = createReviewHarness({
+		cwd: fixture.cwd,
+		custom: () => {
+			throw new Error("picker should not open outside architect mode");
+		},
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		await harness.handler("", harness.ctx);
+	});
+
+	assert.equal(harness.customCallCount, 0);
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message:
+				"/review only works while the architect primary agent is active. Current primary agent: rush. Switch to architect with /switch-primary-agent architect (or Shift+Tab), then rerun /review.",
 			level: "error",
 		},
 	]);

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -398,6 +398,86 @@ test("/review picker-selected branch uses main by default without extra prompts"
 	assert.match(harness.sentMessages[0], /base: main/);
 });
 
+
+test("/review branch rejects a leading-dash base before using it as a git ref", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-branch-leading-dash-");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			assert.equal(args.includes("-main"), false, "should reject before passing -main to git");
+			if (command === "git" && args.join(" ") === "symbolic-ref -q HEAD") {
+				return { code: 0, stdout: "refs/heads/feature/review\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("branch -main", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "base cannot start with '-' (got '-main'). If this is intentional, run the underlying command manually.",
+			level: "error",
+		},
+	]);
+	assert.equal(
+		harness.execCalls.some(({ args }) => args.includes("-main")),
+		false,
+		"should not pass the leading-dash base to git",
+	);
+});
+
+
+test("/review commit rejects a leading-dash sha before git use", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-commit-leading-dash-");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("commit -abc123", harness.ctx);
+
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "sha cannot start with '-' (got '-abc123'). If this is intentional, run the underlying command manually.",
+			level: "error",
+		},
+	]);
+});
+
+
+test("/review pr rejects a leading-dash ref before gh use", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-leading-dash-");
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args) => {
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("pr -42", harness.ctx);
+
+	assert.equal(harness.execCalls.length, 0);
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "pr cannot start with '-' (got '-42'). If this is intentional, run the underlying command manually.",
+			level: "error",
+		},
+	]);
+});
+
 test("/review picker-selected commit prompts for a sha before dispatch", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-picker-commit-");
 
@@ -772,6 +852,53 @@ test("/review folder escapes snapshot fence lines found in file content", async 
 	assert.equal(harness.sentMessages.length, 1);
 	assert.match(harness.sentMessages[0], /\\--- end snapshot ---/);
 	assert.match(harness.sentMessages[0], /\n--- end snapshot ---$/);
+});
+
+
+test("/review folder skips per-file lstat and binary-check failures while continuing", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-folder-problematic-");
+	const docsDir = join(cwd, "docs");
+	const unreadablePath = join(docsDir, "secret.txt");
+	mkdirSync(docsDir, { recursive: true });
+	writeFileSync(join(docsDir, "guide.md"), "# Guide\n");
+	writeFileSync(unreadablePath, "top secret\n");
+	chmodSync(unreadablePath, 0o000);
+	t.after(() => {
+		try {
+			chmodSync(unreadablePath, 0o600);
+		} catch {
+			// Ignore cleanup failures if the temp directory is already gone.
+		}
+	});
+
+	const harness = createReviewHarness({
+		cwd,
+		exec: async (command, args, options) => {
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "main\n", stderr: "" };
+			}
+			if (
+				command === "git" &&
+				args.join(" ") === "ls-files -z --cached --others --exclude-standard -- ." &&
+				options.cwd === docsDir
+			) {
+				return { code: 0, stdout: "missing.md\0secret.txt\0guide.md\0", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")} @ ${options.cwd ?? ""}`);
+		},
+	});
+
+	await harness.handler("folder docs", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assertRenderedPathLine(harness.sentMessages[0], /^\[skipped lstat failure: (".*")\]$/, "docs/missing.md");
+	assertRenderedPathLine(
+		harness.sentMessages[0],
+		/^\[skipped binary detection failure: (".*")\]$/,
+		"docs/secret.txt",
+	);
+	assert.match(harness.sentMessages[0], /--- file: "docs\/guide\.md" ---\n# Guide/);
 });
 
 test("/review folder renders newline/control/delimiter-like snapshot paths as escaped labels", async (t) => {

--- a/tests/tlh-ticket-docs-static.test.mjs
+++ b/tests/tlh-ticket-docs-static.test.mjs
@@ -62,6 +62,7 @@ test("README and integrations docs describe Rush primary behavior and switching 
 	assert.match(readme, /Anthropic Opus with low thinking on Anthropic/i);
 	assert.match(readme, /`architect` → `rush` → `product` → `bug-hunter` → `disabled`/);
 	assert.match(readme, /\/switch-primary-agent \[status\|architect\|rush\|product\|bug-hunter\|disabled\|reset\|default architect\|default rush\|default product\|default bug-hunter\|default disabled\|default reset\]/);
+	assert.match(readme, /`\/review` is architect-only/i);
 	assert.doesNotMatch(readme, /`\/tlh(?=`| \[)/);
 	assert.doesNotMatch(readme, /`\/harness(?=`| \[)/);
 	assert.doesNotMatch(readme, /`\/agent(?=`| \[)/);


### PR DESCRIPTION
## Summary

Adds a `/review` slash command to tlh that lets the user pick what to review and delegates the actual review to the `code-reviewer` subagent in a fresh isolated context. The architect interprets the findings critically before presenting a digested summary to the user.

## Modes

- `/review` — interactive picker
- `/review uncommitted`
- `/review branch <base>`
- `/review commit <sha>`
- `/review pr <n|url>`
- `/review folder <path...>`

All modes accept an optional `--extra "..."` focus note.

## PR-mode safety

- Requires the `gh` CLI; cross-repo PRs are refused for now.
- If the working tree is dirty and the user isn't on the PR head, the command refuses (no auto-stash, no surprise mutation).
- If the tree is clean, the command asks before switching, and prints a `git checkout -` reminder so the user can return.

## Handoff contract

The command emits a structured envelope whose first line is exactly `[/review]`. `agents/primary/architect.md` gains a new `/review handoff` section that instructs the architect to:

1. Skip session-startup discovery and the normal clarify → plan → tickets flow when `[/review]` opens a turn.
2. Delegate to `code-reviewer` in a fresh isolated context.
3. Critically evaluate the findings — push back on weak ones, confirm strong ones — rather than relaying the raw transcript.
4. Return to normal architect mode after the digested summary (no `/end-review`).

## Other details

- Large diffs (>~200 KB) emit a one-time `warning` notification but never block.
- Leading-dash user input (`base`, `sha`, `pr <ref>`) is rejected up front to avoid being misread as git/gh flags.
- Folder mode includes tracked + untracked-but-not-gitignored files; binary files are skipped with a marker; the non-git fallback walker skips `node_modules` and dotfile directories.

## Validation

`npm run validate` — 330/330 tests pass, lint clean, installer smoke clean, pack dry-run clean. 24 new tests cover `parseReviewArgs`, `buildReviewEnvelope`, and `decideBranchAction`.

## Files

- `extensions/the-last-harness/review.ts` (new)
- `extensions/the-last-harness.ts` (wires registration)
- `agents/primary/architect.md` (new `/review handoff` section)
- `README.md` (new `Reviewing changes (/review)` section)
- `CHANGELOG.md` (Unreleased entry)
- `tests/review.test.mjs` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/review` interactive command with five review scopes (uncommitted, branch, commit, PR, folder); only picker-driven invocation supported. PR mode may prompt before switching branches and uses the GitHub CLI when available. Reviews run in an isolated review context; the architect returns a digested summary (no raw transcript).  

* **Documentation**
  * README and changelog document invocation, modes, folder-snapshot rules, skipped-binary handling, and a one-time large-diff (~200 KB) warning.

* **Tests**
  * New test suite for argument parsing, envelope formatting, branch-decision flows, file/folder handling, PR flows, and end-to-end review interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->