### PR TITLE
Add token optimization follow-up tickets

### DIFF
--- a/.tickets/tlhf-dn7h.md
+++ b/.tickets/tlhf-dn7h.md
@@ -1,0 +1,27 @@
+---
+id: tlhf-dn7h
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:05Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+tags: [token-optimization, subagents, prompt]
+---
+# Reduce redundant review and oracle fan-out
+
+Tighten TLH orchestration guidance to reduce redundant review/oracle fan-out while preserving safety. Investigation tlhf-obvs found classified child review/oracle spend was $15.176 (74.2% of classified child spend), with conservative reducible overlap of about $4.5 (22%) from repeated full-branch rereads and duplicate oracle/reviewer scopes. The goal is not to reduce high-risk installer or trust-boundary safety review; it is to make follow-ups delta-only and avoid multiple agents reviewing the same full diff without disjoint scope.
+
+## Design
+
+Likely touchpoints: agents/primary/architect.md and any packaged primary-agent guidance. Preserve explicit carve-outs for destructive installer/path deletion, trust-boundary, execution, auth, or unresolved disagreement cases. Parallel reviewers should be allowed only with disjoint scopes. Oracle should remain available for high-uncertainty/high-blast-radius work, but default to one oracle per branch unless the threat model materially changes.
+
+## Acceptance Criteria
+
+- Architect/orchestration guidance defaults to one reviewer for normal code changes.
+- Oracle use is reserved for trust-boundary, destructive-path, auth/execution, unresolved disagreement, or durable uncertainty cases, with one oracle per branch by default.
+- Follow-up reviews after fixes default to delta-only scope.
+- Guidance preserves targeted safety re-reviews and one final whole-branch review for high-risk installer/destructive-path work when warranted.
+- Guidance discourages multiple reviewers/oracles over the same full `main...HEAD` diff unless scopes are explicitly disjoint.
+

--- a/.tickets/tlhf-drxp.md
+++ b/.tickets/tlhf-drxp.md
@@ -1,0 +1,27 @@
+---
+id: tlhf-drxp
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:05Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+tags: [rtk, tools, correctness]
+---
+# Guard pi-rtk complex find rewrites
+
+Prevent TLH pi-rtk from rewriting complex native `find` expressions into unsupported `rtk find` commands. Investigation tlhf-45se reproduced real failures where grouped predicates, negation, actions, and control flags were rewritten and then failed or silently drifted (for example `-quit` ignored). Simple `find` rewrites can still be valuable; complex native forms should pass through unchanged. This is primarily a correctness fix that also prevents retries and extra transcript churn.
+
+## Design
+
+The change likely belongs in the TLH pi-rtk fork first, then TLH should update its bundled default extension source/tag if needed. Do not rely on `rtk rewrite` exit code alone; supported rewrites returned mixed exit codes in investigation. Prefer a conservative guard that special-cases original commands beginning with native `find` and skips rewrite when known-unsafe tokens/patterns appear: grouping, `-o`, `-or`, `-not`, `!`, `-exec`, `-print0`, `-prune`, `-quit`, and similar behavior-changing actions/control flags. Preserve `/usr/bin/find ...` and `RTK_DISABLED=1 find ...` bypasses.
+
+## Acceptance Criteria
+
+- Simple supported native `find` forms still rewrite through RTK and run successfully.
+- Complex native `find` forms with grouped predicates, boolean operators, negation, actions, print0/prune/quit/control flags are left as native `find`.
+- `/usr/bin/find ...` and `RTK_DISABLED=1 find ...` remain passthrough/bypass-safe.
+- Tests or a documented rewrite matrix cover at least one positive rewrite and several complex passthrough cases.
+- If the pi-rtk fork tag changes, TLH default-extension configuration and release notes/docs are updated accordingly.
+

--- a/.tickets/tlhf-hc2q.md
+++ b/.tickets/tlhf-hc2q.md
@@ -1,0 +1,28 @@
+---
+id: tlhf-hc2q
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:05Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+tags: [token-optimization, sessions, feature]
+---
+# Add read-only tlh sessions audit helper
+
+Add a read-only TLH-native session audit helper so session analysis can start from compact aggregates instead of raw JSONL transcript reads. Investigation tlhf-oz75 recommended `tlh sessions audit` after measuring a current corpus of 62 session JSONLs, ~74.8M recorded total tokens, and ~8.58M chars of tool-result text. Tool output dominated visible text, and raw session JSONL is expensive because each line is a large JSON object. RTK session/discover is not the right surface because it is Claude-format oriented.
+
+## Design
+
+Likely implementation: a new script such as scripts/tlh-sessions.mjs exposed by the wrapper as `tlh sessions audit`. Parse session JSONL streaming line-by-line from the isolated agent dir. Group a logical session tree as the root `<timestamp>_<id>.jsonl` plus child `run-*/session.jsonl` files. Defaults should be privacy-safe: current cwd/recent window when possible, aggregate-only, no prompts/prose/tool bodies/thinking/signatures/compaction summaries. Support text and JSON output.
+
+## Acceptance Criteria
+
+- `tlh sessions audit` (or equivalent approved subcommand) is read-only and operates on the isolated TLH profile, never normal Pi config.
+- Default output summarizes session trees rather than treating nested child run files as independent top-level sessions.
+- Default scope is bounded and privacy-safe (for example current cwd and recent window) and prints aggregate-only metrics.
+- Output includes token/cost totals, provider/model mix if available, top tools, tool-result char counts, and optional child-run summaries.
+- JSON mode is supported and omits transcript content by default.
+- Tests/fixtures cover session-tree grouping, aggregate fields, text output, JSON output, and no-content defaults.
+

--- a/.tickets/tlhf-kk5w.md
+++ b/.tickets/tlhf-kk5w.md
@@ -1,0 +1,26 @@
+---
+id: tlhf-kk5w
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:05Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+tags: [rtk, docs, sessions]
+---
+# Document RTK reporting limits for TLH sessions
+
+Clarify RTK reporting boundaries for TLH sessions. Investigation tlhf-2820 found `rtk session` / `rtk discover` are built around Claude Code session files under `~/.claude/projects` and hook-success metadata, not TLH/Pi session JSONL under `~/.the-last-harness/agent/sessions`. Path-remapping TLH sessions into a fake Claude root still yielded 0 bash commands and risks exposing isolated transcripts. `rtk gain --project --history` already captures local RTK savings for TLH usage via RTK history.
+
+## Design
+
+This can be a docs-only ticket unless the sessions audit helper adds its own RTK note. Do not recommend symlinking/copying TLH sessions into `~/.claude/projects`; that is inaccurate and weakens isolation. Position `rtk gain --project --history` as the current savings/adoption evidence source, and position `tlh sessions audit` as the future transcript aggregate surface.
+
+## Acceptance Criteria
+
+- TLH docs explain that `rtk session` / `rtk discover` are Claude-session oriented and do not currently provide trustworthy TLH session reporting.
+- Docs recommend `rtk gain --project --history` for local TLH RTK savings evidence.
+- Docs explicitly avoid recommending symlinking/copying TLH sessions into Claude session directories.
+- If `tlh sessions audit` exists by implementation time, docs explain how it complements RTK gain reporting.
+

--- a/.tickets/tlhf-ncoz.md
+++ b/.tickets/tlhf-ncoz.md
@@ -1,0 +1,27 @@
+---
+id: tlhf-ncoz
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:04Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+tags: [token-optimization, tools, prompt]
+---
+# Add TLH tool-budget guardrails
+
+Add explicit TLH tool-budget guardrails for investigation and review workflows. Investigation tlhf-sn9r found tool results were 98.3% of visible transcript chars, and `bash` + `read` + `grep` produced 98.3% of tool-output chars. The largest waste patterns were broad `grep` (`path='.'`, no glob, `limit=200`, context), whole-file/long-line `read` (especially session JSONL), and raw `bash` diffs/log/API dumps. Investigation tlhf-oz75 also found session analysis should be aggregate-first.
+
+## Design
+
+Likely touchpoints: config/APPEND_SYSTEM.md, extensions/the-last-harness/constants.ts, prompts/analyse-tlh-sessions.md, and any agent prompts that steer repository investigation. Prefer guidance and safer TLH-native surfaces before changing upstream-style tool transport caps. Include proactive temp-file summary patterns for commands expected to produce large output.
+
+## Acceptance Criteria
+
+- Guidance gives numeric starting defaults: `grep` with explicit path+glob, `limit<=20`, `context<=1`; `read` with explicit offset and `limit<=120`; `bash` favoring summaries/counts/stats over raw bodies.
+- `/analyse-tlh-sessions` tells agents to prefer streaming JSONL parsers/aggregate summaries over raw transcript `read`/`grep`.
+- Guidance warns that TLH session JSONL has long lines and should not be broadly read by default.
+- Guidance includes a proactive temp-file-first shell pattern for large outputs and cleanup/privacy notes.
+- Validation confirms updated prompts/docs contain the guardrails and examples.
+

--- a/.tickets/tlhf-oxgl.md
+++ b/.tickets/tlhf-oxgl.md
@@ -1,0 +1,27 @@
+---
+id: tlhf-oxgl
+status: open
+deps: []
+links: []
+created: 2026-05-28T05:45:04Z
+type: task
+priority: 1
+assignee: Diego Petrucci
+tags: [token-optimization, gnosis, prompt]
+---
+# Embed concise Gnosis workflow guidance
+
+Replace the current unconditional full-output Gnosis help workflow with concise TLH-owned guidance plus an explicit full-help fallback. Investigation tlhf-jl51 found repeated `gn help plan` / `gn help review` output was the clearest single token waste source: about 46k direct tokens and about 1.90M recirculated/context tokens in observed TLH sessions. Suppressed historical calls (`gn help ... >/dev/null && echo ok`) reduced visible payload by ~99.9%, but suppression is safe only if the required guidance is already summarized in context.
+
+## Design
+
+Likely touchpoints: AGENTS.md repo guidance and packaged primary-agent/system guidance where TLH currently requires full `gn help plan` / `gn help review` every task. Preserve the intent: agents must still use Gnosis for relevant memory search/recording and must be able to read the full doctrine when uncertain, missing, or stale. Avoid making the full Gnosis text an always-on prompt dump. Do not weaken the Gnosis requirement itself.
+
+## Acceptance Criteria
+
+- TLH repo/agent guidance includes a concise authoritative summary of required Gnosis plan/review behavior.
+- Unconditional instructions that dump full `gn help plan` / `gn help review` output every session are removed or narrowed.
+- Guidance explicitly keeps full `gn help ...` as a fallback when uncertain, when the summary is missing, or when Gnosis behavior changes.
+- If a bookkeeping command is still required, guidance uses a bounded/suppressed form rather than adding the full help text to transcript context.
+- Tests or targeted prompt checks cover the updated wording.
+


### PR DESCRIPTION
## Summary

Adds implementation-ready `tk` tickets for the token/session/RTK optimization follow-ups identified in the TLH session review.

## Tickets added

- `tlhf-oxgl` — Embed concise Gnosis workflow guidance
- `tlhf-ncoz` — Add TLH tool-budget guardrails
- `tlhf-dn7h` — Reduce redundant review and oracle fan-out
- `tlhf-hc2q` — Add read-only `tlh sessions audit` helper
- `tlhf-drxp` — Guard pi-rtk complex find rewrites
- `tlhf-kk5w` — Document RTK reporting limits for TLH sessions

## Notes

- These are planning/task-tracking artifacts only; no runtime code changes.
- Tickets include investigation context, design notes, and acceptance criteria.

## Validation

- Reviewed staged diff for the new ticket files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal task documentation outlining planned platform improvements, including session audit capabilities, review workflow guidance, tool usage constraints, and help system refinements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diegopetrucci/the-last-harness/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->