### PR TITLE
Add concise Gnosis workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ git diff --cached
 
 ## Miscellaneous
 
-- At the start of any task, run `gn help plan` and follow its instructions.
+- Before implementation, use or load the packaged `tlh-gnosis-workflow` skill at `skills/tlh-gnosis-workflow/SKILL.md`. Search relevant keywords with `OR`, read the relevant hits, and surface conflicts early. If your role is allowed to run `gn` and that summary is missing, stale, conflicting, or you are uncertain, read full `gn help plan`. If your role forbids `gn` (for example, child subagents), do not run Gnosis commands; report durable findings to the parent agent or supervisor instead.
 - Before final handoff or review for TLH repository work, load and apply the repo-local hygiene skill at `.pi/skills/tlh-dev-hygiene/SKILL.md`.
 - The `tlh-dev-hygiene` checklist is for TLH repository contributors only; it is not part of the packaged end-user tlh workflow.
-- After finishing a task, run `gn help review`.
+- During review or handoff, follow the packaged Gnosis workflow skill's durable-memory guidance. If your role is allowed to run `gn` and that summary is missing, stale, conflicting, or you are uncertain, read full `gn help review`. If your role forbids `gn` (for example, child subagents), do not run Gnosis commands; report durable findings to the parent agent or supervisor instead.
 - This project uses a CLI ticket system for task management. Run `tk help` when you need to use it.

--- a/README.md
+++ b/README.md
@@ -91,12 +91,7 @@ Opt-outs are written to `~/.the-last-harness/agent/settings.json` and survive `t
 
 TLH also requires the `tk` ticket CLI for architect/product ticket workflows. If no valid configured or existing `tk` command is found, install and update flows install the pinned managed copy at `~/.the-last-harness/agent/bin/tk`.
 
-When a valid `gn` binary is present, TLH appends these instructions to the system prompt:
-
-```text
-At the start of any task, run `gn help plan` and follow its instructions.
-After finishing a task, run `gn help review`.
-```
+When a valid `gn` binary is present, TLH appends concise Gnosis workflow guidance to the system prompt. It tells agents to use or load the packaged `tlh-gnosis-workflow` skill (`skills/tlh-gnosis-workflow/SKILL.md`) for keyword-first memory search, conflict checks, durable-memory write rules, and review-time checks. It keeps full `gn help plan` and `gn help review` as fallbacks when the summary is missing, stale, conflicting, or the agent is uncertain.
 
 Gnosis project data lives in repo-local `.gnosis` directories and ticket data lives in repo-local `.tickets` directories; TLH does not delete either. More integration details live in [`docs/integrations.md`](docs/integrations.md).
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -6,12 +6,7 @@ TLH includes managed integrations for project memory and ticketed workflows. Gno
 
 [Gnosis](https://github.com/skorokithakis/gnosis) is a small `gn` CLI for recording project decisions, constraints, rejected alternatives, and lessons that are not obvious from code alone. On supported platforms (linux/darwin × x64/arm64), TLH installs it automatically because `tlh` works better when agents can consult and update repo-local project memory. Installs and updates on unsupported platforms hard-fail.
 
-When a valid Gnosis `gn` binary is present, TLH appends these instructions to the system prompt:
-
-```text
-At the start of any task, run `gn help plan` and follow its instructions.
-After finishing a task, run `gn help review`.
-```
+When a valid Gnosis `gn` binary is present, TLH appends concise workflow guidance to the system prompt. It tells agents to use or load the packaged `tlh-gnosis-workflow` skill (`skills/tlh-gnosis-workflow/SKILL.md`) for keyword-first memory search, conflict checks, durable-memory write rules, and review-time checks. It keeps full `gn help plan` and `gn help review` as fallbacks when the summary is missing, stale, conflicting, or the agent is uncertain.
 
 Gnosis project data lives in repo-local `.gnosis` directories. Removing `~/.the-last-harness` removes only the managed `gn` binary under the isolated profile; it does not delete repo-local memory.
 

--- a/extensions/the-last-harness/constants.ts
+++ b/extensions/the-last-harness/constants.ts
@@ -37,8 +37,8 @@ The Last Harness (tlh) profile is active. Prefer safe, transparent, and reviewab
 `;
 
 export const GNOSIS_PROMPT = [
-	"At the start of any task, run `gn help plan` and follow its instructions.",
-	"After finishing a task, run `gn help review`.",
+	"Use or load the packaged `tlh-gnosis-workflow` skill for the TLH Gnosis workflow summary: search memory with relevant `OR` keywords before implementation, surface conflicts, write only durable human-origin or cross-cutting knowledge, and re-check memory implications during review.",
+	"If that summary is missing, stale, conflicting, or you are uncertain, read full `gn help plan` before implementation and full `gn help review` before final review.",
 ].join("\n");
 
 export const CHILD_SUBAGENT_PROMPT = `

--- a/skills/tlh-gnosis-workflow/SKILL.md
+++ b/skills/tlh-gnosis-workflow/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tlh-gnosis-workflow
+description: Use for concise TLH Gnosis workflow guidance before implementation and during review.
+---
+
+# TLH Gnosis Workflow
+
+Use this summary when Gnosis is available and your role is allowed to run `gn`. If your role forbids Gnosis commands, do not use `gn`; report durable findings to the parent agent or supervisor instead.
+
+## Before implementation
+
+1. Search existing memory first with 2-5 relevant keywords joined by `OR`; start broad, then refine.
+2. Read the most relevant hits before coding.
+3. Surface conflicts early when memory disagrees with the ticket, repo state, or other trusted instructions.
+
+## Write memory only when it is
+
+- human-origin knowledge that will not be obvious from code later,
+- durable enough to matter across future tasks,
+- cross-cutting rationale, constraints, decisions, rejected options, process rules, or non-obvious gotchas.
+
+## Do not write memory for
+
+- secrets, tokens, PII, or private incident details,
+- transient task status, scratch notes, or one-off debugging steps,
+- facts already clear from code, tests, or docs,
+- speculative ideas that were not actually adopted.
+
+## Review / handoff
+
+- Re-check whether the work created or invalidated durable knowledge.
+- If code or docs now conflict with existing memory, update memory or flag the conflict in handoff.
+- Use review-time memory writes only for durable follow-up knowledge, not for restating the diff.
+
+## Read full help when
+
+- you are uncertain how to search, read, or write safely,
+- this summary is missing,
+- Gnosis behavior or policy seems stale or has changed,
+- instructions conflict and you need the source doctrine.
+
+Then read `gn help plan` before implementation and `gn help review` before final review or handoff.

--- a/tests/tlh-gnosis-workflow-static.test.mjs
+++ b/tests/tlh-gnosis-workflow-static.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createJiti } from "jiti";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const jiti = createJiti(import.meta.url);
+const { CHILD_SUBAGENT_PROMPT, GNOSIS_PROMPT } = await jiti.import("../extensions/the-last-harness/constants.ts");
+const { buildChildSubagentSystemPrompt } = await jiti.import("../extensions/the-last-harness/prompts.ts");
+
+function readRepoFile(path) {
+	return readFileSync(join(repoRoot, path), "utf8");
+}
+
+const legacyPlanLine = /At the start of any task, run `gn help plan` and follow its instructions\./;
+const legacyReviewLine = /After finishing a task, run `gn help review`\./;
+const unqualifiedAgentsPlanFallback = /If that summary is missing, stale, conflicting, or you are uncertain, read full `gn help plan`\./;
+const unqualifiedAgentsReviewFallback = /If that summary is missing, stale, conflicting, or you are uncertain, read full `gn help review`\./;
+
+test("packaged Gnosis workflow skill summarizes search, write, review, and fallback guidance", () => {
+	const skill = readRepoFile("skills/tlh-gnosis-workflow/SKILL.md");
+
+	assert.match(skill, /^---[\s\S]*name:\s*tlh-gnosis-workflow/m);
+	assert.match(skill, /keywords joined by `OR`/);
+	assert.match(skill, /Surface conflicts early/);
+	assert.match(skill, /human-origin knowledge/);
+	assert.match(skill, /cross-cutting rationale, constraints, decisions, rejected options/);
+	assert.match(skill, /Do not write memory for/);
+	assert.match(skill, /secrets, tokens, PII/);
+	assert.match(skill, /review-time memory writes only for durable follow-up knowledge/);
+	assert.match(skill, /Then read `gn help plan` before implementation and `gn help review` before final review or handoff\./);
+});
+
+test("system and contributor guidance prefer the packaged skill over unconditional full-help dumps", () => {
+	const sources = [GNOSIS_PROMPT, readRepoFile("AGENTS.md"), readRepoFile("README.md"), readRepoFile("docs/integrations.md")];
+
+	for (const source of sources) {
+		assert.match(source, /tlh-gnosis-workflow/);
+		assert.doesNotMatch(source, legacyPlanLine);
+		assert.doesNotMatch(source, legacyReviewLine);
+	}
+
+	assert.match(GNOSIS_PROMPT, /search memory with relevant `OR` keywords before implementation/);
+	assert.match(GNOSIS_PROMPT, /write only durable human-origin or cross-cutting knowledge/);
+	assert.match(GNOSIS_PROMPT, /read full `gn help plan` before implementation and full `gn help review` before final review/);
+
+	const agents = readRepoFile("AGENTS.md");
+	assert.match(agents, /If your role is allowed to run `gn` and that summary is missing, stale, conflicting, or you are uncertain, read full `gn help plan`/);
+	assert.match(agents, /If your role forbids `gn` \(for example, child subagents\), do not run Gnosis commands; report durable findings to the parent agent or supervisor instead\./);
+	assert.match(agents, /If your role is allowed to run `gn` and that summary is missing, stale, conflicting, or you are uncertain, read full `gn help review`/);
+	assert.doesNotMatch(agents, unqualifiedAgentsPlanFallback);
+	assert.doesNotMatch(agents, unqualifiedAgentsReviewFallback);
+});
+
+test("child subagent prompt still forbids direct Gnosis use", () => {
+	const childPrompt = buildChildSubagentSystemPrompt();
+
+	assert.match(CHILD_SUBAGENT_PROMPT, /Do not run Gnosis \(`gn`\) planning, review, write, edit, or removal commands/);
+	assert.match(childPrompt, /Do not run Gnosis \(`gn`\) planning, review, write, edit, or removal commands/);
+	assert.doesNotMatch(childPrompt, /tlh-gnosis-workflow/);
+	assert.doesNotMatch(childPrompt, /gn help plan/);
+	assert.doesNotMatch(childPrompt, /gn help review/);
+});


### PR DESCRIPTION
## Summary
- add packaged `tlh-gnosis-workflow` skill with concise Gnosis planning/review guidance
- update TLH prompts/docs to prefer the skill and keep full `gn help` as a role-guarded fallback
- add static coverage for package, prompt, and child-subagent Gnosis restrictions

## Validation
- `npm run validate`

## Review
- code-reviewer re-review: no required fixes