### PR TITLE
Hard-fail unverifiable Pi versions

### DIFF
--- a/scripts/check-installer-smoke.sh
+++ b/scripts/check-installer-smoke.sh
@@ -355,8 +355,8 @@ make_fake_present_pi() {
   local fakebin="$1"
   mkdir -p "${fakebin}"
   cat >"${fakebin}/pi" <<'EOF_FAKE_PRESENT_PI'
-#!/usr/bin/env bash
-if [[ "${1:-}" == "--version" ]]; then
+#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
   printf '0.75.3\n'
   exit 0
 fi

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -494,21 +494,24 @@ function gitCheckoutIo() {
 function assertSupportedPiVersion(config) {
 	// `pi --version` prints a bare semver (e.g. "0.75.3") on stdout. Older builds may
 	// differ, so we extract the first semver-shaped substring rather than match strictly.
-	const result = spawnCapture(config, ["pi", "--version"], { allowFailure: true });
+	const result = spawnCapture(config, ["pi", "--version"], {
+		allowFailure: true,
+		env: { PI_CODING_AGENT_DIR: config.agentDir },
+	});
+	const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
+	const upgradeCommand = `npm install -g --ignore-scripts --prefix "${piInstallPrefix(config)}" @earendil-works/pi-coding-agent`;
 	if (result.error || result.status !== 0) {
-		warn(`unable to determine Pi version (pi --version exited with ${result.status ?? result.error?.code ?? "error"}); continuing without version check`);
-		return;
+		const status = result.status ?? result.signal ?? result.error?.code ?? "error";
+		const probeDetails = output ? ` Probe output: ${output}` : "";
+		throw new Error(`unable to determine Pi version from existing pi on PATH (pi --version exited with ${status}). The Last Harness requires Pi >= ${MIN_PI_VERSION}. Verify that \`pi --version\` works, or upgrade with: ${upgradeCommand}.${probeDetails}`);
 	}
-	const output = `${result.stdout || ""}${result.stderr || ""}`;
 	const match = output.match(/\d+\.\d+\.\d+/);
 	if (!match) {
-		warn(`unable to parse Pi version from output: ${output.trim() || "<empty>"}; continuing without version check`);
-		return;
+		throw new Error(`unable to parse Pi version from existing pi on PATH: ${output || "<empty>"}. The Last Harness requires Pi >= ${MIN_PI_VERSION}. Verify that \`pi --version\` prints a semantic version like ${MIN_PI_VERSION}, or upgrade with: ${upgradeCommand}.`);
 	}
 	const currentVersion = match[0];
 	if (!nodeVersionMeetsMinimum(currentVersion, MIN_PI_VERSION)) {
-		const piPrefix = piInstallPrefix(config);
-		throw new Error(`Pi >= ${MIN_PI_VERSION} is required (found ${currentVersion}). Upgrade with: npm install -g --ignore-scripts --prefix "${piPrefix}" @earendil-works/pi-coding-agent`);
+		throw new Error(`Pi >= ${MIN_PI_VERSION} is required (found ${currentVersion}). Upgrade with: ${upgradeCommand}`);
 	}
 	verboseLog(config, `Pi version: ${currentVersion}`);
 }

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -56,6 +56,15 @@ function runQuery(args, env = scrubInstallerEnv()) {
 	});
 }
 
+function runInstaller(args, env = scrubInstallerEnv()) {
+	return spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-install.mjs"), ...args], {
+		cwd: repoRoot,
+		env,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
 function captureConsole(method, callback) {
 	const original = console[method];
 	const lines = [];
@@ -144,6 +153,108 @@ test("stage-1 enforces the TLH Node runtime minimum", () => {
 		() => assertSupportedNodeRuntime("not-a-version"),
 		/unable to determine Node\.js version; The Last Harness requires Node\.js >= 22\.19\.0\./,
 	);
+});
+
+test("stage-1 hard-fails existing Pi version probes that exit nonzero", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const fakebin = join(root, "fakebin");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFakePi(fakebin, "printf 'version probe failed\\n' >&2\nexit 23");
+	const env = scrubInstallerEnv({
+		HOME: homeDir,
+		PATH: `${fakebin}:${process.env.PATH || ""}`,
+		TLH_SKIP_GNOSIS_INSTALL: "1",
+	});
+	const result = runInstaller(["--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], env);
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /unable to determine Pi version from existing pi on PATH/);
+	assert.match(result.stderr, /pi --version exited with 23/);
+	assert.match(result.stderr, /The Last Harness requires Pi >= 0\.75\.3/);
+	assert.match(result.stderr, /Verify that `pi --version` works, or upgrade with: npm install -g --ignore-scripts --prefix /);
+	assert.match(result.stderr, /Probe output: version probe failed/);
+});
+
+test("stage-1 probes existing Pi version with the isolated agent dir", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const fakebin = join(root, "fakebin");
+	const probeLog = join(root, "pi-version-probe.log");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFakePi(fakebin, [
+		"printf '%s\\n' \"${PI_CODING_AGENT_DIR:-}\" >\"${PROBE_LOG}\"",
+		"if [[ \"${PI_CODING_AGENT_DIR:-}\" != \"${EXPECTED_AGENT_DIR}\" ]]; then",
+		"\tprintf 'poisoned profile\\n' >&2",
+		"\texit 24",
+		"fi",
+		"printf '0.75.3\\n'",
+	].join("\n"));
+	const env = scrubInstallerEnv({
+		HOME: homeDir,
+		PATH: `${fakebin}:${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: join(root, "poisoned-pi-agent"),
+		EXPECTED_AGENT_DIR: agentDir,
+		PROBE_LOG: probeLog,
+		TLH_SKIP_GNOSIS_INSTALL: "1",
+	});
+	const result = runInstaller(["--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], env);
+	assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+	assert.equal(readFileSync(probeLog, "utf8").trim(), agentDir);
+	assert.doesNotMatch(result.stderr, /poisoned profile/);
+});
+
+test("stage-1 hard-fails existing Pi version probes with unparsable output", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const fakebin = join(root, "fakebin");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFakePi(fakebin, "printf 'development build\\n'");
+	const env = scrubInstallerEnv({
+		HOME: homeDir,
+		PATH: `${fakebin}:${process.env.PATH || ""}`,
+		TLH_SKIP_GNOSIS_INSTALL: "1",
+	});
+	const result = runInstaller(["--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], env);
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /unable to parse Pi version from existing pi on PATH: development build/);
+	assert.match(result.stderr, /The Last Harness requires Pi >= 0\.75\.3/);
+	assert.match(result.stderr, /Verify that `pi --version` prints a semantic version like 0\.75\.3, or upgrade with: npm install -g --ignore-scripts --prefix /);
+});
+
+test("stage-1 rejects existing Pi older than the TLH minimum", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const fakebin = join(root, "fakebin");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFakePi(fakebin, "printf '0.75.2\\n'");
+	const env = scrubInstallerEnv({
+		HOME: homeDir,
+		PATH: `${fakebin}:${process.env.PATH || ""}`,
+		TLH_SKIP_GNOSIS_INSTALL: "1",
+	});
+	const result = runInstaller(["--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], env);
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /Pi >= 0\.75\.3 is required \(found 0\.75\.2\)\. Upgrade with: npm install -g --ignore-scripts --prefix /);
 });
 
 test("declared Node minimum stays aligned across installer metadata", () => {


### PR DESCRIPTION
## Summary
- hard-fail existing `pi` runtimes when `pi --version` fails or cannot be parsed
- keep below-minimum Pi rejection on the upgrade-guidance path
- add installer tests and fix the dry-run smoke fake Pi fixture under scrubbed PATH

## Validation
- npm run validate

## Review
- developer implementation completed
- code-reviewer final pass completed; only ticket residue was noted and removed