### PR TITLE
Guide sequencer conflict continuation

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -73,6 +73,8 @@ For each ready task:
 
 1. Use `tk ready` to pick the next dependency-unblocked ticket.
 2. Delegate one ticket to `developer` and instruct it to run `tk show <id>`.
+   - For git rebase/merge/cherry-pick conflict work, specify whether the task is resolve-only or resolve + continue.
+   - Default to resolve + continue when the user already approved the sequencer operation and did not explicitly say to stop before continuing.
 3. Evaluate the developer report against the ticket and overall plan.
 4. If needed, send focused corrections back to `developer`.
 5. Close the `tk` ticket only when its intent is met.

--- a/agents/subagents/developer.md
+++ b/agents/subagents/developer.md
@@ -35,6 +35,13 @@ Use `contact_supervisor` to ask the architect targeted questions when:
 
 Do not guess on important decisions. Escalate early and continue only after the architect resolves the blocker.
 
+## Git sequencer operations
+
+- When the assigned ticket covers user-approved conflict resolution for `git rebase`, `git merge`, or `git cherry-pick`, treat resolve + continue as part of completing the task unless the ticket, delegation, or user explicitly says not to continue.
+- Only continue when the sequencer state is active, affected or conflicted files for the current step no longer contain conflict markers like `<<<<<<<`, `=======`, or `>>>>>>>`, required resolutions are staged, and `git status` shows no remaining unmerged paths.
+- For non-interactive rebases, prefer `GIT_EDITOR=true git rebase --continue` so Git keeps the existing sequencer commit message without opening an editor.
+- Escalate instead of continuing when instructions say to stop after resolution, the correct resolution is unclear, the sequencer wants a message edit or other user choice, Git reports an empty patch or `the previous cherry-pick is now empty`, skip-versus-commit-empty needs a decision, or the repo state suggests unrelated risk.
+
 ## Implementation expectations
 
 - Prefer the simplest correct implementation.

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -25,6 +25,8 @@ const contracts = [
 			orderedTerms("exact approved signoff gate", ["exact word", "approved"]),
 			orderedTerms("developer waits for approved tickets", ["do not launch", "developer", "until", "approves", "tickets"]),
 			includesAllTerms("high-risk oracle gating", ["high-stakes", "broad blast radius", "explicitly agrees"]),
+			orderedTerms("architect specifies sequencer continue behavior", ["git rebase/merge/cherry-pick", "specify", "resolve-only", "resolve + continue"]),
+			orderedTerms("architect defaults approved sequencer work to continue", ["Default to resolve + continue", "approved", "did not explicitly say to stop"]),
 		],
 	},
 	{
@@ -79,11 +81,16 @@ const contracts = [
 		anchors: [
 			heading("Operating model"),
 			heading("Ambiguity and escalation"),
+			heading("Git sequencer operations"),
 			heading("Validation"),
 			heading("Completion report"),
 			orderedTerms("developer treats ticket as source of truth", ["tk show <id>", "source of truth"]),
 			bodyPattern("developer uses contact_supervisor for blocking decisions", /contact_supervisor/i),
 			orderedTerms("developer runs narrow validation", ["narrowest meaningful validation"]),
+			orderedTerms("developer defaults approved sequencer work to continue", ["user-approved conflict resolution", "git rebase", "git merge", "git cherry-pick", "resolve + continue"]),
+			orderedTerms("developer checks safe sequencer continue preconditions", ["Only continue", "sequencer state is active", "conflict markers", "<<<<<<<", "=======", ">>>>>>>", "required resolutions are staged", "git status", "no remaining unmerged paths"]),
+			orderedTerms("developer uses non-interactive rebase continue guidance", ["GIT_EDITOR=true git rebase --continue", "existing sequencer commit message", "without opening an editor"]),
+			orderedTerms("developer escalates real sequencer decisions", ["Escalate instead of continuing", "stop after resolution", "message edit", "empty patch", "previous cherry-pick is now empty", "skip-versus-commit-empty", "unrelated risk"]),
 		],
 	},
 	{


### PR DESCRIPTION
## Summary
- Teach the architect to specify resolve-only vs resolve + continue for git sequencer conflict work
- Teach the developer to continue approved rebase/merge/cherry-pick conflict work only after safe preconditions
- Add prompt-contract anchors for continuation, conflict-marker, staging, editor, and empty-patch escalation guidance

## Validation
- npm run validate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for handling Git sequencer operations (rebase, merge, cherry-pick) conflicts with clearer resolution and continuation protocols.
  * Improved agent instructions to reduce escalations and optimize decision-making during complex Git workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->