### PR TITLE
Refactor duplicated TLH helpers

### DIFF
--- a/extensions/the-last-harness/common.ts
+++ b/extensions/the-last-harness/common.ts
@@ -127,3 +127,19 @@ export function formatPathFromCwd(cwd: string, filePath: string): string {
 	}
 	return absolutePath;
 }
+
+export function formatCompactTokenCount(count: number): string {
+	if (count < 1000) {
+		return count.toString();
+	}
+	if (count < 10000) {
+		return `${(count / 1000).toFixed(1)}k`;
+	}
+	if (count < 1000000) {
+		return `${Math.round(count / 1000)}k`;
+	}
+	if (count < 10000000) {
+		return `${(count / 1000000).toFixed(1)}M`;
+	}
+	return `${Math.round(count / 1000000)}M`;
+}

--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { formatCompactTokenCount } from "./common.js";
 import type {
 	TlhSubscriptionUsageSnapshot,
 	TlhSubscriptionUsageSnapshotProvider,
@@ -19,22 +20,6 @@ export type TlhSubscriptionUsageFooterState = {
 	segment?: string;
 };
 
-function formatUsageTokens(count: number): string {
-	if (count < 1000) {
-		return count.toString();
-	}
-	if (count < 10000) {
-		return `${(count / 1000).toFixed(1)}k`;
-	}
-	if (count < 1000000) {
-		return `${Math.round(count / 1000)}k`;
-	}
-	if (count < 10000000) {
-		return `${(count / 1000000).toFixed(1)}M`;
-	}
-	return `${Math.round(count / 1000000)}M`;
-}
-
 function finiteNumber(value: number | undefined): number | undefined {
 	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -46,7 +31,7 @@ function formatUsagePercent(percent: number): string {
 
 function formatUsageCount(count: number): string {
 	const normalized = Math.round(count * 10) / 10;
-	return formatUsageTokens(normalized);
+	return formatCompactTokenCount(normalized);
 }
 
 function formatUsageDuration(durationMs: number | undefined): string | undefined {

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -7,7 +7,7 @@ import {
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
-import { formatHomePath, sanitizeStatusText } from "./common.js";
+import { formatCompactTokenCount, formatHomePath, sanitizeStatusText } from "./common.js";
 import type { FooterGitCache } from "./footer-git-cache.js";
 import { composeTlhFooterFirstLine } from "./footer-first-line.js";
 import {
@@ -15,22 +15,6 @@ import {
 	type TlhFooterSubscriptionUsageOptions,
 } from "./footer-subscription-usage.js";
 export { formatTlhSubscriptionUsageFooterSegment } from "./footer-subscription-usage.js";
-
-function formatTokens(count: number): string {
-	if (count < 1000) {
-		return count.toString();
-	}
-	if (count < 10000) {
-		return `${(count / 1000).toFixed(1)}k`;
-	}
-	if (count < 1000000) {
-		return `${Math.round(count / 1000)}k`;
-	}
-	if (count < 10000000) {
-		return `${(count / 1000000).toFixed(1)}M`;
-	}
-	return `${Math.round(count / 1000000)}M`;
-}
 
 function formatCost(cost: number): string {
 	return cost < 0.001 ? "<$0.001" : `$${cost.toFixed(3)}`;
@@ -105,7 +89,7 @@ export function createTlhFooter(
 			}
 
 			const contextPercentDisplay =
-				contextPercent === "?" ? `?/${formatTokens(contextWindow)}` : `${contextPercent}%/${formatTokens(contextWindow)}`;
+				contextPercent === "?" ? `?/${formatCompactTokenCount(contextWindow)}` : `${contextPercent}%/${formatCompactTokenCount(contextWindow)}`;
 			let contextPercentStr: string;
 			if (contextPercentValue > 90) {
 				contextPercentStr = theme.fg("error", contextPercentDisplay);

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -1,5 +1,3 @@
-import { writeFileSync } from "node:fs";
-
 import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import {
@@ -26,10 +24,9 @@ import {
 	loadSubagentMetadata,
 } from "./prompts.js";
 import { activateTlhTicketRuntime } from "./tickets.js";
-import { assertSafeTlhSettingsPath, tlhSettingsPathForWrite } from "./profile-state.js";
+import { tlhSettingsPathForWrite, withLockedTlhSettingsWrite } from "./profile-state.js";
 import type {
 	AgentPrompt,
-	SettingsStorageLike,
 	SubagentMetadata,
 	TlhPrimaryAgentConfig,
 	TlhPrimaryAgentSelection,
@@ -85,27 +82,8 @@ function parseTlhSettingsContent(content: string | undefined): Record<string, un
 	return parsed;
 }
 
-function settingsBackupTimestamp(): string {
-	return new Date().toISOString().replace(/[:.]/g, "-");
-}
-
-function getSettingsStorageForWrite(cwd: string): SettingsStorageLike {
-	const manager = SettingsManager.create(cwd, getAgentDir()) as unknown as { storage?: SettingsStorageLike };
-	if (!manager.storage || typeof manager.storage.withLock !== "function") {
-		throw new Error("Pi settings storage is unavailable.");
-	}
-	return manager.storage;
-}
-
 function writeTlhPrimaryAgentDefault(cwd: string, selection: TlhPrimaryAgentSelection | undefined): TlhPrimaryAgentWriteResult {
-	const settingsPath = tlhSettingsPathForWrite();
-	if (!settingsPath) {
-		throw new Error("Refusing to write primary-agent settings outside the isolated TLH profile.");
-	}
-	assertSafeTlhSettingsPath(settingsPath);
-
-	let result: TlhPrimaryAgentWriteResult | undefined;
-	getSettingsStorageForWrite(cwd).withLock("global", (current) => {
+	return withLockedTlhSettingsWrite(cwd, "Refusing to write primary-agent settings outside the isolated TLH profile.", (current) => {
 		const settings = parseTlhSettingsContent(current);
 		const rawTlh = settings.tlh;
 		let tlh: Record<string, unknown>;
@@ -156,22 +134,14 @@ function writeTlhPrimaryAgentDefault(cwd: string, selection: TlhPrimaryAgentSele
 		}
 
 		if (!changed) {
-			result = { settingsPath, changed: false };
-			return undefined;
+			return { changed: false };
 		}
 
-		const backupPath = current ? `${settingsPath}.bak-${settingsBackupTimestamp()}` : undefined;
-		if (backupPath) {
-			writeFileSync(backupPath, current, { encoding: "utf8", flag: "wx", mode: 0o600 });
-		}
-		result = { settingsPath, backupPath, changed: true };
-		return `${JSON.stringify(settings, null, 2)}\n`;
+		return {
+			changed: true,
+			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
+		};
 	});
-
-	if (!result) {
-		throw new Error("Pi settings storage did not return a write result.");
-	}
-	return result;
 }
 
 function primaryToolAllowlist(primary: AgentPrompt | undefined): string[] {

--- a/extensions/the-last-harness/profile-state.ts
+++ b/extensions/the-last-harness/profile-state.ts
@@ -1,9 +1,9 @@
 import { closeSync, constants, lstatSync, mkdirSync, openSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
-import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { formatHomePath, isRecord, pathWithinOrEqual, readText, realpathForCompare } from "./common.js";
-import type { TlhInstallState, TlhStartupState } from "./types.js";
+import type { SettingsStorageLike, TlhInstallState, TlhStartupState } from "./types.js";
 
 export function isDefaultPiAgentDir(agentDir: string): boolean {
 	const home = process.env.HOME || process.env.USERPROFILE;
@@ -187,6 +187,54 @@ export function tlhSettingsPathForWrite(): string | undefined {
 		return undefined;
 	}
 	return join(agentDir, "settings.json");
+}
+
+function settingsBackupTimestamp(): string {
+	return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function getSettingsStorageForWrite(cwd: string): SettingsStorageLike {
+	const manager = SettingsManager.create(cwd, getAgentDir()) as unknown as { storage?: SettingsStorageLike };
+	if (!manager.storage || typeof manager.storage.withLock !== "function") {
+		throw new Error("Pi settings storage is unavailable.");
+	}
+	return manager.storage;
+}
+
+export function withLockedTlhSettingsWrite<TResult extends { changed: boolean }>(
+	cwd: string,
+	outsideProfileError: string,
+	update: (current: string | undefined) => TResult & { nextContent?: string },
+): TResult & { settingsPath: string; backupPath?: string } {
+	const settingsPath = tlhSettingsPathForWrite();
+	if (!settingsPath) {
+		throw new Error(outsideProfileError);
+	}
+	assertSafeTlhSettingsPath(settingsPath);
+
+	let result: (TResult & { settingsPath: string; backupPath?: string }) | undefined;
+	getSettingsStorageForWrite(cwd).withLock("global", (current) => {
+		const outcome = update(current);
+		const { nextContent, ...baseResult } = outcome;
+		if (!baseResult.changed) {
+			result = { ...baseResult, settingsPath };
+			return undefined;
+		}
+		if (typeof nextContent !== "string") {
+			throw new Error("TLH settings write must provide replacement content when changed.");
+		}
+		const backupPath = current ? `${settingsPath}.bak-${settingsBackupTimestamp()}` : undefined;
+		if (backupPath) {
+			writeFileSync(backupPath, current, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		}
+		result = backupPath ? { ...baseResult, settingsPath, backupPath } : { ...baseResult, settingsPath };
+		return nextContent;
+	});
+
+	if (!result) {
+		throw new Error("Pi settings storage did not return a write result.");
+	}
+	return result;
 }
 
 export function assertSafeTlhSettingsPath(settingsPath: string): void {

--- a/extensions/the-last-harness/usage-limits.ts
+++ b/extensions/the-last-harness/usage-limits.ts
@@ -1,11 +1,8 @@
-import { writeFileSync } from "node:fs";
-
 import { SettingsManager, getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { formatHomePath, isRecord } from "./common.js";
-import { assertSafeTlhSettingsPath, tlhSettingsPathForWrite } from "./profile-state.js";
+import { withLockedTlhSettingsWrite } from "./profile-state.js";
 import type {
-	SettingsStorageLike,
 	TlhSettings,
 	TlhUsageLimitsConfig,
 	TlhUsageLimitsWriteResult,
@@ -62,48 +59,21 @@ function parseTlhSettingsContent(content: string | undefined): TlhSettings {
 	return parsed;
 }
 
-function settingsBackupTimestamp(): string {
-	return new Date().toISOString().replace(/[:.]/g, "-");
-}
-
-function getSettingsStorageForWrite(cwd: string): SettingsStorageLike {
-	const manager = SettingsManager.create(cwd, getAgentDir()) as unknown as { storage?: SettingsStorageLike };
-	if (!manager.storage || typeof manager.storage.withLock !== "function") {
-		throw new Error("Pi settings storage is unavailable.");
-	}
-	return manager.storage;
-}
-
 function writeTlhUsageWeeklyPreference(cwd: string, showWeekly: boolean): TlhUsageLimitsWriteResult {
-	const settingsPath = tlhSettingsPathForWrite();
-	if (!settingsPath) {
-		throw new Error("Refusing to write usage-limit settings outside the isolated TLH profile.");
-	}
-	assertSafeTlhSettingsPath(settingsPath);
-
-	let result: TlhUsageLimitsWriteResult | undefined;
-	getSettingsStorageForWrite(cwd).withLock("global", (current) => {
+	return withLockedTlhSettingsWrite(cwd, "Refusing to write usage-limit settings outside the isolated TLH profile.", (current) => {
 		const settings = parseTlhSettingsContent(current);
 		ensureMutableUsageLimitsSettings(settings);
 
 		if (settings.tlh.usageLimits.showWeekly === showWeekly) {
-			result = { settingsPath, changed: false };
-			return undefined;
+			return { changed: false };
 		}
 
 		settings.tlh.usageLimits.showWeekly = showWeekly;
-		const backupPath = current ? `${settingsPath}.bak-${settingsBackupTimestamp()}` : undefined;
-		if (backupPath) {
-			writeFileSync(backupPath, current, { encoding: "utf8", flag: "wx", mode: 0o600 });
-		}
-		result = { settingsPath, backupPath, changed: true };
-		return `${JSON.stringify(settings, null, 2)}\n`;
+		return {
+			changed: true,
+			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
+		};
 	});
-
-	if (!result) {
-		throw new Error("Pi settings storage did not return a write result.");
-	}
-	return result;
 }
 
 function parseUsageSlashAction(args: string): TlhUsageSlashAction | undefined {

--- a/scripts/lib/tlh-install-utils.mjs
+++ b/scripts/lib/tlh-install-utils.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 
 import { pathWithinOrEqual, realpathForCompare } from "./tlh-install-paths.mjs";
 
@@ -15,6 +16,66 @@ export function requiredValue(argv, index, flag) {
 export function assignRequiredEqualsValue(target, key, value, flag) {
 	if (!value) throw new Error(`${flag} requires a value`);
 	target[key] = value;
+}
+
+export function readOptionValue(argv, index, flags, { requireEqualsValue = false } = {}) {
+	const arg = argv[index];
+	if (typeof arg !== "string") return undefined;
+	for (const flag of Array.isArray(flags) ? flags : [flags]) {
+		if (arg === flag) {
+			return { flag, value: requiredValue(argv, index + 1, arg), nextIndex: index + 1 };
+		}
+		const prefix = `${flag}=`;
+		if (!arg.startsWith(prefix)) continue;
+		const value = arg.slice(prefix.length);
+		if (requireEqualsValue && !value) throw new Error(`${flag} requires a value`);
+		return { flag, value, nextIndex: index };
+	}
+	return undefined;
+}
+
+export function assignOptionValue(target, key, argv, index, flags, options = {}) {
+	const match = readOptionValue(argv, index, flags, options);
+	if (!match) return undefined;
+	target[key] = match.value;
+	return match.nextIndex;
+}
+
+export function expandHomePath(path, { homeDir = homedir() } = {}) {
+	if (typeof path !== "string") return path;
+	if (path === "~") return homeDir;
+	if (path.startsWith("~/")) return join(homeDir, path.slice(2));
+	return path;
+}
+
+function firstConfiguredValue(...values) {
+	for (const value of values) {
+		if (typeof value === "string" && value) return value;
+	}
+	return undefined;
+}
+
+export function defaultTlhAgentDir(env = process.env, { homeDir = homedir(), preferTlhAgentDir = false } = {}) {
+	const configured = preferTlhAgentDir
+		? firstConfiguredValue(env.TLH_AGENT_DIR, env.PI_CODING_AGENT_DIR)
+		: firstConfiguredValue(env.PI_CODING_AGENT_DIR, env.TLH_AGENT_DIR);
+	return expandHomePath(configured || join(homeDir, ".the-last-harness", "agent"), { homeDir });
+}
+
+export function resolveTlhAgentDir(agentDir, options = {}) {
+	return expandHomePath(agentDir || defaultTlhAgentDir(options.env, options), options);
+}
+
+export function defaultTlhSettingsPath({ agentDir, env = process.env, homeDir = homedir(), preferTlhAgentDir = false } = {}) {
+	return join(resolveTlhAgentDir(agentDir, { env, homeDir, preferTlhAgentDir }), "settings.json");
+}
+
+export function defaultTlhKeybindingsPath({ agentDir, env = process.env, homeDir = homedir(), preferTlhAgentDir = false } = {}) {
+	return join(resolveTlhAgentDir(agentDir, { env, homeDir, preferTlhAgentDir }), "keybindings.json");
+}
+
+export function defaultTlhBinDir(env = process.env, { homeDir = homedir() } = {}) {
+	return expandHomePath(env.TLH_BIN_DIR || join(homeDir, ".local", "bin"), { homeDir });
 }
 
 export function readJsonFile(path, { missingValue, emptyValue = {} } = {}) {

--- a/scripts/merge-keybindings.mjs
+++ b/scripts/merge-keybindings.mjs
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
 import {
 	assertNotInNormalPiConfig,
+	assignOptionValue,
 	backupPathWithTimestamp,
+	defaultTlhKeybindingsPath,
+	expandHomePath,
 	readJsonFile,
-	requiredValue,
 } from "./lib/tlh-install-utils.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -52,20 +53,14 @@ function parseArgs(argv) {
 			args.help = true;
 			continue;
 		}
-		if (arg === "--keybindings") {
-			args.keybindingsPath = requiredValue(argv, ++index, arg);
+		const keybindingsIndex = assignOptionValue(args, "keybindingsPath", argv, index, "--keybindings");
+		if (keybindingsIndex !== undefined) {
+			index = keybindingsIndex;
 			continue;
 		}
-		if (arg.startsWith("--keybindings=")) {
-			args.keybindingsPath = arg.slice("--keybindings=".length);
-			continue;
-		}
-		if (arg === "--defaults") {
-			args.defaultsPath = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--defaults=")) {
-			args.defaultsPath = arg.slice("--defaults=".length);
+		const defaultsIndex = assignOptionValue(args, "defaultsPath", argv, index, "--defaults");
+		if (defaultsIndex !== undefined) {
+			index = defaultsIndex;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -78,14 +73,6 @@ function parseArgs(argv) {
 	}
 
 	return args;
-}
-
-function getAgentDir() {
-	return process.env.PI_CODING_AGENT_DIR || process.env.TLH_AGENT_DIR || join(homedir(), ".the-last-harness", "agent");
-}
-
-function defaultKeybindingsPath() {
-	return join(getAgentDir(), "keybindings.json");
 }
 
 function defaultDefaultsPath() {
@@ -169,8 +156,8 @@ function main() {
 		return;
 	}
 
-	const defaultsPath = resolve(args.defaultsPath || defaultDefaultsPath());
-	const keybindingsPath = resolve(args.keybindingsPath || defaultKeybindingsPath());
+	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()));
+	const keybindingsPath = resolve(expandHomePath(args.keybindingsPath || defaultTlhKeybindingsPath()));
 	assertKeybindingsTarget(keybindingsPath);
 	const existed = existsSync(keybindingsPath);
 	const existing = readJsonFile(keybindingsPath, { missingValue: {} });

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize, parse, resolve, sep } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
@@ -16,9 +15,11 @@ import {
 } from "./lib/default-extensions.mjs";
 import {
 	assertNotInNormalPiConfig,
+	assignOptionValue,
 	backupPathWithTimestamp,
+	defaultTlhSettingsPath,
+	expandHomePath,
 	readJsonFile,
-	requiredValue,
 } from "./lib/tlh-install-utils.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -74,28 +75,19 @@ function parseArgs(argv) {
 			args.help = true;
 			continue;
 		}
-		if (arg === "--settings") {
-			args.settingsPath = requiredValue(argv, ++i, arg);
+		const settingsIndex = assignOptionValue(args, "settingsPath", argv, i, "--settings");
+		if (settingsIndex !== undefined) {
+			i = settingsIndex;
 			continue;
 		}
-		if (arg === "--package-source") {
-			args.packageSource = requiredValue(argv, ++i, arg);
+		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, i, "--package-source");
+		if (packageSourceIndex !== undefined) {
+			i = packageSourceIndex;
 			continue;
 		}
-		if (arg === "--default-extensions") {
-			args.defaultExtensionsPath = requiredValue(argv, ++i, arg);
-			continue;
-		}
-		if (arg.startsWith("--settings=")) {
-			args.settingsPath = arg.slice("--settings=".length);
-			continue;
-		}
-		if (arg.startsWith("--package-source=")) {
-			args.packageSource = arg.slice("--package-source=".length);
-			continue;
-		}
-		if (arg.startsWith("--default-extensions=")) {
-			args.defaultExtensionsPath = arg.slice("--default-extensions=".length);
+		const defaultExtensionsIndex = assignOptionValue(args, "defaultExtensionsPath", argv, i, "--default-extensions");
+		if (defaultExtensionsIndex !== undefined) {
+			i = defaultExtensionsIndex;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -108,14 +100,6 @@ function parseArgs(argv) {
 	}
 
 	return args;
-}
-
-function getAgentDir() {
-	return process.env.PI_CODING_AGENT_DIR || process.env.TLH_AGENT_DIR || join(homedir(), ".the-last-harness", "agent");
-}
-
-function defaultSettingsPath() {
-	return join(getAgentDir(), "settings.json");
 }
 
 function defaultDefaultsPath() {
@@ -504,9 +488,9 @@ function main() {
 		return;
 	}
 
-	const defaultsPath = resolve(args.defaultsPath || defaultDefaultsPath());
-	const defaultExtensionsPath = resolve(args.defaultExtensionsPath || defaultDefaultExtensionsPath());
-	const settingsPath = resolve(args.settingsPath || defaultSettingsPath());
+	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()));
+	const defaultExtensionsPath = resolve(expandHomePath(args.defaultExtensionsPath || defaultDefaultExtensionsPath()));
+	const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath()));
 	assertNotNormalPiSettings(settingsPath);
 	const existed = existsSync(settingsPath);
 	const existing = readJsonFile(settingsPath, { missingValue: {} });

--- a/scripts/tlh-defaults.mjs
+++ b/scripts/tlh-defaults.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
@@ -14,9 +13,11 @@ import {
 } from "./lib/default-extensions.mjs";
 import {
 	assertNotInNormalPiConfig,
+	assignOptionValue,
 	backupPathWithTimestamp,
+	defaultTlhSettingsPath,
+	expandHomePath,
 	readJsonFile,
-	requiredValue,
 } from "./lib/tlh-install-utils.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -56,24 +57,14 @@ function parseArgs(argv) {
 			args.help = true;
 			continue;
 		}
-		if (arg === "--settings") {
-			args.settingsPath = requiredValue(argv, ++index, arg);
+		const settingsIndex = assignOptionValue(args, "settingsPath", argv, index, "--settings");
+		if (settingsIndex !== undefined) {
+			index = settingsIndex;
 			continue;
 		}
-		if (arg.startsWith("--settings=")) {
-			args.settingsPath = arg.slice("--settings=".length);
-			continue;
-		}
-		if (arg === "--defaults" || arg === "--default-extensions") {
-			args.defaultExtensionsPath = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--defaults=")) {
-			args.defaultExtensionsPath = arg.slice("--defaults=".length);
-			continue;
-		}
-		if (arg.startsWith("--default-extensions=")) {
-			args.defaultExtensionsPath = arg.slice("--default-extensions=".length);
+		const defaultsIndex = assignOptionValue(args, "defaultExtensionsPath", argv, index, ["--defaults", "--default-extensions"]);
+		if (defaultsIndex !== undefined) {
+			index = defaultsIndex;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -87,20 +78,6 @@ function parseArgs(argv) {
 	}
 
 	return args;
-}
-
-function expandHome(path) {
-	if (path === "~") return homedir();
-	if (path.startsWith("~/")) return join(homedir(), path.slice(2));
-	return path;
-}
-
-function getAgentDir() {
-	return process.env.PI_CODING_AGENT_DIR || process.env.TLH_AGENT_DIR || join(homedir(), ".the-last-harness", "agent");
-}
-
-function defaultSettingsPath() {
-	return join(getAgentDir(), "settings.json");
 }
 
 function defaultDefaultExtensionsPath() {
@@ -390,8 +367,8 @@ function main() {
 		return;
 	}
 
-	const settingsPath = resolve(expandHome(args.settingsPath || defaultSettingsPath()));
-	const defaultExtensionsPath = resolve(expandHome(args.defaultExtensionsPath || defaultDefaultExtensionsPath()));
+	const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath()));
+	const defaultExtensionsPath = resolve(expandHomePath(args.defaultExtensionsPath || defaultDefaultExtensionsPath()));
 	const mutatesSettings = args.command === "disable" || args.command === "enable";
 	if (mutatesSettings) assertNotNormalPiSettings(settingsPath);
 	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath);

--- a/scripts/tlh-gnosis.mjs
+++ b/scripts/tlh-gnosis.mjs
@@ -6,7 +6,11 @@ import { homedir, tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-import { requiredValue } from "./lib/tlh-install-utils.mjs";
+import {
+	assignOptionValue,
+	expandHomePath,
+	resolveTlhAgentDir,
+} from "./lib/tlh-install-utils.mjs";
 
 const VALIDATION_TIMEOUT_MS = 5000;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
@@ -66,36 +70,24 @@ function parseArgs(argv) {
 			args.quiet = true;
 			continue;
 		}
-		if (arg === "--agent-dir") {
-			args.agentDir = requiredValue(argv, ++index, arg);
+		const agentDirIndex = assignOptionValue(args, "agentDir", argv, index, "--agent-dir");
+		if (agentDirIndex !== undefined) {
+			index = agentDirIndex;
 			continue;
 		}
-		if (arg.startsWith("--agent-dir=")) {
-			args.agentDir = arg.slice("--agent-dir=".length);
+		const targetIndex = assignOptionValue(args, "target", argv, index, "--target");
+		if (targetIndex !== undefined) {
+			index = targetIndex;
 			continue;
 		}
-		if (arg === "--target") {
-			args.target = requiredValue(argv, ++index, arg);
+		const repoIndex = assignOptionValue(args, "gnosisRepo", argv, index, "--gnosis-repo");
+		if (repoIndex !== undefined) {
+			index = repoIndex;
 			continue;
 		}
-		if (arg.startsWith("--target=")) {
-			args.target = arg.slice("--target=".length);
-			continue;
-		}
-		if (arg === "--gnosis-repo") {
-			args.gnosisRepo = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--gnosis-repo=")) {
-			args.gnosisRepo = arg.slice("--gnosis-repo=".length);
-			continue;
-		}
-		if (arg === "--gnosis-version") {
-			args.gnosisVersion = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--gnosis-version=")) {
-			args.gnosisVersion = arg.slice("--gnosis-version=".length);
+		const versionIndex = assignOptionValue(args, "gnosisVersion", argv, index, "--gnosis-version");
+		if (versionIndex !== undefined) {
+			index = versionIndex;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -109,16 +101,6 @@ function parseArgs(argv) {
 	}
 
 	return args;
-}
-
-function expandHome(path) {
-	if (path === "~") return homedir();
-	if (path.startsWith("~/")) return join(homedir(), path.slice(2));
-	return path;
-}
-
-function getAgentDir(argAgentDir) {
-	return expandHome(argAgentDir || process.env.PI_CODING_AGENT_DIR || process.env.TLH_AGENT_DIR || join(homedir(), ".the-last-harness", "agent"));
 }
 
 function candidateCommands(agentDir) {
@@ -161,8 +143,8 @@ function findValidGnosis(agentDir) {
 }
 
 function managedGnosisTargetPath(args, agentDir) {
-	const agentRoot = resolve(expandHome(agentDir));
-	return resolve(expandHome(args.target || join(agentRoot, "bin", "gn")));
+	const agentRoot = resolve(expandHomePath(agentDir));
+	return resolve(expandHomePath(args.target || join(agentRoot, "bin", "gn")));
 }
 
 function findValidGnosisForConfigure(args, agentDir) {
@@ -288,7 +270,7 @@ function findFileNamed(root, name) {
 }
 
 function resolvedManagedAgentDir(agentDir) {
-	return realpathForCompare(resolve(expandHome(agentDir)));
+	return realpathForCompare(resolve(expandHomePath(agentDir)));
 }
 
 function assertManagedGnosisTempPath(path, agentDir, label, { mustExist = false, expectDirectory = false, expectFile = false } = {}) {
@@ -488,7 +470,7 @@ function assertNoSymlinkedManagedTargetParents(target, boundary) {
 }
 
 function validateManagedGnosisTarget(args, agentDir) {
-	const agentRoot = resolve(expandHome(agentDir));
+	const agentRoot = resolve(expandHomePath(agentDir));
 	const target = managedGnosisTargetPath(args, agentDir);
 
 	assertNotNormalPiPath(agentRoot, "agent dir");
@@ -576,7 +558,7 @@ async function main() {
 		return;
 	}
 
-	const agentDir = resolve(getAgentDir(args.agentDir));
+	const agentDir = resolve(resolveTlhAgentDir(args.agentDir));
 
 	if (args.command === "validate") {
 		commandValidate(agentDir, args.commandArgs);

--- a/scripts/tlh-install-state.mjs
+++ b/scripts/tlh-install-state.mjs
@@ -3,7 +3,11 @@ import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import process from "node:process";
 
-import { assertNotInNormalPiConfig, requiredValue } from "./lib/tlh-install-utils.mjs";
+import {
+	assertNotInNormalPiConfig,
+	assignOptionValue,
+	readOptionValue,
+} from "./lib/tlh-install-utils.mjs";
 
 function usage() {
 	return `Usage: tlh-install-state.mjs [options]
@@ -60,102 +64,65 @@ function parseArgs(argv) {
 			args.quiet = true;
 			continue;
 		}
-		if (arg === "--state-path") {
-			args.statePath = requiredValue(argv, ++index, arg);
+		const statePathIndex = assignOptionValue(args, "statePath", argv, index, "--state-path");
+		if (statePathIndex !== undefined) {
+			index = statePathIndex;
 			continue;
 		}
-		if (arg.startsWith("--state-path=")) {
-			args.statePath = arg.slice("--state-path=".length);
+		const repoIndex = assignOptionValue(args, "repo", argv, index, "--repo");
+		if (repoIndex !== undefined) {
+			index = repoIndex;
 			continue;
 		}
-		if (arg === "--repo") {
-			args.repo = requiredValue(argv, ++index, arg);
+		const refIndex = assignOptionValue(args, "ref", argv, index, "--ref");
+		if (refIndex !== undefined) {
+			index = refIndex;
 			continue;
 		}
-		if (arg.startsWith("--repo=")) {
-			args.repo = arg.slice("--repo=".length);
+		const trackIndex = assignOptionValue(args, "track", argv, index, "--track");
+		if (trackIndex !== undefined) {
+			index = trackIndex;
 			continue;
 		}
-		if (arg === "--ref") {
-			args.ref = requiredValue(argv, ++index, arg);
+		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, index, "--package-source");
+		if (packageSourceIndex !== undefined) {
+			index = packageSourceIndex;
 			continue;
 		}
-		if (arg.startsWith("--ref=")) {
-			args.ref = arg.slice("--ref=".length);
+		const packageSourceIsDefaultIndex = assignOptionValue(args, "packageSourceIsDefault", argv, index, "--package-source-is-default");
+		if (packageSourceIsDefaultIndex !== undefined) {
+			index = packageSourceIsDefaultIndex;
 			continue;
 		}
-		if (arg === "--track") {
-			args.track = requiredValue(argv, ++index, arg);
+		const rawBaseIndex = assignOptionValue(args, "rawBase", argv, index, "--raw-base");
+		if (rawBaseIndex !== undefined) {
+			index = rawBaseIndex;
 			continue;
 		}
-		if (arg.startsWith("--track=")) {
-			args.track = arg.slice("--track=".length);
+		const agentDirIndex = assignOptionValue(args, "agentDir", argv, index, "--agent-dir");
+		if (agentDirIndex !== undefined) {
+			index = agentDirIndex;
 			continue;
 		}
-		if (arg === "--package-source") {
-			args.packageSource = requiredValue(argv, ++index, arg);
+		const binDirIndex = assignOptionValue(args, "binDir", argv, index, "--bin-dir");
+		if (binDirIndex !== undefined) {
+			index = binDirIndex;
 			continue;
 		}
-		if (arg.startsWith("--package-source=")) {
-			args.packageSource = arg.slice("--package-source=".length);
+		const wrapperNameIndex = assignOptionValue(args, "wrapperName", argv, index, "--wrapper-name");
+		if (wrapperNameIndex !== undefined) {
+			index = wrapperNameIndex;
 			continue;
 		}
-		if (arg === "--package-source-is-default") {
-			args.packageSourceIsDefault = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--package-source-is-default=")) {
-			args.packageSourceIsDefault = arg.slice("--package-source-is-default=".length);
-			continue;
-		}
-		if (arg === "--raw-base") {
-			args.rawBase = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--raw-base=")) {
-			args.rawBase = arg.slice("--raw-base=".length);
-			continue;
-		}
-		if (arg === "--agent-dir") {
-			args.agentDir = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--agent-dir=")) {
-			args.agentDir = arg.slice("--agent-dir=".length);
-			continue;
-		}
-		if (arg === "--bin-dir") {
-			args.binDir = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--bin-dir=")) {
-			args.binDir = arg.slice("--bin-dir=".length);
-			continue;
-		}
-		if (arg === "--wrapper-name") {
-			args.wrapperName = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--wrapper-name=")) {
-			args.wrapperName = arg.slice("--wrapper-name=".length);
-			continue;
-		}
-		if (arg === "--pi-installed-by-tlh") {
-			const raw = requiredValue(argv, ++index, arg);
+		const piInstalledByTlh = readOptionValue(argv, index, "--pi-installed-by-tlh");
+		if (piInstalledByTlh) {
+			const raw = piInstalledByTlh.value;
 			const lower = raw.toLowerCase();
 			if (lower !== "true" && lower !== "false") {
 				throw new Error(`--pi-installed-by-tlh must be true or false (got: ${raw})`);
 			}
 			args.piInstalledByTlh = lower === "true";
-			continue;
-		}
-		if (arg.startsWith("--pi-installed-by-tlh=")) {
-			const raw = arg.slice("--pi-installed-by-tlh=".length);
-			const lower = raw.toLowerCase();
-			if (lower !== "true" && lower !== "false") {
-				throw new Error(`--pi-installed-by-tlh must be true or false (got: ${raw})`);
-			}
-			args.piInstalledByTlh = lower === "true";
+			index = piInstalledByTlh.nextIndex;
 			continue;
 		}
 		throw new Error(`Unknown option: ${arg}`);

--- a/scripts/tlh-tickets.mjs
+++ b/scripts/tlh-tickets.mjs
@@ -7,9 +7,12 @@ import { spawnSync } from "node:child_process";
 import process from "node:process";
 
 import {
+	assignOptionValue,
 	backupPathWithTimestamp,
+	defaultTlhSettingsPath,
+	expandHomePath,
 	readJsonFile,
-	requiredValue,
+	resolveTlhAgentDir,
 } from "./lib/tlh-install-utils.mjs";
 
 const VALIDATION_TIMEOUT_MS = 5000;
@@ -74,68 +77,44 @@ function parseArgs(argv) {
 			args.quiet = true;
 			continue;
 		}
-		if (arg === "--settings") {
-			args.settingsPath = requiredValue(argv, ++index, arg);
+		const settingsIndex = assignOptionValue(args, "settingsPath", argv, index, "--settings");
+		if (settingsIndex !== undefined) {
+			index = settingsIndex;
 			continue;
 		}
-		if (arg.startsWith("--settings=")) {
-			args.settingsPath = arg.slice("--settings=".length);
+		const agentDirIndex = assignOptionValue(args, "agentDir", argv, index, "--agent-dir");
+		if (agentDirIndex !== undefined) {
+			index = agentDirIndex;
 			continue;
 		}
-		if (arg === "--agent-dir") {
-			args.agentDir = requiredValue(argv, ++index, arg);
+		const installPathIndex = assignOptionValue(args, "installPath", argv, index, "--install-path");
+		if (installPathIndex !== undefined) {
+			index = installPathIndex;
 			continue;
 		}
-		if (arg.startsWith("--agent-dir=")) {
-			args.agentDir = arg.slice("--agent-dir=".length);
+		const targetIndex = assignOptionValue(args, "target", argv, index, "--target");
+		if (targetIndex !== undefined) {
+			index = targetIndex;
 			continue;
 		}
-		if (arg === "--install-path") {
-			args.installPath = requiredValue(argv, ++index, arg);
+		const sourceUrlIndex = assignOptionValue(args, "ticketSourceUrl", argv, index, "--unsafe-test-ticket-source-url");
+		if (sourceUrlIndex !== undefined) {
+			index = sourceUrlIndex;
 			continue;
 		}
-		if (arg.startsWith("--install-path=")) {
-			args.installPath = arg.slice("--install-path=".length);
+		const sourceShaIndex = assignOptionValue(args, "ticketSourceSha256", argv, index, "--unsafe-test-ticket-source-sha256");
+		if (sourceShaIndex !== undefined) {
+			index = sourceShaIndex;
 			continue;
 		}
-		if (arg === "--target") {
-			args.target = requiredValue(argv, ++index, arg);
+		const archiveEntryIndex = assignOptionValue(args, "ticketArchiveEntry", argv, index, "--unsafe-test-ticket-archive-entry");
+		if (archiveEntryIndex !== undefined) {
+			index = archiveEntryIndex;
 			continue;
 		}
-		if (arg.startsWith("--target=")) {
-			args.target = arg.slice("--target=".length);
-			continue;
-		}
-		if (arg === "--unsafe-test-ticket-source-url") {
-			args.ticketSourceUrl = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--unsafe-test-ticket-source-url=")) {
-			args.ticketSourceUrl = arg.slice("--unsafe-test-ticket-source-url=".length);
-			continue;
-		}
-		if (arg === "--unsafe-test-ticket-source-sha256") {
-			args.ticketSourceSha256 = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--unsafe-test-ticket-source-sha256=")) {
-			args.ticketSourceSha256 = arg.slice("--unsafe-test-ticket-source-sha256=".length);
-			continue;
-		}
-		if (arg === "--unsafe-test-ticket-archive-entry") {
-			args.ticketArchiveEntry = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--unsafe-test-ticket-archive-entry=")) {
-			args.ticketArchiveEntry = arg.slice("--unsafe-test-ticket-archive-entry=".length);
-			continue;
-		}
-		if (arg === "--wrapper-name") {
-			args.wrapperName = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--wrapper-name=")) {
-			args.wrapperName = arg.slice("--wrapper-name=".length);
+		const wrapperNameIndex = assignOptionValue(args, "wrapperName", argv, index, "--wrapper-name");
+		if (wrapperNameIndex !== undefined) {
+			index = wrapperNameIndex;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -149,20 +128,6 @@ function parseArgs(argv) {
 	}
 
 	return args;
-}
-
-function expandHome(path) {
-	if (path === "~") return homedir();
-	if (path.startsWith("~/")) return join(homedir(), path.slice(2));
-	return path;
-}
-
-function getAgentDir(argAgentDir) {
-	return expandHome(argAgentDir || process.env.PI_CODING_AGENT_DIR || process.env.TLH_AGENT_DIR || join(homedir(), ".the-last-harness", "agent"));
-}
-
-function defaultSettingsPath(agentDir) {
-	return join(agentDir, "settings.json");
 }
 
 function isPlainObject(value) {
@@ -208,7 +173,7 @@ function ticketsState(settings) {
 
 function normalizedInstallPath(path) {
 	if (!path) return undefined;
-	return resolve(expandHome(path));
+	return resolve(expandHomePath(path));
 }
 
 function configuredInstallPath(settings) {
@@ -223,8 +188,8 @@ function managedTkPinIsFresh(settings, expectedSha256) {
 }
 
 function managedTkTargetPath(args, agentDir) {
-	const agentRoot = resolve(expandHome(agentDir));
-	return resolve(expandHome(args.target || join(agentRoot, "bin", "tk")));
+	const agentRoot = resolve(expandHomePath(agentDir));
+	return resolve(expandHomePath(args.target || join(agentRoot, "bin", "tk")));
 }
 
 function candidateCommands(args, settings, agentDir) {
@@ -517,7 +482,7 @@ function resolvedPathFromRoot(path, root, resolvedRoot) {
 }
 
 function managedTkTargetPlan(args, agentDir) {
-	const agentRoot = resolve(expandHome(agentDir));
+	const agentRoot = resolve(expandHomePath(agentDir));
 	const target = managedTkTargetPath(args, agentDir);
 
 	assertNotNormalPiPath(agentRoot, "agent dir");
@@ -1189,8 +1154,8 @@ async function main() {
 		return;
 	}
 
-	const agentDir = resolve(getAgentDir(args.agentDir));
-	const settingsPath = resolve(expandHome(args.settingsPath || defaultSettingsPath(agentDir)));
+	const agentDir = resolve(resolveTlhAgentDir(args.agentDir));
+	const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath({ agentDir })));
 	if (args.command === "disable") {
 		throw new Error("disable is no longer supported because tk ticket integration is required");
 	}

--- a/scripts/tlh-update.mjs
+++ b/scripts/tlh-update.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 import { accessSync, chmodSync, constants, existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-import { requiredValue } from "./lib/tlh-install-utils.mjs";
+import {
+	assignOptionValue,
+	defaultTlhAgentDir,
+	defaultTlhBinDir,
+	expandHomePath,
+} from "./lib/tlh-install-utils.mjs";
 
 const DEFAULT_REPO = "diegopetrucci/the-last-harness";
 const DEFAULT_WRAPPER_NAME = "tlh";
@@ -36,24 +41,10 @@ Options:
 `;
 }
 
-function expandHome(path) {
-	if (path === "~") return homedir();
-	if (path.startsWith("~/")) return join(homedir(), path.slice(2));
-	return path;
-}
-
-function defaultAgentDir() {
-	return process.env.TLH_AGENT_DIR || process.env.PI_CODING_AGENT_DIR || join(homedir(), ".the-last-harness", "agent");
-}
-
-function defaultBinDir() {
-	return process.env.TLH_BIN_DIR || join(homedir(), ".local", "bin");
-}
-
 function parseArgs(argv) {
 	const args = {
-		agentDir: defaultAgentDir(),
-		binDir: defaultBinDir(),
+		agentDir: defaultTlhAgentDir(process.env, { preferTlhAgentDir: true }),
+		binDir: defaultTlhBinDir(process.env),
 		wrapperName: process.env.TLH_WRAPPER_NAME || DEFAULT_WRAPPER_NAME,
 		repo: process.env.TLH_REPO,
 		track: undefined,
@@ -100,67 +91,46 @@ function parseArgs(argv) {
 			args.quiet = false;
 			continue;
 		}
-		if (arg === "--agent-dir") {
-			args.agentDir = requiredValue(argv, ++i, arg);
+		const agentDirIndex = assignOptionValue(args, "agentDir", argv, i, "--agent-dir");
+		if (agentDirIndex !== undefined) {
+			i = agentDirIndex;
 			continue;
 		}
-		if (arg === "--bin-dir") {
-			args.binDir = requiredValue(argv, ++i, arg);
+		const binDirIndex = assignOptionValue(args, "binDir", argv, i, "--bin-dir");
+		if (binDirIndex !== undefined) {
+			i = binDirIndex;
 			continue;
 		}
-		if (arg === "--wrapper-name") {
-			args.wrapperName = requiredValue(argv, ++i, arg);
+		const wrapperNameIndex = assignOptionValue(args, "wrapperName", argv, i, "--wrapper-name");
+		if (wrapperNameIndex !== undefined) {
+			i = wrapperNameIndex;
 			continue;
 		}
-		if (arg === "--track") {
-			args.track = requiredValue(argv, ++i, arg);
+		const trackIndex = assignOptionValue(args, "track", argv, i, "--track");
+		if (trackIndex !== undefined) {
+			i = trackIndex;
 			continue;
 		}
-		if (arg === "--ref") {
-			args.ref = requiredValue(argv, ++i, arg);
+		const refIndex = assignOptionValue(args, "ref", argv, i, "--ref");
+		if (refIndex !== undefined) {
+			i = refIndex;
 			continue;
 		}
-		if (arg === "--repo") {
-			args.repo = requiredValue(argv, ++i, arg);
+		const repoIndex = assignOptionValue(args, "repo", argv, i, "--repo");
+		if (repoIndex !== undefined) {
+			i = repoIndex;
 			continue;
 		}
-		if (arg === "--package-source") {
-			args.packageSource = requiredValue(argv, ++i, arg);
-			continue;
-		}
-		if (arg.startsWith("--agent-dir=")) {
-			args.agentDir = arg.slice("--agent-dir=".length);
-			continue;
-		}
-		if (arg.startsWith("--bin-dir=")) {
-			args.binDir = arg.slice("--bin-dir=".length);
-			continue;
-		}
-		if (arg.startsWith("--wrapper-name=")) {
-			args.wrapperName = arg.slice("--wrapper-name=".length);
-			continue;
-		}
-		if (arg.startsWith("--track=")) {
-			args.track = arg.slice("--track=".length);
-			continue;
-		}
-		if (arg.startsWith("--ref=")) {
-			args.ref = arg.slice("--ref=".length);
-			continue;
-		}
-		if (arg.startsWith("--repo=")) {
-			args.repo = arg.slice("--repo=".length);
-			continue;
-		}
-		if (arg.startsWith("--package-source=")) {
-			args.packageSource = arg.slice("--package-source=".length);
+		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, i, "--package-source");
+		if (packageSourceIndex !== undefined) {
+			i = packageSourceIndex;
 			continue;
 		}
 		throw new Error(`Unknown option for tlh update: ${arg}`);
 	}
 
-	args.agentDir = expandHome(args.agentDir);
-	args.binDir = expandHome(args.binDir);
+	args.agentDir = expandHomePath(args.agentDir);
+	args.binDir = expandHomePath(args.binDir);
 	return args;
 }
 

--- a/scripts/tlh-wrapper.mjs
+++ b/scripts/tlh-wrapper.mjs
@@ -5,8 +5,8 @@ import process from "node:process";
 
 import {
 	assertNotInNormalPiConfig,
+	assignOptionValue,
 	renderShellWords,
-	requiredValue,
 	shellQuote,
 } from "./lib/tlh-install-utils.mjs";
 
@@ -59,36 +59,24 @@ function parseArgs(argv) {
 			args.quiet = true;
 			continue;
 		}
-		if (arg === "--agent-dir") {
-			args.agentDir = requiredValue(argv, ++index, arg);
+		const agentDirIndex = assignOptionValue(args, "agentDir", argv, index, "--agent-dir");
+		if (agentDirIndex !== undefined) {
+			index = agentDirIndex;
 			continue;
 		}
-		if (arg.startsWith("--agent-dir=")) {
-			args.agentDir = arg.slice("--agent-dir=".length);
+		const binDirIndex = assignOptionValue(args, "binDir", argv, index, "--bin-dir");
+		if (binDirIndex !== undefined) {
+			index = binDirIndex;
 			continue;
 		}
-		if (arg === "--bin-dir") {
-			args.binDir = requiredValue(argv, ++index, arg);
+		const wrapperNameIndex = assignOptionValue(args, "wrapperName", argv, index, "--wrapper-name");
+		if (wrapperNameIndex !== undefined) {
+			index = wrapperNameIndex;
 			continue;
 		}
-		if (arg.startsWith("--bin-dir=")) {
-			args.binDir = arg.slice("--bin-dir=".length);
-			continue;
-		}
-		if (arg === "--wrapper-name") {
-			args.wrapperName = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--wrapper-name=")) {
-			args.wrapperName = arg.slice("--wrapper-name=".length);
-			continue;
-		}
-		if (arg === "--package-root") {
-			args.packageRoot = requiredValue(argv, ++index, arg);
-			continue;
-		}
-		if (arg.startsWith("--package-root=")) {
-			args.packageRoot = arg.slice("--package-root=".length);
+		const packageRootIndex = assignOptionValue(args, "packageRoot", argv, index, "--package-root");
+		if (packageRootIndex !== undefined) {
+			index = packageRootIndex;
 			continue;
 		}
 		throw new Error(`Unknown option: ${arg}`);

--- a/tests/install-utils.test.mjs
+++ b/tests/install-utils.test.mjs
@@ -6,13 +6,21 @@ import test from "node:test";
 
 import {
 	assertNotInNormalPiConfig,
+	assignOptionValue,
 	assignRequiredEqualsValue,
 	backupPathWithTimestamp,
 	backupTimestampSuffix,
+	defaultTlhAgentDir,
+	defaultTlhBinDir,
+	defaultTlhKeybindingsPath,
+	defaultTlhSettingsPath,
+	expandHomePath,
 	pathIsInNormalPiConfig,
 	readJsonFile,
+	readOptionValue,
 	renderShellWords,
 	requiredValue,
+	resolveTlhAgentDir,
 	shellQuote,
 	shellWord,
 } from "../scripts/lib/tlh-install-utils.mjs";
@@ -32,6 +40,37 @@ test("required CLI value helpers preserve installer option errors", () => {
 	assignRequiredEqualsValue(target, "key", "value", "--flag");
 	assert.deepEqual(target, { key: "value" });
 	assert.throws(() => assignRequiredEqualsValue(target, "key", "", "--flag"), /--flag requires a value/);
+});
+
+test("shared CLI option helpers parse split, equals, alias, and default path values", () => {
+	assert.deepEqual(readOptionValue(["--flag", "value"], 0, "--flag"), {
+		flag: "--flag",
+		value: "value",
+		nextIndex: 1,
+	});
+	assert.deepEqual(readOptionValue(["--flag=value"], 0, "--flag"), {
+		flag: "--flag",
+		value: "value",
+		nextIndex: 0,
+	});
+	assert.deepEqual(readOptionValue(["--defaults=manifest.json"], 0, ["--defaults", "--default-extensions"]), {
+		flag: "--defaults",
+		value: "manifest.json",
+		nextIndex: 0,
+	});
+	assert.throws(() => readOptionValue(["--flag="], 0, "--flag", { requireEqualsValue: true }), /--flag requires a value/);
+
+	const args = {};
+	assert.equal(assignOptionValue(args, "path", ["--path", "~/value"], 0, "--path"), 1);
+	assert.deepEqual(args, { path: "~/value" });
+
+	assert.equal(expandHomePath("~/agent", { homeDir: "/tmp/home" }), "/tmp/home/agent");
+	assert.equal(defaultTlhAgentDir({ PI_CODING_AGENT_DIR: "~/pi-agent", TLH_AGENT_DIR: "~/tlh-agent" }, { homeDir: "/tmp/home" }), "/tmp/home/pi-agent");
+	assert.equal(defaultTlhAgentDir({ PI_CODING_AGENT_DIR: "~/pi-agent", TLH_AGENT_DIR: "~/tlh-agent" }, { homeDir: "/tmp/home", preferTlhAgentDir: true }), "/tmp/home/tlh-agent");
+	assert.equal(resolveTlhAgentDir("~/custom-agent", { homeDir: "/tmp/home" }), "/tmp/home/custom-agent");
+	assert.equal(defaultTlhSettingsPath({ env: { TLH_AGENT_DIR: "~/tlh-agent" }, homeDir: "/tmp/home" }), "/tmp/home/tlh-agent/settings.json");
+	assert.equal(defaultTlhKeybindingsPath({ env: { PI_CODING_AGENT_DIR: "~/pi-agent" }, homeDir: "/tmp/home" }), "/tmp/home/pi-agent/keybindings.json");
+	assert.equal(defaultTlhBinDir({ TLH_BIN_DIR: "~/bin" }, { homeDir: "/tmp/home" }), "/tmp/home/bin");
 });
 
 test("readJsonFile handles BOM, empty files, missing fallbacks, and parse errors", (t) => {

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -10,8 +9,9 @@ import {
 	parseReviewArgs,
 	registerReviewCommand,
 } from "../extensions/the-last-harness/review.ts";
+import { cleanupTempDir, createIsolatedProfileFixture, makeTempDir as makeSharedTempDir, withEnv } from "./test-fixture-helpers.mjs";
 
-const reviewEnvRoot = mkdtempSync(join(tmpdir(), "tlh-review-agent-env-"));
+const reviewEnvRoot = makeSharedTempDir("tlh-review-agent-env-");
 const reviewEnvHome = join(reviewEnvRoot, "home");
 const reviewEnvAgent = join(reviewEnvRoot, "agent");
 const previousReviewPiAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -21,7 +21,7 @@ mkdirSync(reviewEnvAgent, { recursive: true });
 process.env.PI_CODING_AGENT_DIR = reviewEnvAgent;
 process.env.HOME = reviewEnvHome;
 process.on("exit", () => {
-	rmSync(reviewEnvRoot, { force: true, recursive: true });
+	cleanupTempDir(reviewEnvRoot);
 	if (previousReviewPiAgentDir === undefined) {
 		delete process.env.PI_CODING_AGENT_DIR;
 	} else {
@@ -106,45 +106,11 @@ function createReviewHarness({ cwd, exec, hasUI = true, custom, editor, branchEn
 }
 
 function makeTempDir(t, prefix) {
-	const cwd = mkdtempSync(join(tmpdir(), prefix));
-	t.after(() => {
-		rmSync(cwd, { force: true, recursive: true });
-	});
-	return cwd;
+	return makeSharedTempDir(prefix, t);
 }
 
 function makePrimaryFixture(t, prefix) {
-	const dir = makeTempDir(t, prefix);
-	const home = join(dir, "home");
-	const agent = join(dir, "agent");
-	const cwd = join(dir, "workspace");
-	mkdirSync(home, { recursive: true });
-	mkdirSync(agent, { recursive: true });
-	mkdirSync(cwd, { recursive: true });
-	return { dir, home, agent, cwd };
-}
-
-async function withEnv(env, fn) {
-	const previous = new Map();
-	for (const key of Object.keys(env)) {
-		previous.set(key, process.env[key]);
-		if (env[key] === undefined) {
-			delete process.env[key];
-		} else {
-			process.env[key] = env[key];
-		}
-	}
-	try {
-		return await fn();
-	} finally {
-		for (const [key, value] of previous) {
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
+	return createIsolatedProfileFixture(prefix, { cwd: true, test: t });
 }
 
 function assertRenderedPathLine(message, linePattern, expectedPath) {

--- a/tests/test-fixture-helpers.mjs
+++ b/tests/test-fixture-helpers.mjs
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function cleanupTempDir(target) {
+	const dir = typeof target === "string" ? target : target?.dir;
+	if (!dir) {
+		return;
+	}
+	rmSync(dir, { recursive: true, force: true });
+}
+
+export function makeTempDir(prefix, t) {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	t?.after?.(() => {
+		cleanupTempDir(dir);
+	});
+	return dir;
+}
+
+export function createIsolatedProfileFixture(prefix, { cwd = false, test } = {}) {
+	const dir = makeTempDir(prefix, test);
+	const home = join(dir, "home");
+	const agent = join(dir, "agent");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(agent, { recursive: true });
+	if (!cwd) {
+		return { dir, home, agent };
+	}
+	const workspace = join(dir, "workspace");
+	mkdirSync(workspace, { recursive: true });
+	return { dir, home, agent, cwd: workspace };
+}
+
+export async function withEnv(env, fn) {
+	const previous = new Map();
+	for (const key of Object.keys(env)) {
+		previous.set(key, process.env[key]);
+		if (env[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = env[key];
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -16,6 +16,7 @@ const primaryRuntimeSource = readFileSync(new URL("../extensions/the-last-harnes
 const effortSource = readFileSync(new URL("../extensions/the-last-harness/effort.ts", import.meta.url), "utf8");
 const promptsSource = readFileSync(new URL("../extensions/the-last-harness/prompts.ts", import.meta.url), "utf8");
 const usageLimitsSource = readFileSync(new URL("../extensions/the-last-harness/usage-limits.ts", import.meta.url), "utf8");
+const profileStateSource = readFileSync(new URL("../extensions/the-last-harness/profile-state.ts", import.meta.url), "utf8");
 const jiti = createJiti(import.meta.url);
 const { buildChildSubagentSystemPrompt, buildTlhSystemPrompt, loadPrimaryAgents, loadSubagentMetadata } = await jiti.import(
 	"../extensions/the-last-harness/prompts.ts",
@@ -235,13 +236,28 @@ test("extension wires TLH changelog command and release-notes rendering", () => 
 });
 
 test("extension wires usage-limit command to isolated TLH settings", () => {
+	const lockedWriteHelper = sourceSection(
+		profileStateSource,
+		"export function withLockedTlhSettingsWrite",
+		"export function assertSafeTlhSettingsPath",
+	);
+
 	assert.match(extensionSource, /registerUsageCommand\(pi\)/);
+	assert.match(usageLimitsSource, /from "\.\/profile-state\.js"/);
 	assert.match(usageLimitsSource, /pi\.registerCommand\("usage"/);
 	assert.match(usageLimitsSource, /value: "weekly on"/);
 	assert.match(usageLimitsSource, /value: "weekly off"/);
 	assert.match(usageLimitsSource, /value: "weekly toggle"/);
-	assert.match(usageLimitsSource, /tlhSettingsPathForWrite\(\)/);
-	assert.match(usageLimitsSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
+	assert.match(
+		usageLimitsSource,
+		/withLockedTlhSettingsWrite\(cwd, "Refusing to write usage-limit settings outside the isolated TLH profile\./,
+	);
+	assert.doesNotMatch(usageLimitsSource, /tlhSettingsPathForWrite\(\)/);
+	assert.doesNotMatch(usageLimitsSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
+	assert.match(lockedWriteHelper, /const settingsPath = tlhSettingsPathForWrite\(\);/);
+	assert.match(lockedWriteHelper, /assertSafeTlhSettingsPath\(settingsPath\);/);
+	assert.match(lockedWriteHelper, /const backupPath = current \? `\$\{settingsPath\}\.bak-\$\{settingsBackupTimestamp\(\)\}` : undefined;/);
+	assert.match(lockedWriteHelper, /writeFileSync\(backupPath, current, \{ encoding: "utf8", flag: "wx", mode: 0o600 \}\);/);
 	assert.match(usageLimitsSource, /settings\.tlh\.usageLimits\.showWeekly = showWeekly/);
 	assert.match(usageLimitsSource, /showWeekly === true/);
 });

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -174,6 +174,28 @@ test("footer includes Anthropic weekly usage only when the preference enables it
 	assert.match(sessionLine, /weekly 88\.9% used/);
 });
 
+test("footer context and subscription usage keep compact token formatting", () => {
+	const snapshot = {
+		provider: "openai-codex",
+		fetchedAt: NOW_MS,
+		windows: {
+			session: { key: "primary_window", label: "session", used: 1500, limit: 9999 },
+		},
+	};
+	const ctx = createCtx({
+		provider: "openai-codex",
+		contextUsage: { tokens: 1000, contextWindow: 9999, percent: 12.3 },
+	});
+	const usageOptions = {
+		subscriptionUsage: usageProvider(snapshot),
+		shouldShowWeekly: () => false,
+	};
+
+	assert.match(renderAgentLine(ctx, usageOptions), /12\.3%\/10\.0k/);
+	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot), "session 1.5k/10.0k used");
+	assert.match(renderSessionStatsLine(ctx, usageOptions), /session 1\.5k\/10\.0k used/);
+});
+
 test("footer render reads cached usage snapshots without refreshing", () => {
 	let refreshCalls = 0;
 	const subscriptionUsage = {

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { createJiti } from "jiti";
 
 import { PRIMARY_AGENT_SESSION_STATE_ENTRY } from "../extensions/the-last-harness-primary-agent.mjs";
+import { cleanupTempDir, createIsolatedProfileFixture, withEnv } from "./test-fixture-helpers.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { registerTlhPrimaryAgentRuntime } = await jiti.import("../extensions/the-last-harness/primary-agent-runtime.ts");
@@ -77,39 +77,6 @@ function registerRuntimeHarness(options = {}) {
 	return { pi, runtime, toolCall };
 }
 
-function tempFixture() {
-	const dir = mkdtempSync(join(tmpdir(), "tlh-primary-runtime-test-"));
-	const home = join(dir, "home");
-	const agent = join(dir, "agent");
-	const cwd = join(dir, "workspace");
-	mkdirSync(home, { recursive: true });
-	mkdirSync(agent, { recursive: true });
-	mkdirSync(cwd, { recursive: true });
-	return { dir, home, agent, cwd };
-}
-
-async function withEnv(env, fn) {
-	const previous = new Map();
-	for (const key of Object.keys(env)) {
-		previous.set(key, process.env[key]);
-		if (env[key] === undefined) {
-			delete process.env[key];
-		} else {
-			process.env[key] = env[key];
-		}
-	}
-	try {
-		return await fn();
-	} finally {
-		for (const [key, value] of previous) {
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
-}
 
 function writePrimaryConfig(agentDir, primaryAgent = {}) {
 	writeFileSync(join(agentDir, "settings.json"), `${JSON.stringify({ tlh: { primaryAgent } }, null, 2)}\n`);
@@ -274,7 +241,7 @@ test("/switch-primary-agent includes Rush completions, usage, and status strings
 });
 
 test("/switch-primary-agent default writes tlh.primaryAgent with a backup", async () => {
-	const fixture = tempFixture();
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true });
 	const initialSettings = `${JSON.stringify({ tlh: { primaryAgent: { selected: "architect" } } }, null, 2)}\n`;
 
 	try {
@@ -296,7 +263,28 @@ test("/switch-primary-agent default writes tlh.primaryAgent with a backup", asyn
 			assert.match(writeDefault.notifications.at(-1)?.message ?? "", /Updated TLH primary-agent persistent default/);
 		});
 	} finally {
-		rmSync(fixture.dir, { recursive: true, force: true });
+		cleanupTempDir(fixture);
+	}
+});
+
+test("/switch-primary-agent default refuses normal Pi settings", async () => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true });
+	const normalAgent = join(fixture.home, ".pi", "agent");
+
+	try {
+		await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: normalAgent }, async () => {
+			const { pi } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+			const command = pi.commands.get("switch-primary-agent");
+			assert.ok(command, "registers /switch-primary-agent");
+
+			const writeDefault = createCommandContext([], { cwd: fixture.cwd });
+			await command.handler("default rush", writeDefault.ctx);
+
+			assert.equal(writeDefault.notifications.at(-1)?.type, "error");
+			assert.match(writeDefault.notifications.at(-1)?.message ?? "", /isolated TLH profile|normal Pi config/);
+		});
+	} finally {
+		cleanupTempDir(fixture);
 	}
 });
 
@@ -328,7 +316,7 @@ test("Rush blocks developer delegation even inside nested subagent plans", async
 });
 
 test("primary runtime applies OpenAI Rush-like metadata defaults with no settings opt-in", async () => {
-	const fixture = tempFixture();
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true });
 	const primaryAgents = new Map([["architect", rushLikePrimary()]]);
 
 	try {
@@ -348,12 +336,12 @@ test("primary runtime applies OpenAI Rush-like metadata defaults with no setting
 			assert.equal(pi.thinkingLevel, "off");
 		});
 	} finally {
-		rmSync(fixture.dir, { recursive: true, force: true });
+		cleanupTempDir(fixture);
 	}
 });
 
 test("primary runtime falls back to Anthropic Rush-like metadata defaults when only Anthropic is available", async () => {
-	const fixture = tempFixture();
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true });
 	const primaryAgents = new Map([["architect", rushLikePrimary()]]);
 
 	try {
@@ -373,12 +361,12 @@ test("primary runtime falls back to Anthropic Rush-like metadata defaults when o
 			assert.equal(pi.thinkingLevel, "low");
 		});
 	} finally {
-		rmSync(fixture.dir, { recursive: true, force: true });
+		cleanupTempDir(fixture);
 	}
 });
 
 test("primary runtime respects explicit false settings over Rush-like metadata defaults", async () => {
-	const fixture = tempFixture();
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true });
 	const primaryAgents = new Map([["architect", rushLikePrimary()]]);
 
 	try {
@@ -399,6 +387,6 @@ test("primary runtime respects explicit false settings over Rush-like metadata d
 			assert.equal(pi.thinkingLevel, "normal");
 		});
 	} finally {
-		rmSync(fixture.dir, { recursive: true, force: true });
+		cleanupTempDir(fixture);
 	}
 });

--- a/tests/the-last-harness-usage-limits.test.mjs
+++ b/tests/the-last-harness-usage-limits.test.mjs
@@ -1,45 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
 import { createJiti } from "jiti";
 
+import { createIsolatedProfileFixture, withEnv } from "./test-fixture-helpers.mjs";
+
 const jiti = createJiti(import.meta.url);
 const { registerUsageCommand, shouldShowTlhUsageWeekly } = await jiti.import("../extensions/the-last-harness/usage-limits.ts");
-
-function tempFixture() {
-	const dir = mkdtempSync(join(tmpdir(), "tlh-usage-limits-test-"));
-	const home = join(dir, "home");
-	const agent = join(dir, "agent");
-	mkdirSync(home, { recursive: true });
-	mkdirSync(agent, { recursive: true });
-	return { dir, home, agent };
-}
-
-async function withEnv(env, fn) {
-	const previous = new Map();
-	for (const key of Object.keys(env)) {
-		previous.set(key, process.env[key]);
-		if (env[key] === undefined) {
-			delete process.env[key];
-		} else {
-			process.env[key] = env[key];
-		}
-	}
-	try {
-		return await fn();
-	} finally {
-		for (const [key, value] of previous) {
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
-}
 
 function createPiHarness() {
 	const commands = new Map();
@@ -74,8 +43,8 @@ function registeredUsageCommand() {
 	return command;
 }
 
-test("usage command registers completions and reports weekly hidden by default", async () => {
-	const fixture = tempFixture();
+test("usage command registers completions and reports weekly hidden by default", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const command = registeredUsageCommand();
@@ -97,8 +66,8 @@ test("usage command registers completions and reports weekly hidden by default",
 	});
 });
 
-test("usage weekly preference writes isolated settings and backs up existing settings", async () => {
-	const fixture = tempFixture();
+test("usage weekly preference writes isolated settings and backs up existing settings", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 	const settingsPath = join(fixture.agent, "settings.json");
 	const initialSettings = `${JSON.stringify({ tlh: { gnosis: { enabled: true } } }, null, 2)}\n`;
 	writeFileSync(settingsPath, initialSettings);
@@ -126,8 +95,8 @@ test("usage weekly preference writes isolated settings and backs up existing set
 	});
 });
 
-test("usage weekly on is idempotent across repeated invocations", async () => {
-	const fixture = tempFixture();
+test("usage weekly on is idempotent across repeated invocations", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 	const settingsPath = join(fixture.agent, "settings.json");
 	writeFileSync(settingsPath, `${JSON.stringify({ tlh: { gnosis: { enabled: true } } }, null, 2)}\n`);
 
@@ -163,8 +132,8 @@ test("usage weekly on is idempotent across repeated invocations", async () => {
 	});
 });
 
-test("usage weekly off and toggle persist explicit preferences", async () => {
-	const offFixture = tempFixture();
+test("usage weekly off and toggle persist explicit preferences", async (t) => {
+	const offFixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 	const offSettingsPath = join(offFixture.agent, "settings.json");
 	writeFileSync(offSettingsPath, `${JSON.stringify({ tlh: { usageLimits: { showWeekly: true } } }, null, 2)}\n`);
 
@@ -187,7 +156,7 @@ test("usage weekly off and toggle persist explicit preferences", async () => {
 		assert.match(notice?.message ?? "", /\/usage weekly on/);
 	});
 
-	const toggleFixture = tempFixture();
+	const toggleFixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 	const toggleSettingsPath = join(toggleFixture.agent, "settings.json");
 
 	await withEnv({ HOME: toggleFixture.home, PI_CODING_AGENT_DIR: toggleFixture.agent }, async () => {
@@ -207,8 +176,8 @@ test("usage weekly off and toggle persist explicit preferences", async () => {
 	});
 });
 
-test("usage weekly writes refuse normal Pi settings", async () => {
-	const fixture = tempFixture();
+test("usage weekly writes refuse normal Pi settings", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 	const normalAgent = join(fixture.home, ".pi", "agent");
 	mkdirSync(normalAgent, { recursive: true });
 


### PR DESCRIPTION
## Summary
- extract shared test fixture helpers for env/temp isolated-profile setup
- centralize repeated Node CLI option/path/default helpers in `scripts/lib/tlh-install-utils.mjs`
- share compact token formatting and locked TLH settings write/backup logic across extension modules

## Validation
- `npm run validate`

## Notes
- intentionally leaves `install.sh` / `uninstall.sh` duplication in place to preserve standalone bootstrap/uninstall behavior
