### PR TITLE
Add isolated extension update command

### DIFF
--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -9,6 +9,7 @@ import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
 import { readTlhInstallNotice } from "./the-last-harness/install-state.js";
 import { scheduleTlhLaunchTelemetry } from "./the-last-harness/launch-telemetry.js";
+import { installTlhPackageUpdateNotificationOverride } from "./the-last-harness/package-update-notice.js";
 import { registerTlhPrimaryAgentRuntime } from "./the-last-harness/primary-agent-runtime.js";
 import { collectStartupResources } from "./the-last-harness/resources.js";
 import { createTlhSubscriptionUsageService } from "./the-last-harness/subscription-usage.mjs";
@@ -22,6 +23,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 		return;
 	}
 
+	installTlhPackageUpdateNotificationOverride();
 	registerEffortCommand(pi);
 	registerReviewCommand(pi);
 	registerTlhChangelogCommand(pi);

--- a/extensions/the-last-harness/package-update-notice.ts
+++ b/extensions/the-last-harness/package-update-notice.ts
@@ -1,0 +1,42 @@
+import { DynamicBorder, InteractiveMode } from "@earendil-works/pi-coding-agent";
+import { Spacer, Text } from "@earendil-works/pi-tui";
+
+const TLH_PACKAGE_UPDATE_NOTICE_PATCHED = Symbol.for("tlh.packageUpdateNoticePatched");
+const TLH_PACKAGE_UPDATE_TITLE = "TLH Extension/Package Updates Available";
+const TLH_PACKAGE_UPDATE_INSTRUCTION = "TLH extension/package updates are available. Run tlh update --extensions";
+
+type TlhPackageUpdateNotificationTarget = {
+	chatContainer: {
+		addChild(component: unknown): void;
+	};
+	ui: {
+		requestRender(): void;
+	};
+};
+
+type TlhInteractiveModePrototype = typeof InteractiveMode.prototype & {
+	[TLH_PACKAGE_UPDATE_NOTICE_PATCHED]?: boolean;
+};
+
+function showTlhPackageUpdateNotification(this: TlhPackageUpdateNotificationTarget, packages: string[]): void {
+	const packageLines = packages.map((pkg) => `- ${pkg}`).join("\n");
+
+	this.chatContainer.addChild(new Spacer(1));
+	this.chatContainer.addChild(new DynamicBorder((text) => text));
+	this.chatContainer.addChild(
+		new Text(`${TLH_PACKAGE_UPDATE_TITLE}\n${TLH_PACKAGE_UPDATE_INSTRUCTION}\nPackages:\n${packageLines}`, 1, 0),
+	);
+	this.chatContainer.addChild(new DynamicBorder((text) => text));
+	this.ui.requestRender();
+}
+
+export function installTlhPackageUpdateNotificationOverride(): void {
+	const interactiveModePrototype = InteractiveMode.prototype as TlhInteractiveModePrototype;
+	if (interactiveModePrototype[TLH_PACKAGE_UPDATE_NOTICE_PATCHED]) {
+		return;
+	}
+
+	interactiveModePrototype.showPackageUpdateNotification =
+		showTlhPackageUpdateNotification as unknown as typeof interactiveModePrototype.showPackageUpdateNotification;
+	interactiveModePrototype[TLH_PACKAGE_UPDATE_NOTICE_PATCHED] = true;
+}

--- a/scripts/tlh-update.mjs
+++ b/scripts/tlh-update.mjs
@@ -6,6 +6,9 @@ import { spawnSync } from "node:child_process";
 import process from "node:process";
 
 import {
+	pathIsProtectedPiConfig,
+} from "./lib/tlh-install-paths.mjs";
+import {
 	assignOptionValue,
 	defaultTlhAgentDir,
 	defaultTlhBinDir,
@@ -16,6 +19,16 @@ const DEFAULT_REPO = "diegopetrucci/the-last-harness";
 const DEFAULT_WRAPPER_NAME = "tlh";
 const VALID_TRACKS = new Set(["latest-release", "pinned-tag", "ref", "custom"]);
 const DOWNLOAD_TIMEOUT_MS = 30_000;
+const PACKAGE_UPDATE_ARGS = ["update", "--extensions"];
+const PACKAGE_UPDATE_UNSUPPORTED_OPTIONS = [
+	["track", "--track"],
+	["ref", "--ref"],
+	["repo", "--repo"],
+	["packageSource", "--package-source"],
+	["force", "--force"],
+	["noSettings", "--no-settings"],
+	["noWrapper", "--no-wrapper"],
+];
 
 function usage() {
 	return `Usage: tlh update [options]
@@ -27,6 +40,7 @@ Options:
   --agent-dir DIR       Isolated profile dir (default: ~/.the-last-harness/agent)
   --bin-dir DIR         Wrapper install dir (default: ~/.local/bin)
   --wrapper-name NAME   Wrapper command name (default: tlh)
+  --extensions          Update isolated extensions/packages only via pi update --extensions
   --track TRACK         Override update track: latest-release, pinned-tag, ref, custom
   --ref REF             Override git ref/tag for pinned-tag or ref tracks
   --repo OWNER/REPO     Override GitHub repository
@@ -50,7 +64,9 @@ function parseArgs(argv) {
 		track: undefined,
 		ref: undefined,
 		packageSource: process.env.TLH_PACKAGE_SOURCE,
+		explicitOptions: new Set(),
 		dryRun: false,
+		extensions: false,
 		force: false,
 		noSettings: false,
 		noWrapper: false,
@@ -67,18 +83,27 @@ function parseArgs(argv) {
 		}
 		if (arg === "--dry-run") {
 			args.dryRun = true;
+			args.explicitOptions.add("dryRun");
+			continue;
+		}
+		if (arg === "--extensions") {
+			args.extensions = true;
+			args.explicitOptions.add("extensions");
 			continue;
 		}
 		if (arg === "--force") {
 			args.force = true;
+			args.explicitOptions.add("force");
 			continue;
 		}
 		if (arg === "--no-settings") {
 			args.noSettings = true;
+			args.explicitOptions.add("noSettings");
 			continue;
 		}
 		if (arg === "--no-wrapper") {
 			args.noWrapper = true;
+			args.explicitOptions.add("noWrapper");
 			continue;
 		}
 		if (arg === "--quiet") {
@@ -93,36 +118,43 @@ function parseArgs(argv) {
 		}
 		const agentDirIndex = assignOptionValue(args, "agentDir", argv, i, "--agent-dir");
 		if (agentDirIndex !== undefined) {
+			args.explicitOptions.add("agentDir");
 			i = agentDirIndex;
 			continue;
 		}
 		const binDirIndex = assignOptionValue(args, "binDir", argv, i, "--bin-dir");
 		if (binDirIndex !== undefined) {
+			args.explicitOptions.add("binDir");
 			i = binDirIndex;
 			continue;
 		}
 		const wrapperNameIndex = assignOptionValue(args, "wrapperName", argv, i, "--wrapper-name");
 		if (wrapperNameIndex !== undefined) {
+			args.explicitOptions.add("wrapperName");
 			i = wrapperNameIndex;
 			continue;
 		}
 		const trackIndex = assignOptionValue(args, "track", argv, i, "--track");
 		if (trackIndex !== undefined) {
+			args.explicitOptions.add("track");
 			i = trackIndex;
 			continue;
 		}
 		const refIndex = assignOptionValue(args, "ref", argv, i, "--ref");
 		if (refIndex !== undefined) {
+			args.explicitOptions.add("ref");
 			i = refIndex;
 			continue;
 		}
 		const repoIndex = assignOptionValue(args, "repo", argv, i, "--repo");
 		if (repoIndex !== undefined) {
+			args.explicitOptions.add("repo");
 			i = repoIndex;
 			continue;
 		}
 		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, i, "--package-source");
 		if (packageSourceIndex !== undefined) {
+			args.explicitOptions.add("packageSource");
 			i = packageSourceIndex;
 			continue;
 		}
@@ -458,6 +490,56 @@ function printDryRun(plan, installerArgs, env) {
 	console.log(`Would run: ${prefix}bash <downloaded install.sh> ${installerArgs.map(shellQuote).join(" ")}`);
 }
 
+function assertPackageUpdateTargetSafe(agentDir) {
+	if (pathIsProtectedPiConfig(agentDir)) {
+		throw new Error(`refusing to run The Last Harness extension update against normal Pi config root: ${agentDir}`);
+	}
+}
+
+function assertPackageUpdateArgs(args) {
+	const unsupported = PACKAGE_UPDATE_UNSUPPORTED_OPTIONS
+		.filter(([key]) => args.explicitOptions.has(key))
+		.map(([, flag]) => flag);
+	if (unsupported.length > 0) {
+		throw new Error(`--extensions does not support ${unsupported.join(", ")}. Run plain tlh update for installer updates.`);
+	}
+}
+
+function printPackageUpdateDryRun(piCommand, args) {
+	console.log("The Last Harness extension update plan");
+	console.log(`Agent dir: ${args.agentDir}`);
+	console.log(`Would run: PI_CODING_AGENT_DIR=${shellQuote(args.agentDir)} ${shellQuote(piCommand)} ${PACKAGE_UPDATE_ARGS.map(shellQuote).join(" ")}`);
+}
+
+function runPackageUpdate(args) {
+	assertPackageUpdateTargetSafe(args.agentDir);
+	assertPackageUpdateArgs(args);
+	const sanitizedEnv = envWithSanitizedPath(process.env, args.agentDir);
+	const piCommand = resolveCommand("pi", sanitizedEnv);
+	if (args.dryRun) {
+		printPackageUpdateDryRun(piCommand, args);
+		return;
+	}
+	if (isTruthyEnv(process.env.PI_OFFLINE)) {
+		throw new Error("PI_OFFLINE is set; refusing to run a network update.");
+	}
+	if (!args.quiet) {
+		console.log("Updating The Last Harness isolated extensions...");
+		if (args.verbose) console.log(`Pi: ${piCommand}`);
+	}
+	const result = spawnSync(piCommand, PACKAGE_UPDATE_ARGS, {
+		stdio: "inherit",
+		env: {
+			...sanitizedEnv,
+			PI_CODING_AGENT_DIR: args.agentDir,
+		},
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	process.exitCode = result.status ?? (result.signal ? 1 : 0);
+}
+
 async function downloadInstaller(url) {
 	const response = await fetch(url, {
 		headers: {
@@ -484,6 +566,10 @@ async function main() {
 	const args = parseArgs(process.argv.slice(2));
 	if (args.help) {
 		process.stdout.write(usage());
+		return;
+	}
+	if (args.extensions) {
+		runPackageUpdate(args);
 		return;
 	}
 	if (args.track && !VALID_TRACKS.has(args.track)) {

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -774,6 +774,168 @@ test("tlh update rejects legacy ticket integration flags", (t) => {
 	}
 });
 
+test("tlh update --extensions dry-run prints the isolated package update plan and rejects installer-only flags", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const fakebin = join(root, "fakebin");
+	const dryRunPiLog = join(root, "dry-run-pi.log");
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	writeFakePi(fakebin, "printf 'pi should not run during dry-run\\n' >\"${DRY_RUN_PI_LOG}\"\nexit 91");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const runUpdate = (...extraArgs) => spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-update.mjs"), "--extensions", "--dry-run", "--agent-dir", agentDir, ...extraArgs], {
+		cwd: repoRoot,
+		env: scrubInstallerEnv({
+			HOME: homeDir,
+			PATH: `${fakebin}:${process.env.PATH || ""}`,
+			DRY_RUN_PI_LOG: dryRunPiLog,
+			PI_CODING_AGENT_DIR: join(homeDir, ".pi", "agent"),
+		}),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	const defaultResult = runUpdate();
+	assert.equal(defaultResult.status, 0, defaultResult.stderr);
+	assert.match(defaultResult.stdout, /The Last Harness extension update plan/);
+	assert.ok(defaultResult.stdout.includes(`Agent dir: ${agentDir}`));
+	assert.match(defaultResult.stdout, /Would run: PI_CODING_AGENT_DIR='/);
+	assert.match(defaultResult.stdout, /'update' '--extensions'/);
+	assert.equal(defaultResult.stdout.includes(join(homeDir, ".pi", "agent")), false);
+	assert.equal(defaultResult.stderr, "");
+	assert.equal(existsSync(dryRunPiLog), false);
+
+	const unsupportedFlags = [
+		["--track", "ref"],
+		["--ref", "main"],
+		["--repo", "owner/repo"],
+		["--package-source", "git:github.com/owner/repo@main"],
+		["--force"],
+		["--no-settings"],
+		["--no-wrapper"],
+	];
+	for (const [flag, value] of unsupportedFlags) {
+		const result = value ? runUpdate(flag, value) : runUpdate(flag);
+		assert.notEqual(result.status, 0, `expected ${flag} to be rejected`);
+		assert.match(result.stderr, /--extensions does not support /);
+		assert.match(result.stderr, new RegExp(flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+		assert.equal(result.stdout, "");
+	}
+});
+
+test("tlh update --extensions refuses to target normal Pi config via explicit or inherited agent dir selection", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const protectedAgentDir = join(homeDir, ".pi", "agent");
+	mkdirSync(homeDir, { recursive: true });
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const scenarios = [
+		{
+			name: "explicit --agent-dir",
+			args: ["--agent-dir", protectedAgentDir],
+			env: {},
+		},
+		{
+			name: "PI_CODING_AGENT_DIR fallback",
+			args: [],
+			env: { PI_CODING_AGENT_DIR: protectedAgentDir },
+		},
+		{
+			name: "TLH_AGENT_DIR override",
+			args: [],
+			env: { TLH_AGENT_DIR: protectedAgentDir },
+		},
+	];
+
+	for (const scenario of scenarios) {
+		const result = spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-update.mjs"), "--extensions", "--dry-run", ...scenario.args], {
+			cwd: repoRoot,
+			env: scrubInstallerEnv({
+				HOME: homeDir,
+				PATH: "",
+				...scenario.env,
+			}),
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		assert.notEqual(result.status, 0, `expected ${scenario.name} to be rejected`);
+		assert.equal(result.stdout, "");
+		assert.match(result.stderr, /refusing to run The Last Harness extension update against normal Pi config root/);
+		assert.ok(result.stderr.includes(protectedAgentDir), `${scenario.name} stderr should mention the protected agent dir`);
+		assert.doesNotMatch(result.stderr, /required command not found on sanitized PATH: pi/);
+	}
+	assert.equal(existsSync(join(homeDir, ".pi")), false);
+});
+
+test("tlh update --extensions resolves pi on the sanitized PATH and targets the isolated agent dir", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const agentBin = join(agentDir, "bin");
+	const agentBinLink = join(root, "agent-bin-link");
+	const cwdDir = join(root, "cwd");
+	const cwdLink = join(root, "cwd-link");
+	const safeBin = join(root, "safe-bin");
+	const piLog = join(root, "pi.txt");
+	const currentPiLog = join(root, "current-pi.log");
+	const isolatedPiLog = join(root, "isolated-pi.log");
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentBin, { recursive: true });
+	mkdirSync(cwdDir, { recursive: true });
+	if (process.platform !== "win32") {
+		symlinkSync(agentBin, agentBinLink, "dir");
+		symlinkSync(cwdDir, cwdLink, "dir");
+	}
+	writeFakePi(agentBin, "printf 'isolated pi intercepted\\n' >\"${ISOLATED_PI_LOG}\"\nexit 89");
+	writeFakePi(cwdDir, "printf 'current-dir pi intercepted\\n' >\"${CURRENT_PI_LOG}\"\nexit 86");
+	writeFakePi(safeBin, "{ printf 'cmd=%s\\n' \"$0\"; printf 'argv=%s\\n' \"$*\"; printf 'agent=%s\\n' \"${PI_CODING_AGENT_DIR:-}\"; printf 'path=%s\\n' \"${PATH:-}\"; } >\"${PI_WRAPPER_LOG}\"");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const poisonedPathEntries = ["", ".", cwdDir, agentBin];
+	if (process.platform !== "win32") poisonedPathEntries.push(cwdLink, agentBinLink);
+	poisonedPathEntries.push(safeBin, process.env.PATH || "");
+	const result = spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-update.mjs"), "--extensions", "--agent-dir", agentDir, "--quiet"], {
+		cwd: cwdDir,
+		env: scrubInstallerEnv({
+			HOME: homeDir,
+			PATH: poisonedPathEntries.join(":"),
+			PI_WRAPPER_LOG: piLog,
+			CURRENT_PI_LOG: currentPiLog,
+			ISOLATED_PI_LOG: isolatedPiLog,
+			PI_CODING_AGENT_DIR: join(homeDir, ".pi", "agent"),
+		}),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.stdout, "");
+	const piRecord = Object.fromEntries(readFileSync(piLog, "utf8").trim().split(/\r?\n/).map((line) => {
+		const separator = line.indexOf("=");
+		return [line.slice(0, separator), line.slice(separator + 1)];
+	}));
+	assert.equal(piRecord.cmd, join(safeBin, "pi"));
+	assert.equal(piRecord.argv, "update --extensions");
+	assert.equal(piRecord.agent, agentDir);
+	assert.notEqual(piRecord.agent, join(homeDir, ".pi", "agent"));
+	const piPathEntries = piRecord.path.split(":");
+	assert.equal(piPathEntries[0], safeBin);
+	assert.equal(piPathEntries.includes(""), false);
+	assert.equal(piPathEntries.includes("."), false);
+	assert.equal(piPathEntries.includes(cwdDir), false);
+	assert.equal(piPathEntries.includes(agentBin), false);
+	if (process.platform !== "win32") {
+		assert.equal(piPathEntries.includes(cwdLink), false);
+		assert.equal(piPathEntries.includes(agentBinLink), false);
+	}
+	assert.equal(existsSync(currentPiLog), false);
+	assert.equal(existsSync(isolatedPiLog), false);
+});
+
 test("tlh update removes isolated bin and skips non-file bash candidates before running bash", (t) => {
 	const root = makeTempDir();
 	const homeDir = join(root, "home");

--- a/tests/the-last-harness-extension-package-update-notice.test.mjs
+++ b/tests/the-last-harness-extension-package-update-notice.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { InteractiveMode } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { installTlhPackageUpdateNotificationOverride } = await jiti.import(
+	"../extensions/the-last-harness/package-update-notice.ts",
+);
+
+function findTextComponent(children) {
+	return children.find((child) => child instanceof Text || child?.constructor?.name === "Text");
+}
+
+test("TLH package-update startup notice directs users to tlh update --extensions and preserves packages", () => {
+	installTlhPackageUpdateNotificationOverride();
+
+	const children = [];
+	let renderRequests = 0;
+	const target = {
+		chatContainer: {
+			addChild(child) {
+				children.push(child);
+			},
+		},
+		ui: {
+			requestRender() {
+				renderRequests += 1;
+			},
+		},
+	};
+
+	InteractiveMode.prototype.showPackageUpdateNotification.call(target, [
+		"npm:@acme/first-extension",
+		"git:github.com/acme/second-extension",
+	]);
+
+	const text = findTextComponent(children);
+	assert.ok(text, "expected a text component in the startup notice");
+	assert.equal(renderRequests, 1);
+	assert.match(text.text, /TLH extension\/package updates are available\. Run tlh update --extensions/);
+	assert.match(text.text, /Packages:\n- npm:@acme\/first-extension\n- git:github\.com\/acme\/second-extension/);
+	assert.doesNotMatch(text.text, /pi update/);
+});

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -142,6 +142,7 @@ test("extension imports extracted shared helpers from nested TypeScript modules"
 	assert.doesNotMatch(extensionSource, /from "\.\/the-last-harness\/gnosis\.js"/);
 	assert.doesNotMatch(extensionSource, /registerGnosisCommand/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/header\.js"/);
+	assert.match(extensionSource, /from "\.\/the-last-harness\/package-update-notice\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/primary-agent-runtime\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/resources\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/subscription-usage\.mjs"/);
@@ -174,6 +175,10 @@ test("extension delegates launch update and telemetry services to feature module
 	assert.match(sessionStart, /maybeNotifyAvailableTlhUpdate\(ctx\)/);
 	assert.doesNotMatch(extensionSource, /function maybeSendTlhLaunchTelemetry/);
 	assert.doesNotMatch(extensionSource, /function fetchLatestTlhRelease/);
+});
+
+test("extension installs the TLH package-update startup notice override during activation", () => {
+	assert.match(extensionSource, /installTlhPackageUpdateNotificationOverride\(\)/);
 });
 
 test("extension runs primary session_start work before UI startup in one handler", () => {


### PR DESCRIPTION
## Summary
- add `tlh update --extensions` for isolated TLH package updates
- guard the command from targeting normal `~/.pi` / `~/.pi/agent` paths
- override the startup package-update notice to recommend `tlh update --extensions`

## Validation
- `npm run validate`
- final code-reviewer pass: no findings