### PR TITLE
Show subscription usage reset countdown in footer

### DIFF
--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -7,12 +7,14 @@ import type {
 } from "./types.js";
 
 const TLH_SUBSCRIPTION_USAGE_PROVIDERS = new Set(["openai-codex", "anthropic"]);
-const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
 export type TlhFooterSubscriptionUsageOptions = {
 	subscriptionUsage?: TlhSubscriptionUsageSnapshotProvider;
 	shouldShowWeekly?: () => boolean;
+	nowMs?: number;
 };
 
 export type TlhSubscriptionUsageFooterState = {
@@ -49,6 +51,40 @@ function formatUsageDuration(durationMs: number | undefined): string | undefined
 	return undefined;
 }
 
+function formatResetCountdown(
+	resetsAt: string | undefined,
+	nowMs: number,
+	windowType: "session" | "weekly",
+): string | undefined {
+	if (!resetsAt) {
+		return undefined;
+	}
+	const resetMs = Date.parse(resetsAt);
+	if (!Number.isFinite(resetMs)) {
+		return undefined;
+	}
+	const deltaMs = resetMs - nowMs;
+	if (deltaMs <= 0) {
+		return undefined;
+	}
+	const totalMinutes = Math.floor(deltaMs / MINUTE_MS);
+	const totalHours = Math.floor(deltaMs / HOUR_MS);
+	const totalDays = Math.floor(deltaMs / DAY_MS);
+	if (windowType === "weekly" && totalDays >= 1) {
+		const remainingHours = Math.floor((deltaMs - totalDays * DAY_MS) / HOUR_MS);
+		return `${totalDays}d ${remainingHours}h`;
+	}
+	// Session-style format (also used as weekly fallback when delta < 1 day)
+	if (totalMinutes < 1) {
+		return "<1m";
+	}
+	if (totalHours < 1) {
+		return `${totalMinutes}m`;
+	}
+	const remainingMinutes = totalMinutes - totalHours * 60;
+	return `${totalHours}h${remainingMinutes}m`;
+}
+
 function normalizedUsageLabel(value: string | undefined): string {
 	return value?.trim().toLowerCase().replaceAll("_", "-").replaceAll(" ", "-") ?? "";
 }
@@ -80,6 +116,7 @@ function formatUsageWindow(
 	provider: string,
 	window: TlhSubscriptionUsageWindow | undefined,
 	windowType: "session" | "weekly",
+	nowMs: number,
 ): string | undefined {
 	if (!window) {
 		return undefined;
@@ -87,39 +124,47 @@ function formatUsageWindow(
 
 	const label = formatUsageWindowLabel(provider, window, windowType);
 	const percent = finiteNumber(window.percent);
+
+	let base: string | undefined;
 	if (percent !== undefined) {
-		return `${label} ${formatUsagePercent(percent)}% used`;
+		base = `${label} ${formatUsagePercent(percent)}% used`;
+	} else {
+		const limit = finiteNumber(window.limit);
+		let used = finiteNumber(window.used);
+		const remaining = finiteNumber(window.remaining);
+		if (used === undefined && limit !== undefined && remaining !== undefined) {
+			used = Math.max(0, limit - remaining);
+		}
+		if (used !== undefined && limit !== undefined && limit > 0) {
+			base = `${label} ${formatUsageCount(used)}/${formatUsageCount(limit)} used`;
+		}
 	}
 
-	const limit = finiteNumber(window.limit);
-	let used = finiteNumber(window.used);
-	const remaining = finiteNumber(window.remaining);
-	if (used === undefined && limit !== undefined && remaining !== undefined) {
-		used = Math.max(0, limit - remaining);
-	}
-	if (used !== undefined && limit !== undefined && limit > 0) {
-		return `${label} ${formatUsageCount(used)}/${formatUsageCount(limit)} used`;
+	if (!base) {
+		return undefined;
 	}
 
-	return undefined;
+	const countdown = formatResetCountdown(window.resetsAt, nowMs, windowType);
+	return countdown ? `${base}, resets in ${countdown}` : base;
 }
 
 export function formatTlhSubscriptionUsageFooterSegment(
 	snapshot: TlhSubscriptionUsageSnapshot | undefined,
-	options: { showWeekly?: boolean } = {},
+	options: { showWeekly?: boolean; nowMs?: number } = {},
 ): string | undefined {
 	if (!snapshot || !TLH_SUBSCRIPTION_USAGE_PROVIDERS.has(snapshot.provider)) {
 		return undefined;
 	}
 
-	const sessionSegment = formatUsageWindow(snapshot.provider, snapshot.windows?.session, "session");
+	const nowMs = options.nowMs ?? Date.now();
+	const sessionSegment = formatUsageWindow(snapshot.provider, snapshot.windows?.session, "session", nowMs);
 	if (!sessionSegment) {
 		return undefined;
 	}
 
 	const segments = [sessionSegment];
 	if (options.showWeekly) {
-		const weeklySegment = formatUsageWindow(snapshot.provider, snapshot.windows?.weekly, "weekly");
+		const weeklySegment = formatUsageWindow(snapshot.provider, snapshot.windows?.weekly, "weekly", nowMs);
 		if (weeklySegment) {
 			segments.push(weeklySegment);
 		}
@@ -189,6 +234,7 @@ export function getTlhSubscriptionUsageFooterState(
 	const segment = subscriptionEligible
 		? formatTlhSubscriptionUsageFooterSegment(subscriptionUsageSnapshot(ctx, provider, options.subscriptionUsage), {
 				showWeekly: shouldShowWeeklyUsage(options.shouldShowWeekly),
+				nowMs: options.nowMs,
 			})
 		: undefined;
 

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -447,3 +447,124 @@ test("line 3 renders subscription only when cost is suppressed and segment is pr
 	assert.match(sessionLine, /^5h session 42% used$/);
 	assert.doesNotMatch(sessionLine, /\$/);
 });
+
+// ---------------------------------------------------------------------------
+// NEW: reset countdown in subscription usage footer segment
+// ---------------------------------------------------------------------------
+
+// Helper: build a minimal Anthropic snapshot with explicit window fields.
+function anthropicSnapshotWithResets({ sessionResetsAt, weeklyResetsAt } = {}) {
+	return {
+		provider: "anthropic",
+		fetchedAt: NOW_MS,
+		windows: {
+			session: { key: "five_hour", label: "session", percent: 42, ...(sessionResetsAt ? { resetsAt: sessionResetsAt } : {}) },
+			weekly: { key: "seven_day", label: "weekly", percent: 88.9, ...(weeklyResetsAt ? { resetsAt: weeklyResetsAt } : {}) },
+		},
+	};
+}
+
+test("reset countdown: session 2h13m future appends ', resets in 2h13m'", () => {
+	// 2026-05-19T19:00:00Z + 2h13m = 2026-05-19T21:13:00Z
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: "2026-05-19T21:13:00.000Z" });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in 2h13m");
+});
+
+test("reset countdown: session 47m future appends ', resets in 47m'", () => {
+	// 2026-05-19T19:00:00Z + 47m = 2026-05-19T19:47:00Z
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: "2026-05-19T19:47:00.000Z" });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in 47m");
+});
+
+test("reset countdown: session 30s future appends ', resets in <1m'", () => {
+	// 2026-05-19T19:00:00Z + 30s = 2026-05-19T19:00:30Z
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: "2026-05-19T19:00:30.000Z" });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in <1m");
+});
+
+test("reset countdown: session resetsAt in the past produces no suffix", () => {
+	// 2026-05-19T18:00:00Z is 1h before NOW_MS
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: "2026-05-19T18:00:00.000Z" });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used");
+});
+
+test("reset countdown: session with no resetsAt produces no suffix", () => {
+	const snapshot = anthropicSnapshotWithResets();
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used");
+});
+
+test("reset countdown: session with unparseable resetsAt produces no suffix", () => {
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: "not-a-date" });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used");
+});
+
+test("reset countdown: weekly 4d 6h future appends ', resets in 4d 6h'", () => {
+	// 2026-05-19T19:00:00Z + 4d + 6h = 2026-05-24T01:00:00Z
+	const snapshot = anthropicSnapshotWithResets({
+		sessionResetsAt: "2026-05-19T21:13:00.000Z",
+		weeklyResetsAt: "2026-05-24T01:00:00.000Z",
+	});
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true, nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in 2h13m · weekly 88.9% used, resets in 4d 6h");
+});
+
+test("reset countdown: weekly <1d (5h) falls back to session-style format '5h0m'", () => {
+	// 2026-05-19T19:00:00Z + 5h = 2026-05-20T00:00:00Z
+	const snapshot = anthropicSnapshotWithResets({
+		weeklyResetsAt: "2026-05-20T00:00:00.000Z",
+	});
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true, nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used · weekly 88.9% used, resets in 5h0m");
+});
+
+test("reset countdown: session exactly 60s future appends ', resets in 1m' (boundary <1m→Mm)", () => {
+	const resetsAt = new Date(NOW_MS + 60 * 1000).toISOString();
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: resetsAt });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in 1m");
+});
+
+test("reset countdown: session exactly 1h future appends ', resets in 1h0m' (boundary Mm→XhYm, trailing 0m)", () => {
+	const resetsAt = new Date(NOW_MS + 60 * 60 * 1000).toISOString();
+	const snapshot = anthropicSnapshotWithResets({ sessionResetsAt: resetsAt });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used, resets in 1h0m");
+});
+
+test("reset countdown: weekly exactly 24h future appends ', resets in 1d 0h' (Xd Yh boundary, remainingHours=0)", () => {
+	const weeklyResetsAt = new Date(NOW_MS + 24 * 60 * 60 * 1000).toISOString();
+	const snapshot = anthropicSnapshotWithResets({ weeklyResetsAt });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true, nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used · weekly 88.9% used, resets in 1d 0h");
+});
+
+test("reset countdown: weekly exactly 25h future appends ', resets in 1d 1h' (day count and remainder)", () => {
+	const weeklyResetsAt = new Date(NOW_MS + 25 * 60 * 60 * 1000).toISOString();
+	const snapshot = anthropicSnapshotWithResets({ weeklyResetsAt });
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true, nowMs: NOW_MS });
+	assert.equal(result, "5h session 42% used · weekly 88.9% used, resets in 1d 1h");
+});
+
+test("reset countdown: session+weekly segment joiner is intact when both have countdowns", () => {
+	// Session: 2h13m future, weekly: 4d 6h future
+	// Expected: "5h session 42% used, resets in 2h13m · weekly 88.9% used, resets in 4d 6h"
+	// The single " · " between the two window segments is the inter-segment joiner.
+	const snapshot = anthropicSnapshotWithResets({
+		sessionResetsAt: "2026-05-19T21:13:00.000Z",
+		weeklyResetsAt: "2026-05-24T01:00:00.000Z",
+	});
+	const result = formatTlhSubscriptionUsageFooterSegment(snapshot, { showWeekly: true, nowMs: NOW_MS });
+	// Full string assertion
+	assert.equal(result, "5h session 42% used, resets in 2h13m · weekly 88.9% used, resets in 4d 6h");
+	// Splitting on " · " (the inter-segment joiner) yields exactly two window segments
+	const parts = result?.split(" · ");
+	assert.equal(parts?.length, 2);
+	assert.equal(parts?.[0], "5h session 42% used, resets in 2h13m");
+	assert.equal(parts?.[1], "weekly 88.9% used, resets in 4d 6h");
+});


### PR DESCRIPTION
## What

Adds a reset countdown to the subscription usage segment on line 3 of the footer, alongside the existing usage percentage.

**Before**
```
5h session 42% used
5h session 42% used · weekly 88.9% used
```

**After**
```
5h session 42% used, resets in 2h13m
5h session 42% used, resets in 2h13m · weekly 88.9% used, resets in 4d 6h
```

## Why

The 5-hour Anthropic / weekly OpenAI session window is the limit users actually plan around, but the footer only showed how full it was — not when it next opens up. Both providers already return reset timestamps and `subscription-usage.mjs` was already normalizing them into `window.resetsAt`; the data was just being dropped at the last formatter step.

## How

Presentation-only change in `extensions/the-last-harness/footer-subscription-usage.ts`:

- New private `formatResetCountdown(resetsAt, nowMs, windowType)` helper.
- `formatUsageWindow` appends `, resets in <delta>` to the rendered base when a parseable future `resetsAt` is present.
- Delta format:
  - **session window:** `XhYm` when ≥1h (e.g. `2h13m`), `Mm` when <1h (e.g. `47m`), `<1m` when <1 minute.
  - **weekly window:** `Xd Yh` when ≥1d (e.g. `4d 6h`); otherwise falls back to the session format.
  - Trailing `0m` is intentionally preserved (`5h0m`, `2h0m`, `1d 0h`).
- Optional `nowMs?: number` threaded through `getTlhSubscriptionUsageFooterState` → `formatTlhSubscriptionUsageFooterSegment` → `formatUsageWindow` for test injection. Default to `Date.now()` at a single boundary. `footer.ts` is unchanged — production keeps using the wall clock.

Missing, unparseable, or past `resetsAt` → suffix omitted, current rendering unchanged. No path can corrupt the base segment.

## Design notes

- **Separator choice:** `,` (not `·`) before "resets in" so the countdown visually attaches to its window. `·` remains the inter-segment joiner between session and weekly. With both windows shown, line 3 reads `5h session 42% used, resets in 2h13m · weekly 88.9% used, resets in 4d 6h` rather than four equally-weighted bullets.
- **Snapshot normalization untouched.** `subscription-usage.mjs` already handles every variant of upstream reset key (`reset_at`, `resets_at`, `resetTime`, `end_time`, relative `seconds_until_reset`, …) — see existing tests in `tests/the-last-harness-subscription-usage.test.mjs`.
- **Anthropic OAuth usage endpoint is undocumented** (pre-existing risk, documented behind pi-anthropic-auth in `gn show pstnrk`). If the schema shifts, the countdown degrades silently — percent still renders.

## Tests

13 new tests in `tests/the-last-harness-footer-usage.test.mjs`:

- Spec cases: session 2h13m / 47m / <1m / past / missing resetsAt / unparseable resetsAt
- Weekly: 4d 6h, session-style fallback at 5h, combined session+weekly joiner
- Boundary pins: exactly 60s (`<1m → Mm`), 1h (`Mm → XhYm`, trailing 0m), 24h (`Xd Yh` entry, `remainingHours = 0`), 25h (day count + remainder)

`npm run validate` → 421/421 pass, lint clean, installer dry-run clean.

## Undo

Pure presentation change. Revert this commit and the footer renders exactly as before; no settings, telemetry, or persistent state involved.
