### PR TITLE
Pin pi-intercom relay context fix

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -101,7 +101,7 @@
     "replaces": ["npm:pi-intercom", "git:github.com/nicobailon/pi-intercom"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-4",
+    "source": "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-5",
     "description": "Allow child subagents to escalate questions to the supervising session."
   }
 ]

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -821,7 +821,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	assert.equal(subagents.migrateReplacements, true, "subagents replacements must stay enabled");
 
 	assert.ok(intercom, "bundled intercom entry should exist");
-	assert.equal(intercom.source, "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-4");
+	assert.equal(intercom.source, "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-5");
 	assert.equal(intercom.critical, true, "intercom must stay critical");
 	assert.deepEqual(intercom.aliases, ["pi-intercom"]);
 	assert.deepEqual(intercom.replaces, [
@@ -836,7 +836,7 @@ test("bundled manifest contains intercom entry with correct tag and critical fla
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(intercom, "bundled intercom entry should exist");
-	assert.equal(intercom.source, "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-4");
+	assert.equal(intercom.source, "git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-5");
 	assert.equal(intercom.critical, true, "intercom must stay critical");
 	assert.deepEqual(intercom.aliases, ["pi-intercom"]);
 	assert.deepEqual(intercom.replaces, [


### PR DESCRIPTION
## Summary
- pin bundled critical pi-intercom default to tlh-v0.6.0-5
- update default-extension manifest tests for the new tag

## Upstream
- Includes diegopetrucci/pi-intercom#2, tagged as tlh-v0.6.0-5

## Verification
- npm run validate