### PR TITLE
Highlight non-default primary agent in footer line 2

### DIFF
--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -75,17 +75,26 @@ export function createTlhFooter(
 
 			// Line 2 (single flowing left-justified line):
 			//   agent: <primaryName> • [(provider)] <model|no-model> [• thinking] • context% [• DUMB ZONE]
+			// Each segment is explicitly themed to avoid ANSI foreground-reset bleed from nested
+			// theme.fg() calls. Non-default agent names are highlighted with the accent color.
 			const modelOrNoModel = model?.id ?? "no-model";
 			let modelPart: string = modelOrNoModel;
 			if ((footerData?.getAvailableProviderCount?.() ?? 1) > 1 && model) {
 				modelPart = `(${model.provider}) ${modelOrNoModel}`;
 			}
 
-			const line2Parts: string[] = [`agent: ${getPrimaryName()}`, modelPart];
+			const primaryName = getPrimaryName();
+			const dimSep = theme.fg("dim", " • ");
+			const nameSegment =
+				primaryName === "architect"
+					? theme.fg("dim", primaryName)
+					: theme.fg("accent", primaryName);
+
+			let agentLine2Str = theme.fg("dim", "agent: ") + nameSegment + dimSep + theme.fg("dim", modelPart);
 
 			if (model?.reasoning) {
 				const thinkingLevel = getCurrentThinkingLevel(pi);
-				line2Parts.push(thinkingLevel === "off" ? "thinking off" : thinkingLevel);
+				agentLine2Str += dimSep + theme.fg("dim", thinkingLevel === "off" ? "thinking off" : thinkingLevel);
 			}
 
 			const contextPercentDisplay =
@@ -96,15 +105,14 @@ export function createTlhFooter(
 			} else if (contextPercentValue > 70) {
 				contextPercentStr = theme.fg("warning", contextPercentDisplay);
 			} else {
-				contextPercentStr = contextPercentDisplay;
+				contextPercentStr = theme.fg("dim", contextPercentDisplay);
 			}
-			line2Parts.push(contextPercentStr);
+			agentLine2Str += dimSep + contextPercentStr;
 
-			let agentLine2Str = line2Parts.join(" • ");
 			if ((contextUsage?.tokens ?? 0) > DUMB_ZONE_THRESHOLD_TOKENS) {
-				agentLine2Str += `${theme.fg("dim", " • ")}${theme.fg("error", DUMB_ZONE_LABEL)}`;
+				agentLine2Str += dimSep + theme.fg("error", DUMB_ZONE_LABEL);
 			}
-			const agentLine2 = truncateToWidth(theme.fg("dim", agentLine2Str), width, theme.fg("dim", "..."));
+			const agentLine2 = truncateToWidth(agentLine2Str, width, theme.fg("dim", "..."));
 
 			// Line 3 (optional): [<cost> · ]<subscription usage segment>
 			// Omitted entirely when both parts are absent.

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -7,6 +7,7 @@ import {
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
+import { DEFAULT_PRIMARY_AGENT } from "../the-last-harness-primary-agent.mjs";
 import { formatCompactTokenCount, formatHomePath, sanitizeStatusText } from "./common.js";
 import type { FooterGitCache } from "./footer-git-cache.js";
 import { composeTlhFooterFirstLine } from "./footer-first-line.js";
@@ -86,7 +87,7 @@ export function createTlhFooter(
 			const primaryName = getPrimaryName();
 			const dimSep = theme.fg("dim", " • ");
 			const nameSegment =
-				primaryName === "architect"
+				primaryName === DEFAULT_PRIMARY_AGENT
 					? theme.fg("dim", primaryName)
 					: theme.fg("accent", primaryName);
 

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -5,6 +5,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { createJiti } from "jiti";
 
 import { createTlhSubscriptionUsageService } from "../extensions/the-last-harness/subscription-usage.mjs";
+import { DEFAULT_PRIMARY_AGENT } from "../extensions/the-last-harness-primary-agent.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { createTlhFooter, formatTlhSubscriptionUsageFooterSegment } = await jiti.import(
@@ -618,6 +619,16 @@ test("line 2 (color-aware): disabled renders name with accent", () => {
 
 	assert.match(line, /<accent>disabled<\/accent>/);
 	assert.doesNotMatch(line, /<dim>disabled<\/dim>/);
+});
+
+test("line 2 (color-aware): default primary agent renders name with dim, regardless of constant value", () => {
+	const ctx = createCtx({ provider: "anthropic" });
+	const footer = createTlhFooter(pi, ctx, colorTheme, () => DEFAULT_PRIMARY_AGENT, createFooterData(), {});
+	const line = footer.render(COLOR_WIDTH)[1] ?? "";
+
+	// Name must appear inside <dim>, not <accent>
+	assert.match(line, new RegExp(`<dim>${DEFAULT_PRIMARY_AGENT}</dim>`));
+	assert.doesNotMatch(line, new RegExp(`<accent>${DEFAULT_PRIMARY_AGENT}</accent>`));
 });
 
 test("line 2 (color-aware): product and bug-hunter render name with accent", () => {

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -568,3 +568,64 @@ test("reset countdown: session+weekly segment joiner is intact when both have co
 	assert.equal(parts?.[0], "5h session 42% used, resets in 2h13m");
 	assert.equal(parts?.[1], "weekly 88.9% used, resets in 4d 6h");
 });
+
+// ---------------------------------------------------------------------------
+// NEW: per-segment color tests for line 2 (color-aware theme stub)
+// ---------------------------------------------------------------------------
+
+// Color-aware theme: wraps each segment in XML-style tags so assertions can
+// check which color each piece of text was rendered with.
+const colorTheme = {
+	fg: (color, text) => `<${color}>${text}</${color}>`,
+};
+// Use a generous width so truncateToWidth never truncates the color-tagged line.
+// The XML tags are counted as visible characters, so a standard 100-char width
+// would truncate the line before all segments are visible.
+const COLOR_WIDTH = 1000;
+
+test("line 2 (color-aware): architect name renders with dim, not accent", () => {
+	const ctx = createCtx({ provider: "anthropic" });
+	const footer = createTlhFooter(pi, ctx, colorTheme, () => "architect", createFooterData(), {});
+	const line = footer.render(COLOR_WIDTH)[1] ?? "";
+
+	// Name must appear inside <dim>, not <accent>
+	assert.match(line, /<dim>architect<\/dim>/);
+	assert.doesNotMatch(line, /<accent>architect<\/accent>/);
+	// Surrounding structure must also carry dim
+	assert.match(line, /<dim>agent: <\/dim>/);
+	assert.match(line, /<dim> \u2022 <\/dim>/);
+	assert.match(line, /<dim>claude-sonnet-4-20250514<\/dim>/);
+});
+
+test("line 2 (color-aware): rush name renders with accent, not dim", () => {
+	const ctx = createCtx({ provider: "anthropic" });
+	const footer = createTlhFooter(pi, ctx, colorTheme, () => "rush", createFooterData(), {});
+	const line = footer.render(COLOR_WIDTH)[1] ?? "";
+
+	// Name must appear inside <accent>
+	assert.match(line, /<accent>rush<\/accent>/);
+	assert.doesNotMatch(line, /<dim>rush<\/dim>/);
+	// Surrounding label and separators must remain dim
+	assert.match(line, /<dim>agent: <\/dim>/);
+	assert.match(line, /<dim> \u2022 <\/dim>/);
+	assert.match(line, /<dim>claude-sonnet-4-20250514<\/dim>/);
+});
+
+test("line 2 (color-aware): disabled renders name with accent", () => {
+	const ctx = createCtx({ provider: "anthropic" });
+	const footer = createTlhFooter(pi, ctx, colorTheme, () => "disabled", createFooterData(), {});
+	const line = footer.render(COLOR_WIDTH)[1] ?? "";
+
+	assert.match(line, /<accent>disabled<\/accent>/);
+	assert.doesNotMatch(line, /<dim>disabled<\/dim>/);
+});
+
+test("line 2 (color-aware): product and bug-hunter render name with accent", () => {
+	const ctx = createCtx({ provider: "anthropic" });
+
+	const productFooter = createTlhFooter(pi, ctx, colorTheme, () => "product", createFooterData(), {});
+	assert.match(productFooter.render(COLOR_WIDTH)[1] ?? "", /<accent>product<\/accent>/);
+
+	const bugFooter = createTlhFooter(pi, ctx, colorTheme, () => "bug-hunter", createFooterData(), {});
+	assert.match(bugFooter.render(COLOR_WIDTH)[1] ?? "", /<accent>bug-hunter<\/accent>/);
+});


### PR DESCRIPTION
## Summary

Footer line 2 was wrapped in a single `theme.fg("dim", …)` call, so the selected primary agent name rendered dim along with everything else. Now non-default primaries (`rush`, `product`, `bug-hunter`, `disabled`) render with the theme's `accent` color, making it obvious at a glance which primary is active when you're not on the default `architect`.

## Changes

- **`extensions/the-last-harness/footer.ts`** — Compose line 2 from explicit per-segment `theme.fg(…)` calls. The agent-name segment uses `theme.fg("accent", name)` when the selection ≠ `"architect"`, otherwise `theme.fg("dim", name)`. Other segments (`"agent: "`, separators, model/provider, thinking, normal-range context%) carry their own `dim` SGR.
- **`tests/the-last-harness-footer-usage.test.mjs`** — Four new color-aware tests using an XML-style theme stub (`<color>text</color>`) cover architect→dim, rush→accent, disabled→accent, product/bug-hunter→accent, plus surrounding label/separators/model remain dim.

## Side benefit

The previous single outer-`dim` wrap had a latent ANSI foreground-reset bleed: any inner colored segment (DUMB ZONE error tint, context warning/error) emitted `\x1b[39m`, which dropped the outer dim for everything after it. It only happened to be visually safe because the DUMB ZONE label is always the last segment on the line. Per-segment composition removes that footgun and explicitly tints normal-range context% as dim.

## Behavior matrix

| Primary selection | Name color |
|---|---|
| `architect` | dim (unchanged) |
| `rush` | accent |
| `product` | accent |
| `bug-hunter` | accent |
| `disabled` | accent |

All other line-2 elements (label, separators, model, thinking, context%, DUMB ZONE) keep their existing styling.

## Validation

- `npm test` → 494/494 pass
- `npm run lint` → clean
- `node scripts/merge-settings.mjs --dry-run` → clean
- `npm pack --dry-run` → clean (88 files)
- `bash scripts/check-installer-smoke.sh` → fails identically on `main` due to a local-environment issue (smoke check restricts `PATH` and the per-user `pi` wrapper script needs `node` on `PATH` to answer `--version`). Not introduced by this PR.

## Notes

- Color-only highlight, no bold.
- README untouched — footer styling isn't enumerated there.
- If `disabled` should later use a different shade (e.g. `warning` to flag the off-state), it's a one-line change in the `nameSegment` ternary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved footer display with enhanced color-coded styling for agent names and context information
  * Agent names now display with distinct visual emphasis based on type
  * Conditional display of provider and model information for improved clarity
  * Context percentage and thinking level visibility enhanced with themed styling

* **Tests**
  * Added comprehensive validation tests for footer styling and output formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->