### PR TITLE
Add TLH version slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Added
 
+- Added `/version` slash command that reports the installed TLH version and the upstream Pi runtime version in concise plain text.
 - Added TLH commit attribution for agent-created git commits: the isolated TLH profile now defaults to a TLH-branded commit footer, `/toggle-tlh-git-attribution` persistently disables or re-enables it by managing boolean `tlh.attribution.commit` settings, and git push behavior is unchanged.
 
 ### Removed

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -16,6 +16,7 @@ import { collectStartupResources } from "./the-last-harness/resources.js";
 import { createTlhSubscriptionUsageService } from "./the-last-harness/subscription-usage.mjs";
 import { getTlhUsageLimitsConfig, registerUsageCommand, shouldShowTlhUsageWeekly } from "./the-last-harness/usage-limits.js";
 import { getTlhHeaderUpdate, maybeNotifyAvailableTlhUpdate } from "./the-last-harness/update-check.js";
+import { registerVersionCommand } from "./the-last-harness/version.js";
 import type { StartupResources, TlhUsageRefreshOptions } from "./the-last-harness/types.js";
 
 export default function theLastHarness(pi: ExtensionAPI) {
@@ -30,6 +31,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 	registerReviewCommand(pi);
 	registerTlhChangelogCommand(pi);
 	registerUsageCommand(pi);
+	registerVersionCommand(pi);
 
 	const subscriptionUsageService = createTlhSubscriptionUsageService();
 	const requestFooterRenderByContext = new WeakMap<ExtensionContext, () => void>();

--- a/extensions/the-last-harness/version.ts
+++ b/extensions/the-last-harness/version.ts
@@ -1,0 +1,22 @@
+import { VERSION, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+import { getTlhVersion } from "./package-version.js";
+
+/**
+ * Format a concise plain-text version string for both TLH and Pi.
+ * Exported for unit testing without side effects.
+ */
+export function formatVersionOutput(tlhVersion: string, piVersion: string): string {
+	return `tlh: ${tlhVersion}  |  pi: ${piVersion}`;
+}
+
+export function registerVersionCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("version", {
+		description: "Show the installed TLH and Pi runtime versions",
+		handler: (_args, ctx) => {
+			const tlhVersion = getTlhVersion();
+			const piVersion = VERSION;
+			ctx.ui.notify(formatVersionOutput(tlhVersion, piVersion), "info");
+		},
+	});
+}

--- a/tests/the-last-harness-extension-version.test.mjs
+++ b/tests/the-last-harness-extension-version.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { formatVersionOutput, registerVersionCommand } = await jiti.import(
+	"../extensions/the-last-harness/version.ts",
+);
+
+const extensionSource = readFileSync(new URL("../extensions/the-last-harness.ts", import.meta.url), "utf8");
+const versionSource = readFileSync(new URL("../extensions/the-last-harness/version.ts", import.meta.url), "utf8");
+
+// --- formatVersionOutput ---
+
+test("formatVersionOutput includes tlh and pi labels", () => {
+	const output = formatVersionOutput("0.15.0", "0.76.0");
+	assert.match(output, /tlh/);
+	assert.match(output, /pi/);
+});
+
+test("formatVersionOutput includes both provided version strings verbatim", () => {
+	const output = formatVersionOutput("1.2.3", "4.5.6");
+	assert.match(output, /1\.2\.3/);
+	assert.match(output, /4\.5\.6/);
+});
+
+test("formatVersionOutput is concise plain text without markup", () => {
+	const output = formatVersionOutput("0.15.0", "0.76.0");
+	assert.equal(typeof output, "string");
+	assert.doesNotMatch(output, /[<>]/);  // no HTML-like markup
+	// Should be a single short line, not a multi-paragraph block
+	assert.ok(output.length < 200, "version output should be concise");
+});
+
+// --- registerVersionCommand ---
+
+test("registerVersionCommand registers a command named 'version'", () => {
+	const registeredCommands = [];
+	const pi = {
+		registerCommand(name, _options) {
+			registeredCommands.push(name);
+		},
+	};
+	registerVersionCommand(pi);
+	assert.ok(registeredCommands.includes("version"), "expected 'version' command to be registered");
+});
+
+test("version command handler notifies with formatted output at 'info' level", () => {
+	let notified;
+	const pi = {
+		registerCommand(_name, options) {
+			options.handler("", {
+				ui: {
+					notify(message, type) {
+						notified = { message, type };
+					},
+				},
+			});
+		},
+	};
+	registerVersionCommand(pi);
+	assert.ok(notified, "expected handler to call ctx.ui.notify");
+	assert.equal(notified.type, "info");
+	assert.match(notified.message, /tlh:/);
+	assert.match(notified.message, /pi:/);
+	// Both fields should be real semver strings from the running packages
+	assert.match(notified.message, /\d+\.\d+\.\d+/);
+});
+
+// --- Extension wiring (static source checks) ---
+
+test("extension source imports the version module", () => {
+	assert.match(extensionSource, /from "\.\/the-last-harness\/version\.js"/);
+});
+
+test("extension source calls registerVersionCommand", () => {
+	assert.match(extensionSource, /registerVersionCommand\(pi\)/);
+});
+
+test("version module reads pi version from upstream VERSION export", () => {
+	assert.match(versionSource, /VERSION/);
+	assert.match(versionSource, /@earendil-works\/pi-coding-agent/);
+});
+
+test("version module reads tlh version from package-version helper", () => {
+	assert.match(versionSource, /getTlhVersion\(\)/);
+	assert.match(versionSource, /from "\.\/package-version\.js"/);
+});


### PR DESCRIPTION
## Summary
- add a /version slash command for TLH
- report both the TLH package version and upstream Pi runtime version
- cover registration and output formatting with tests

## Validation
- npm test
- npm run lint