### PR TITLE
Hide context-cap footer status in TLH footer

### DIFF
--- a/.tickets/tlhm-cwje.md
+++ b/.tickets/tlhm-cwje.md
@@ -1,0 +1,23 @@
+---
+id: tlhm-cwje
+status: open
+deps: []
+links: []
+created: 2026-06-03T10:42:08Z
+type: feature
+priority: 4
+assignee: Diego Petrucci
+tags: [backlog, context-cap, core]
+---
+# Move context cap into TLH core
+
+Backlog only: later replace the bundled context-cap default extension with equivalent TLH-core behavior so context capping is a core feature instead of a separate default extension.
+
+## Design
+
+Preserve the current 200k effective context-window cap semantics, opt-out/migration behavior, and a user-visible status/check command or equivalent. Remove the default extension dependency only after parity is covered by tests and docs.
+
+## Acceptance Criteria
+
+TLH core applies the 200k effective context-window cap without relying on the context-cap default extension; users retain an opt-out or equivalent control; installer/default-extension migration is conservative; footer remains quiet by default; tests and README/docs are updated.
+

--- a/extensions/the-last-harness/constants.ts
+++ b/extensions/the-last-harness/constants.ts
@@ -22,6 +22,12 @@ export const DUMB_ZONE_LABEL = "DUMB ZONE";
 export const AUTOCOMPLETE_SOURCE_TAG_PATTERN = /(^|—\s*)\[(?:u|p|t)(?::(?:npm|git):[^\]]+)?\]\s*/g;
 export const PRIMARY_AGENT_CYCLE_SHORTCUT = "shift+tab";
 
+// Extension status IDs whose footer status entries are suppressed in the TLH footer.
+// The extensions remain bundled and functional; only their UI status line is hidden.
+export const FOOTER_HIDDEN_EXTENSION_STATUS_IDS: ReadonlySet<string> = new Set([
+	"context-cap",
+]);
+
 export const HARNESS_PROMPT = `
 ## The Last Harness Defaults
 

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -6,7 +6,7 @@ import {
 	type ReadonlyFooterDataProvider,
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
-import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
+import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS, FOOTER_HIDDEN_EXTENSION_STATUS_IDS } from "./constants.js";
 import { DEFAULT_PRIMARY_AGENT } from "../the-last-harness-primary-agent.mjs";
 import { formatCompactTokenCount, formatHomePath, sanitizeStatusText } from "./common.js";
 import type { FooterGitCache } from "./footer-git-cache.js";
@@ -140,13 +140,19 @@ export function createTlhFooter(
 			}
 
 			// Extension status line (conditional on registered extension statuses)
+			// Entries whose ID appears in FOOTER_HIDDEN_EXTENSION_STATUS_IDS are suppressed;
+			// those extensions remain active — only their status line entry is hidden.
 			const extensionStatuses = footerData?.getExtensionStatuses?.();
 			if (extensionStatuses && extensionStatuses.size > 0) {
-				const statusLine = Array.from(extensionStatuses.entries())
-					.sort(([a], [b]) => a.localeCompare(b))
-					.map(([, text]) => sanitizeStatusText(text))
-					.join(" ");
-				lines.push(truncateToWidth(statusLine, width, theme.fg("dim", "...")));
+				const visibleStatuses = Array.from(extensionStatuses.entries())
+					.filter(([id]) => !FOOTER_HIDDEN_EXTENSION_STATUS_IDS.has(id))
+					.sort(([a], [b]) => a.localeCompare(b));
+				if (visibleStatuses.length > 0) {
+					const statusLine = visibleStatuses
+						.map(([, text]) => sanitizeStatusText(text))
+						.join(" ");
+					lines.push(truncateToWidth(statusLine, width, theme.fg("dim", "...")));
+				}
 			}
 
 			return lines;

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -11,6 +11,9 @@ const jiti = createJiti(import.meta.url);
 const { createTlhFooter, formatTlhSubscriptionUsageFooterSegment } = await jiti.import(
 	"../extensions/the-last-harness/footer.ts",
 );
+const { FOOTER_HIDDEN_EXTENSION_STATUS_IDS } = await jiti.import(
+	"../extensions/the-last-harness/constants.ts",
+);
 
 const NOW_MS = Date.parse("2026-05-19T19:00:00Z");
 const WIDTH = 100;
@@ -639,4 +642,62 @@ test("line 2 (color-aware): product and bug-hunter render name with accent", () 
 
 	const bugFooter = createTlhFooter(pi, ctx, colorTheme, () => "bug-hunter", createFooterData(), {});
 	assert.match(bugFooter.render(COLOR_WIDTH)[1] ?? "", /<accent>bug-hunter<\/accent>/);
+});
+
+// ---------------------------------------------------------------------------
+// NEW: context-cap footer status suppression
+// ---------------------------------------------------------------------------
+
+test("FOOTER_HIDDEN_EXTENSION_STATUS_IDS contains context-cap", () => {
+	assert.ok(
+		FOOTER_HIDDEN_EXTENSION_STATUS_IDS.has("context-cap"),
+		'context-cap must appear in FOOTER_HIDDEN_EXTENSION_STATUS_IDS',
+	);
+});
+
+test("extension status line is omitted when the only registered status is context-cap", () => {
+	// Context-cap is the sole extension status; after filtering the line must not appear.
+	const ctx = createCtx({ entries: [] });
+	const footerData = {
+		getGitBranch: () => undefined,
+		getAvailableProviderCount: () => 1,
+		getExtensionStatuses: () => new Map([["context-cap", "ctx cap 200k"]]),
+	};
+	const lines = renderFooterLines(ctx, {}, WIDTH, footerData);
+	// Only pwd (index 0) + agent line (index 1); no extension-status line.
+	assert.equal(lines.length, 2);
+	assert.ok(lines.every((l) => !l.includes("ctx cap")), "ctx cap text must not appear in any footer line");
+});
+
+test("non-context-cap extension statuses are still rendered in the footer", () => {
+	// An unrelated extension status must not be affected by the context-cap filter.
+	const ctx = createCtx({ entries: [] });
+	const footerData = {
+		getGitBranch: () => undefined,
+		getAvailableProviderCount: () => 1,
+		getExtensionStatuses: () => new Map([["my-ext", "my-ext: active"]]),
+	};
+	const lines = renderFooterLines(ctx, {}, WIDTH, footerData);
+	// pwd + agent + extension-status line
+	assert.equal(lines.length, 3);
+	assert.match(lines[2] ?? "", /my-ext: active/);
+});
+
+test("context-cap status is filtered from a mixed map while other statuses are preserved", () => {
+	// Both context-cap and a second extension have statuses; only the second must appear.
+	const ctx = createCtx({ entries: [] });
+	const footerData = {
+		getGitBranch: () => undefined,
+		getAvailableProviderCount: () => 1,
+		getExtensionStatuses: () =>
+			new Map([
+				["context-cap", "ctx cap 200k"],
+				["my-ext", "my-ext: active"],
+			]),
+	};
+	const lines = renderFooterLines(ctx, {}, WIDTH, footerData);
+	// pwd + agent + extension-status line (context-cap entry removed)
+	assert.equal(lines.length, 3);
+	assert.ok(lines.every((l) => !l.includes("ctx cap")), "ctx cap text must not appear in any footer line");
+	assert.match(lines[2] ?? "", /my-ext: active/);
 });


### PR DESCRIPTION
## Summary

Hides the bundled `context-cap` extension's footer status line (`ctx cap 200k/1000k`) at all times, while keeping the 200k effective context-window cap fully active.

The cap is still provided by the `context-cap` default extension; only its UI status entry is suppressed.

## Changes

- Add documented `FOOTER_HIDDEN_EXTENSION_STATUS_IDS` set in `extensions/the-last-harness/constants.ts` as the single source of truth for suppressed status IDs.
- Filter those IDs out of the extension-status line in `extensions/the-last-harness/footer.ts`, with a guard so an all-hidden map renders no empty line.
- Add 4 targeted tests in `tests/the-last-harness-footer-usage.test.mjs`.

## Validation

- `node --test tests/the-last-harness-footer-usage.test.mjs` — 41/41 pass (incl. 4 new)
- `npm test` — 508/508 pass
- `npm run lint` — clean
- `node scripts/merge-settings.mjs --dry-run` — pass
- `npm pack --dry-run` — pass

Note: `scripts/check-installer-smoke.sh` (and therefore `npm run validate`) has a **pre-existing** failure confirmed on the unmodified baseline; it is unrelated to this change.

## Follow-up

A backlog item exists to later move context capping into TLH core and drop the `context-cap` default-extension dependency (not part of this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer status display now selectively hides certain extension indicators to improve clarity while keeping extensions functional.

* **Tests**
  * Added test coverage for footer status suppression across single, mixed, and unrelated status scenarios.

* **Documentation**
  * Added a ticket outlining the plan to move the suppression behavior into core while preserving existing user-facing behavior and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->