### PR TITLE
Remove Plannotator default extension

### DIFF
--- a/.tickets/tlht-5iv1.md
+++ b/.tickets/tlht-5iv1.md
@@ -1,0 +1,18 @@
+---
+id: tlht-5iv1
+status: open
+deps: []
+links: []
+created: 2026-06-03T18:34:02Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+---
+# Track default-extension provenance
+
+Design and implement future provenance tracking for TLH-managed default extensions so retired defaults can be removed without deleting manually-added packages with the same source.
+
+## Acceptance Criteria
+
+A future implementation records which package entries TLH added or manages; retired-default cleanup can use provenance instead of source-only forced removal; migration/backward-compat behavior is documented and tested.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed Plannotator from the bundled default-extension manifest and TLH command reference. TLH updates/settings merges now also remove existing `npm:@plannotator/pi-extension` entries from isolated profiles as a retired TLH default; if you still want Plannotator after updating, manually re-add it.
+
 ## [0.16.0] - 2026-06-03
 
 ### Added

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -5,11 +5,6 @@
     "description": "Consult a separate read-only reasoning process for second opinions."
   },
   {
-    "id": "plannotator",
-    "source": "npm:@plannotator/pi-extension",
-    "description": "Review plans interactively with annotations."
-  },
-  {
     "id": "openai-fast",
     "source": "npm:@diegopetrucci/pi-openai-fast",
     "description": "Enable optional OpenAI Codex Fast mode commands for eligible ChatGPT-auth GPT-5.4/GPT-5.5 sessions."

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,12 +68,6 @@ These commands are provided by bundled default extensions and are visible in TLH
 | `/mcp-auth` | `pi-mcp-adapter` | Authenticate with an MCP server (OAuth) |
 | `/oracle` | `pi-oracle` | Configure the Oracle default model and thinking level |
 | `/oracle-model` | `pi-oracle` | Show which model the oracle would use right now |
-| `/plannotator` | `plannotator` | Toggle plannotator planning mode |
-| `/plannotator-annotate` | `plannotator` | Open a markdown file or folder in the annotation UI |
-| `/plannotator-archive` | `plannotator` | Browse saved plan decisions |
-| `/plannotator-last` | `plannotator` | Annotate the last assistant message |
-| `/plannotator-review` | `plannotator` | Open an interactive code review for current changes or a PR URL |
-| `/plannotator-status` | `plannotator` | Show plannotator status |
 | `/quiet-tools` | `pi-quiet-tools` | Toggle one-line collapsed invocations for built-in tool rows |
 | `/rtk` | `pi-rtk` | Control pi-rtk shell-command rewriting |
 | `/subagents-doctor` | `pi-subagents` | Show subagent diagnostics |
@@ -102,7 +96,7 @@ Individual bundled extensions can be disabled without affecting the others. Use 
 
 ```sh
 tlh defaults list        # show installed defaults and opt-out status
-tlh defaults disable <id>  # disable a bundled extension (e.g. tlh defaults disable plannotator)
+tlh defaults disable <id>  # disable a bundled extension (e.g. tlh defaults disable oracle)
 tlh defaults enable <id>   # re-enable a disabled extension
 ```
 

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -26,6 +26,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const DEFAULT_PACKAGE_SOURCE = "git:github.com/diegopetrucci/the-last-harness";
+const RETIRED_TLH_DEFAULT_PACKAGE_SOURCES = [
+	"npm:@plannotator/pi-extension",
+];
 const TLH_CHANGELOG_SENTINEL = "9999.0.0";
 const HARNESS_PACKAGE_IDENTITY = packageIdentity(DEFAULT_PACKAGE_SOURCE);
 
@@ -293,6 +296,18 @@ function applyDisabledDefaultExtensions(settings, defaultExtensions, disabledIds
 	}
 }
 
+function applyRetiredTlhDefaultPackageCleanup(settings, changes) {
+	if (!Array.isArray(settings.packages)) return;
+
+	for (const source of RETIRED_TLH_DEFAULT_PACKAGE_SOURCES) {
+		const identity = packageIdentity(source);
+		let removedSource;
+		while ((removedSource = removePackageByIdentity(settings, identity))) {
+			changes.push(`remove retired TLH default package: ${removedSource}`);
+		}
+	}
+}
+
 function applyDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds, changes) {
 	const loadOrderRepair = repairTargetedDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds);
 	if (!loadOrderRepair) return;
@@ -503,6 +518,7 @@ function main() {
 	applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
 	applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });
 	applyDisabledDefaultExtensions(next, defaultExtensions, disabledIds, changes);
+	applyRetiredTlhDefaultPackageCleanup(next, changes);
 	applyDefaultExtensionLoadOrder(next, defaultExtensions, disabledIds, changes);
 	removeCriticalDisabledDefaultExtensionOptOuts(next, defaultExtensions, changes);
 	scrubGnosisSettings(next, changes);

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ const repoRoot = resolve(import.meta.dirname, "..");
 const mergeScript = join(repoRoot, "scripts", "merge-settings.mjs");
 const settingsDefaultsPath = join(repoRoot, "config", "settings.defaults.json");
 const harnessPackage = "git:github.com/diegopetrucci/the-last-harness";
+const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
 const changelogSentinel = "9999.0.0";
 
 function tempFixture(defaultsValue, settingsValue, extensionsValue = []) {
@@ -122,6 +123,30 @@ test("merge treats a missing default-extension manifest as empty", () => {
 	assert.deepEqual(readJson(fixture.settings).packages, [harnessPackage]);
 });
 
+test("merge refuses to mutate normal Pi config paths", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{ packages: [harnessPackage] },
+	);
+	const homeDir = join(dirname(fixture.settings), "home");
+	const protectedSettings = join(homeDir, ".pi", "agent", "settings.json");
+
+	const result = spawnSync(process.execPath, [
+		mergeScript,
+		fixture.defaults,
+		"--settings", protectedSettings,
+		"--default-extensions", fixture.extensions,
+	], {
+		cwd: repoRoot,
+		env: { ...process.env, HOME: homeDir },
+		encoding: "utf8",
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /Refusing to modify normal Pi config from The Last Harness installer/);
+	assert.equal(existsSync(join(homeDir, ".pi")), false);
+});
+
 test("merge treats normalized subagents.agentDirs paths as duplicates", () => {
 	const fixture = tempFixture(
 		{
@@ -196,6 +221,45 @@ test("merge leaves settings unchanged when tlh.gnosis is absent", () => {
 	assert.equal(Object.hasOwn(result.tlh ?? {}, "gnosis"), false, "gnosis key should not appear");
 	assert.deepEqual(result.tlh.disabledDefaultExtensions, ["some-ext"], "disabledDefaultExtensions unchanged");
 	assert.equal(result.otherField, "untouched", "unrelated fields unchanged");
+});
+
+test("merge removes the retired plannotator package from isolated settings and logs it", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				retiredPlannotatorPackage,
+				"npm:unrelated-package",
+			],
+		},
+	);
+
+	const output = runMerge(fixture, { quiet: false });
+
+	assert.match(output, /Will remove retired TLH default package: npm:@plannotator\/pi-extension/);
+	assert.deepEqual(readJson(fixture.settings).packages, [
+		harnessPackage,
+		"npm:unrelated-package",
+	]);
+});
+
+test("merge dry-run reports retired plannotator cleanup without writing settings", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				{ source: retiredPlannotatorPackage, extensions: ["legacy-filter"] },
+			],
+		},
+	);
+	const before = readFileSync(fixture.settings, "utf8");
+
+	const output = runMerge(fixture, { dryRun: true, quiet: false });
+
+	assert.match(output, /Would remove retired TLH default package: npm:@plannotator\/pi-extension/);
+	assert.equal(readFileSync(fixture.settings, "utf8"), before);
 });
 
 test("merge reruns preserve user-owned settings and stay idempotent", () => {


### PR DESCRIPTION
## Summary
- remove Plannotator from bundled default extensions and command docs
- force-clean retired `npm:@plannotator/pi-extension` entries during isolated TLH settings merges
- add follow-up ticket for default-extension provenance tracking

## Validation
- npm run validate

🤖 Generated with [The Last Harness](https://github.com/diegopetrucci/the-last-harness)

Co-authored-by: The Last Harness <hi@thelastharness.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Oracle extension for independent read-only reasoning and second opinions.

* **Removed**
  * Plannotator extension removed from bundled defaults. Users wanting to retain it must manually re-add after upgrading.

* **Documentation**
  * Updated command reference with Oracle extension commands and extension management examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->