### PR TITLE
Document custom TLH resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ The README keeps the overview short on purpose. The detailed operational docs li
 
 You can add your own skills, prompts, extensions, and packages to TLH.
 
-- Put user-owned resources in the isolated TLH profile under `~/.the-last-harness/agent/skills/`, `~/.the-last-harness/agent/prompts/`, and `~/.the-last-harness/agent/extensions/` (for example: `mkdir -p ~/.the-last-harness/agent/{skills,prompts,extensions}`).
+User-level:
+- `~/.the-last-harness/agent/skills/`
+- `~/.the-last-harness/agent/prompts/`
+- `~/.the-last-harness/agent/extensions/`
 - Install package-based resources into the same isolated profile with `tlh install <package-source>`.
 - If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
 - After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The README keeps the overview short on purpose. The detailed operational docs li
 
 ## Add your own skills, extensions, etc
 
-You can add your own skills, prompts, extensions, and packages to TLH without changing this repository or your normal `~/.pi/agent` profile.
+You can add your own skills, prompts, extensions, and packages to TLH.
 
 - Put user-owned resources in the isolated TLH profile under `~/.the-last-harness/agent/skills/`, `~/.the-last-harness/agent/prompts/`, and `~/.the-last-harness/agent/extensions/` (for example: `mkdir -p ~/.the-last-harness/agent/{skills,prompts,extensions}`).
 - Install package-based resources into the same isolated profile with `tlh install <package-source>`.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ TLH also aims to make the day-to-day session experience calmer and safer:
 
 The README keeps the overview short on purpose. The detailed operational docs live elsewhere.
 
+## Add your own TLH resources
+
+You can add your own skills, prompts, extensions, and packages to TLH without changing this repository or your normal `~/.pi/agent` profile.
+
+- Put user-owned resources in the isolated TLH profile under `~/.the-last-harness/agent/skills/`, `~/.the-last-harness/agent/prompts/`, and `~/.the-last-harness/agent/extensions/` (for example: `mkdir -p ~/.the-last-harness/agent/{skills,prompts,extensions}`).
+- Install package-based resources into the same isolated profile with `tlh install <package-source>`.
+- If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
+- After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.
+- Normal `tlh update` runs are conservative: they preserve user-owned isolated-profile resources instead of overwriting them, and they still do not touch your normal Pi config.
+
 ## Everything else, aka the docs dump
 
 - Slash commands reference (built-ins, TLH commands, bundled extensions): [`docs/commands.md`](docs/commands.md)

--- a/README.md
+++ b/README.md
@@ -111,9 +111,16 @@ User-level:
 - `~/.the-last-harness/agent/skills/`
 - `~/.the-last-harness/agent/prompts/`
 - `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo‘)
-- If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
-- After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.
-- Normal `tlh update` runs are conservative: they preserve user-owned isolated-profile resources instead of overwriting them, and they still do not touch your normal Pi config.
+
+
+Repo settings:
+- `.pi/skills/`
+- `.pi/prompts/`
+- `.pi/extensions/`
+
+After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.
+
+Normal `tlh update` runs are conservative: they preserve user-owned isolated-profile resources instead of overwriting them, and they still do not touch your normal Pi config.
 
 ## Everything else, aka the docs dump
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ User-level:
 - `~/.the-last-harness/agent/prompts/`
 - `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo‘)
 
-
 Repo settings:
 - `.pi/skills/`
 - `.pi/prompts/`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can add your own skills, prompts, extensions, and packages to TLH.
 User-level:
 - `~/.the-last-harness/agent/skills/`
 - `~/.the-last-harness/agent/prompts/`
-- `~/.the-last-harness/agent/extensions/`
+- `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo‘)
 - Install package-based resources into the same isolated profile with `tlh install <package-source>` (e.g., `tlh install github-user/repo` or see `tlh install --help`).
 - If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
 - After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ User-level:
 - `~/.the-last-harness/agent/skills/`
 - `~/.the-last-harness/agent/prompts/`
 - `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo‘)
-- Install package-based resources into the same isolated profile with `tlh install <package-source>` (e.g., `tlh install github-user/repo` or see `tlh install --help`).
 - If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
 - After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.
 - Normal `tlh update` runs are conservative: they preserve user-owned isolated-profile resources instead of overwriting them, and they still do not touch your normal Pi config.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ TLH also aims to make the day-to-day session experience calmer and safer:
 
 The README keeps the overview short on purpose. The detailed operational docs live elsewhere.
 
-## Add your own TLH resources
+## Add your own skills, extensions, etc
 
 You can add your own skills, prompts, extensions, and packages to TLH without changing this repository or your normal `~/.pi/agent` profile.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ User-level:
 - `~/.the-last-harness/agent/skills/`
 - `~/.the-last-harness/agent/prompts/`
 - `~/.the-last-harness/agent/extensions/`
-- Install package-based resources into the same isolated profile with `tlh install <package-source>`.
+- Install package-based resources into the same isolated profile with `tlh install <package-source>` (e.g., `tlh install github-user/repo` or see `tlh install --help`).
 - If you want a customization to apply only to one repo, prefer project-local `.pi/skills/`, `.pi/prompts/`, or `.pi/extensions/` there instead of your shared TLH profile.
 - After adding files or installing a package, run `/reload` in TLH (or restart it) so the new resources are picked up.
 - Normal `tlh update` runs are conservative: they preserve user-owned isolated-profile resources instead of overwriting them, and they still do not touch your normal Pi config.


### PR DESCRIPTION
## Summary
- Add README guidance for end users adding custom TLH skills, prompts, extensions, and packages
- Document isolated profile paths, `tlh install`, project-local resources, `/reload`, and update preservation

## Validation
- `git diff --check -- README.md`
- code-reviewer pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for adding custom resources (skills, prompts, extensions) to TLH profiles
  * Documented package installation and repository-local customization options
  * Clarified reload requirements and update behavior with user-owned resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->