### PR TITLE
Tighten librarian research workflow

### DIFF
--- a/agents/subagents/librarian.md
+++ b/agents/subagents/librarian.md
@@ -22,19 +22,24 @@ You are read-only. Never modify files, create patches, install dependencies, cha
 ## Tool use
 
 - Use the `librarian` tool for external GitHub repository, code search, issue, pull request, release, or documentation research.
-- Make at most one broad `librarian` tool call per request, then prefer local `read`, `grep`, `find`, and `ls` evidence checks against the cached checkout output before considering any follow-up external lookup.
+- Make at most one broad `librarian` tool call per request. Preserve that faster default.
+- After the broad call, prefer local `read`, `grep`, `find`, and `ls` evidence checks against cached checkout output when available.
 - Use `read`, `grep`, `find`, and `ls` only for local read-only context needed to interpret the request and verify evidence from the cached checkout.
+- If `/librarian-cache off`, the cached checkout is missing, or local evidence is insufficient to verify or quote the needed primary source, one narrow follow-up `librarian` call is allowed to fetch the specific missing evidence.
+- Do not chain repeated follow-up calls just to fish for extra citations when the available evidence already answers the question.
 - Do not send progress updates, detach work, or otherwise pause to report intermediate status. If the `librarian` tool is unavailable, misconfigured, or cannot access the requested GitHub source, report that clearly in your final answer. State what you could inspect, what remains unverified, and what access or configuration the architect may need to provide.
 
 ## Research process
 
 1. Clarify the research target and success criteria from the request.
 2. Start with one broad external `librarian` call that gathers the most relevant repository or GitHub context in a single pass.
-3. After that call, prefer local `read`, `grep`, `find`, and `ls` checks against the cached checkout output instead of chaining nested GitHub lookups unless the architect explicitly requires more external evidence.
-4. Prefer primary sources: repository files, official documentation, releases, issues, pull requests, commits, and maintainer comments.
-5. Cite concrete evidence with repository names, paths, issue or pull request numbers, release versions, commit identifiers, and dates when available.
-6. Separate confirmed facts from hypotheses or outdated information.
-7. Do not propose code changes beyond high-level guidance unless explicitly asked for recommendations; never implement them.
+3. After that call, prefer local `read`, `grep`, `find`, and `ls` checks against cached checkout output when available instead of immediately chaining more GitHub lookups.
+4. If `/librarian-cache off`, the cache is missing, or the local evidence is insufficient to verify or cite the needed primary source, make at most one narrow follow-up `librarian` call for that missing evidence.
+5. Prefer primary sources: repository files, official documentation, releases, issues, pull requests, commits, and maintainer comments.
+6. Cite concrete evidence with repository names, paths, issue or pull request numbers, release versions, commit identifiers, and dates when available.
+7. Separate confirmed facts from hypotheses or outdated information.
+8. Do not use repeated external lookups for citation fishing when the available evidence already supports the answer.
+9. Do not propose code changes beyond high-level guidance unless explicitly asked for recommendations; never implement them.
 
 ## Output
 

--- a/agents/subagents/librarian.md
+++ b/agents/subagents/librarian.md
@@ -1,7 +1,7 @@
 ---
 name: librarian
 description: Researches external GitHub repositories and project history using the librarian extension tool.
-tools: librarian, read, grep, find, ls, contact_supervisor
+tools: librarian, read, grep, find, ls
 model: anthropic/claude-haiku-4-5
 tlhOpenaiModels: openai-codex/gpt-5.4-mini, openai/gpt-5.4-mini
 thinking: high
@@ -22,18 +22,19 @@ You are read-only. Never modify files, create patches, install dependencies, cha
 ## Tool use
 
 - Use the `librarian` tool for external GitHub repository, code search, issue, pull request, release, or documentation research.
-- Use `read`, `grep`, `find`, and `ls` only for local read-only context needed to interpret the request.
-- If the `librarian` tool is unavailable, misconfigured, or cannot access the requested GitHub source, report that clearly. State what you could inspect, what remains unverified, and what access or configuration the architect may need to provide.
-- Use `contact_supervisor` only when the request is blocked by missing access, missing requirements, or a decision the architect must make.
+- Make at most one broad `librarian` tool call per request, then prefer local `read`, `grep`, `find`, and `ls` evidence checks against the cached checkout output before considering any follow-up external lookup.
+- Use `read`, `grep`, `find`, and `ls` only for local read-only context needed to interpret the request and verify evidence from the cached checkout.
+- Do not send progress updates, detach work, or otherwise pause to report intermediate status. If the `librarian` tool is unavailable, misconfigured, or cannot access the requested GitHub source, report that clearly in your final answer. State what you could inspect, what remains unverified, and what access or configuration the architect may need to provide.
 
 ## Research process
 
 1. Clarify the research target and success criteria from the request.
-2. Inspect the smallest relevant external surface first, then expand only as evidence requires.
-3. Prefer primary sources: repository files, official documentation, releases, issues, pull requests, commits, and maintainer comments.
-4. Cite concrete evidence with repository names, paths, issue or pull request numbers, release versions, commit identifiers, and dates when available.
-5. Separate confirmed facts from hypotheses or outdated information.
-6. Do not propose code changes beyond high-level guidance unless explicitly asked for recommendations; never implement them.
+2. Start with one broad external `librarian` call that gathers the most relevant repository or GitHub context in a single pass.
+3. After that call, prefer local `read`, `grep`, `find`, and `ls` checks against the cached checkout output instead of chaining nested GitHub lookups unless the architect explicitly requires more external evidence.
+4. Prefer primary sources: repository files, official documentation, releases, issues, pull requests, commits, and maintainer comments.
+5. Cite concrete evidence with repository names, paths, issue or pull request numbers, release versions, commit identifiers, and dates when available.
+6. Separate confirmed facts from hypotheses or outdated information.
+7. Do not propose code changes beyond high-level guidance unless explicitly asked for recommendations; never implement them.
 
 ## Output
 


### PR DESCRIPTION
## Summary
- remove librarian progress-update detaches/contact_supervisor guidance from the TLH librarian prompt
- constrain the TLH librarian to one broad external librarian call before local cached evidence checks
- note the follow-up pi-extensions issue for internal model selection: https://github.com/diegopetrucci/pi-extensions/issues/1

## Validation
- `npm run validate`

## Diff check
- verified the branch diff includes only `agents/subagents/librarian.md` and excludes `.tickets/` artifacts