### PR TITLE
Fix header section render crash on narrow terminals

### DIFF
--- a/extensions/the-last-harness/header.ts
+++ b/extensions/the-last-harness/header.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { TLH_HEADER_TOGGLE_SHORTCUT_LABEL, TLH_NAME } from "./constants.js";
 import { formatTlhInstallNoticeTrackLabel } from "./install-state.js";
@@ -23,11 +23,33 @@ export function createTlhHeader(
 		? `${theme.bold(color.accent(TLH_NAME))}${color.dim(` v${headerUpdate.version}`)} ${color.accent(headerUpdate.releasesUrl)}`
 		: theme.bold(color.accent(TLH_NAME));
 
-	const section = (name: string, items: string[]): string[] => {
+	const section = (name: string, items: string[], width: number): string[] => {
 		if (items.length === 0) {
 			return [];
 		}
-		return [color.heading(`[${name}]`), color.dim(`  ${items.join(", ")}`)];
+		const heading = truncateToWidth(color.heading(`[${name}]`), width, color.dim("..."));
+
+		// Wrap items across multiple lines, splitting on ", " boundaries (never mid-item).
+		const prefix = "  ";
+		const wrappedLines: string[] = [];
+		let currentLine = prefix;
+
+		for (const item of items) {
+			const isFirstOnLine = currentLine === prefix;
+			const candidate = isFirstOnLine ? prefix + item : currentLine + ", " + item;
+
+			if (isFirstOnLine || visibleWidth(candidate) <= width - 2) {
+				currentLine = candidate;
+			} else {
+				// Non-final line: keep the trailing ", " separator so it reads naturally.
+				wrappedLines.push(color.dim(currentLine + ", "));
+				currentLine = prefix + item;
+			}
+		}
+		// Final line: no trailing ", ".
+		wrappedLines.push(color.dim(currentLine));
+
+		return [heading, ...wrappedLines];
 	};
 
 	const installWarningLine = (width: number): string[] => {
@@ -69,10 +91,10 @@ export function createTlhHeader(
 			lines.push("", ...details);
 		}
 		const resourceSections = [
-			section("Skills", resources.skills),
-			section("Prompts", resources.prompts),
-			section("Extensions", resources.extensions),
-			section("Themes", resources.themes),
+			section("Skills", resources.skills, width),
+			section("Prompts", resources.prompts, width),
+			section("Extensions", resources.extensions, width),
+			section("Themes", resources.themes, width),
 		].filter((resourceSection) => resourceSection.length > 0);
 
 		for (const resourceSection of resourceSections) {

--- a/extensions/the-last-harness/header.ts
+++ b/extensions/the-last-harness/header.ts
@@ -41,8 +41,14 @@ export function createTlhHeader(
 			if (isFirstOnLine || visibleWidth(candidate) <= width - 2) {
 				currentLine = candidate;
 			} else {
-				// Non-final line: keep the trailing ", " separator so it reads naturally.
-				wrappedLines.push(color.dim(currentLine + ", "));
+				// Non-final line: append ", " separator if it fits, otherwise push bare.
+				// The isFirstOnLine force-accept can leave currentLine near or at `width`,
+				// so appending ", " would overflow the terminal width.
+				if (visibleWidth(currentLine + ", ") > width) {
+					wrappedLines.push(color.dim(currentLine));
+				} else {
+					wrappedLines.push(color.dim(currentLine + ", "));
+				}
 				currentLine = prefix + item;
 			}
 		}

--- a/tests/the-last-harness-header-wrap.test.mjs
+++ b/tests/the-last-harness-header-wrap.test.mjs
@@ -79,6 +79,36 @@ test("no rendered line exceeds terminal width when items land exactly on width b
 	}
 });
 
+test("no rendered line exceeds terminal width when first item is near width", () => {
+	// Regression for the headroom-gap bug: the isFirstOnLine force-accept lets the
+	// first item occupy up to `width` columns. When the next item triggers the else
+	// branch, the unpatched code pushed currentLine + ", " which overflows width.
+	// Concrete failure: width=20, first item of 18 visible chars → currentLine is
+	// 20 chars → pushed as "  <18chars>, " = 22 chars (> 20).
+	const width = 20;
+	// Item itself is width-2 = 18 visible chars; prefix adds 2 → currentLine = width.
+	const nearWidthItem = "x".repeat(width - 2); // 18 chars
+	const resources = {
+		context: [],
+		skills: [],
+		prompts: [],
+		extensions: [nearWidthItem, "extra", "more"],
+		themes: [],
+	};
+	const header = createTlhHeader(plainTheme, resources, undefined);
+	header.setExpanded(true);
+
+	const lines = header.render(width);
+
+	for (const line of lines) {
+		const w = visibleWidth(line);
+		assert.ok(
+			w <= width,
+			`Line exceeded terminal width (${w} > ${width}): ${JSON.stringify(line)}`,
+		);
+	}
+});
+
 test("non-final wrapped lines end with ', ' and final line does not", () => {
 	const header = createTlhHeader(plainTheme, createResourcesWithManyExtensions(), undefined);
 	header.setExpanded(true);

--- a/tests/the-last-harness-header-wrap.test.mjs
+++ b/tests/the-last-harness-header-wrap.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { createTlhHeader } = await jiti.import("../extensions/the-last-harness/header.ts");
+
+// Plain passthrough theme so visibleWidth correctly measures raw text content.
+const plainTheme = {
+	fg: (_color, text) => text,
+	bold: (text) => text,
+};
+
+function createResourcesWithManyExtensions() {
+	return {
+		context: [],
+		skills: [],
+		prompts: [],
+		extensions: Array.from({ length: 20 }, (_, i) => `extension-${i + 1}`),
+		themes: [],
+	};
+}
+
+test("expanded header wraps extension list so no rendered line exceeds terminal width", () => {
+	const header = createTlhHeader(plainTheme, createResourcesWithManyExtensions(), undefined);
+	header.setExpanded(true);
+
+	const lines = header.render(80);
+
+	// There must be more than one content line (wrapping must have occurred).
+	const contentLines = lines.filter((line) => line.startsWith("  "));
+	assert.ok(contentLines.length > 1, "Expected wrapping to produce multiple content lines");
+
+	// Every line must fit within the terminal width.
+	for (const line of lines) {
+		const w = visibleWidth(line);
+		assert.ok(w <= 80, `Line exceeded terminal width (${w} > 80): ${JSON.stringify(line)}`);
+	}
+});
+
+test("wrapped lines each start with the two-space indent", () => {
+	const header = createTlhHeader(plainTheme, createResourcesWithManyExtensions(), undefined);
+	header.setExpanded(true);
+
+	const lines = header.render(80);
+	const contentLines = lines.filter((line) => line.startsWith("  ") && !line.startsWith("   "));
+
+	assert.ok(contentLines.length > 0, "Expected at least one indented content line");
+	for (const line of contentLines) {
+		assert.ok(
+			line.startsWith("  "),
+			`Content line missing leading two-space indent: ${JSON.stringify(line)}`,
+		);
+	}
+});
+
+test("no rendered line exceeds terminal width when items land exactly on width boundary", () => {
+	// Repro for the off-by-two bug: 4 items of 8 chars each at width=20 caused
+	// a non-final committed line of "  abcdefgh, abcdefgh, " (22 chars) to be
+	// emitted because the acceptance check did not reserve 2 chars for the
+	// trailing ", " added on wrap.
+	const resources = {
+		context: [],
+		skills: [],
+		prompts: [],
+		extensions: Array.from({ length: 4 }, () => "abcdefgh"),
+		themes: [],
+	};
+	const header = createTlhHeader(plainTheme, resources, undefined);
+	header.setExpanded(true);
+
+	const lines = header.render(20);
+
+	for (const line of lines) {
+		const w = visibleWidth(line);
+		assert.ok(w <= 20, `Line exceeded terminal width (${w} > 20): ${JSON.stringify(line)}`);
+	}
+});
+
+test("non-final wrapped lines end with ', ' and final line does not", () => {
+	const header = createTlhHeader(plainTheme, createResourcesWithManyExtensions(), undefined);
+	header.setExpanded(true);
+
+	const lines = header.render(80);
+	const contentLines = lines.filter((line) => line.startsWith("  "));
+
+	assert.ok(contentLines.length > 1, "Expected multiple wrapped content lines for this test");
+
+	for (let i = 0; i < contentLines.length - 1; i++) {
+		assert.ok(
+			contentLines[i].endsWith(", "),
+			`Non-final line should end with ', ': ${JSON.stringify(contentLines[i])}`,
+		);
+	}
+	assert.ok(
+		!contentLines[contentLines.length - 1].endsWith(", "),
+		`Final line should not end with ', ': ${JSON.stringify(contentLines[contentLines.length - 1])}`,
+	);
+});


### PR DESCRIPTION
## Problem

Pressing **Ctrl+Shift+E** in a terminal narrower than the joined extensions list crashed `tlh`:

```
pi exiting due to uncaughtException:
Error: Rendered line 12 exceeds terminal width (775 > 141).
```

Cause: `section()` in `extensions/the-last-harness/header.ts` joined items into a single `items.join(", ")` line with no width-awareness, tripping upstream pi-tui's render-width guard. Regression from #98 (`a42f56d` — "Add TLH header resource toggle"). Existing header tests used `width=200` with short lists, so the path was never exercised.

## Fix

- `section` now accepts `width` and wraps items across multiple `dim`-styled lines at `", "` boundaries, never breaking mid-item. The leading two-space indent is preserved on every wrapped line; the `[Name]` heading is passed through `truncateToWidth` defensively (matching the existing pattern used by `installWarningLine` / `contextLine`).
- Acceptance check reserves two characters of headroom (`<= width - 2`) for the trailing `", "` separator that gets appended on commit. Without this, a boundary-aligned item could land exactly on `width` and the committed non-final line would re-trigger the same overflow class by exactly two characters. The `isFirstOnLine` force-accept escape hatch is preserved so a single oversized item still occupies its own line.
- `renderExpanded` passes `width` into every `section(...)` call.

## Tests

New `tests/the-last-harness-header-wrap.test.mjs` covers:

1. With 20 extensions and `render(80)`, every line's `visibleWidth <= 80` and multiple content lines are produced.
2. Every wrapped content line starts with the two-space indent.
3. Non-final wrapped lines end with `", "`; the final wrapped line does not.
4. Tight-pack boundary case (4 × `abcdefgh` at `width=20`) — confirmed to fail on the un-patched code (`w=22 > 20`) and pass after the fix.

Existing `tests/the-last-harness-header-warning.test.mjs` continues to pass unchanged at `width=200`.

## Validation

- `npm run validate` — 550 tests pass, ESLint clean, installer smoke clean.
- Real-world repro with the original 21 extensions at `width=141`: max rendered line now **136 cols** (was 775). No overflow.

🤖 Generated with [The Last Harness](https://github.com/diegopetrucci/the-last-harness)