### PR TITLE
Hide model provider name from footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
+- The footer no longer shows the model provider name; the provider prefix is always hidden.
 - Context cap is now a built-in TLH feature (no longer a bundled default extension). The bundled `@diegopetrucci/pi-context-cap` default extension has been removed and will be force-uninstalled from existing isolated profiles on the next `tlh` install or update. Previous `tlh.disabledDefaultExtensions: ["context-cap"]` opt-outs are intentionally **not** preserved — those entries are silently pruned on upgrade. To opt out of the cap again, run `/toggle-context-cap` or set `tlh.contextCap.disabled: true` in your isolated settings.
 - TLH now records bundled default-extension provenance in `tlh.defaultExtensionProvenance.managedPackageIdentities` so retired-default cleanup can distinguish TLH-managed packages from later manual re-adds. Older installs migrate this metadata on update; legacy Plannotator is still cleaned up once during that migration.
 

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -75,14 +75,11 @@ export function createTlhFooter(
 			const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
 
 			// Line 2 (single flowing left-justified line):
-			//   agent: <primaryName> • [(provider)] <model|no-model> [• thinking] • context% [• DUMB ZONE]
+			//   agent: <primaryName> • <model|no-model> [• thinking] • context% [• DUMB ZONE]
 			// Each segment is explicitly themed to avoid ANSI foreground-reset bleed from nested
 			// theme.fg() calls. Non-default agent names are highlighted with the accent color.
 			const modelOrNoModel = model?.id ?? "no-model";
-			let modelPart: string = modelOrNoModel;
-			if ((footerData?.getAvailableProviderCount?.() ?? 1) > 1 && model) {
-				modelPart = `(${model.provider}) ${modelOrNoModel}`;
-			}
+			const modelPart: string = modelOrNoModel;
 
 			const primaryName = getPrimaryName();
 			const dimSep = theme.fg("dim", " • ");

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -378,9 +378,10 @@ test("line 2 shows model without provider prefix when single provider", () => {
 	assert.doesNotMatch(line, /\(anthropic\)/);
 });
 
-test("line 2 shows provider prefix when multiple providers available", () => {
+test("line 2 never shows provider prefix even when multiple providers are available", () => {
 	const line = renderAgentLine(createCtx({ provider: "anthropic" }), {}, WIDTH, createFooterData({ providerCount: 2 }));
-	assert.match(line, /^agent: architect • \(anthropic\) claude-sonnet-4-20250514 • /);
+	assert.match(line, /^agent: architect • claude-sonnet-4-20250514 • /);
+	assert.doesNotMatch(line, /\(anthropic\)/);
 });
 
 test("line 2 shows thinking level for reasoning models", () => {


### PR DESCRIPTION
## Summary

Footer line 2 previously rendered `(provider) modelId` when more than one provider was available (e.g. `(anthropic) claude-sonnet-4-5`). Hide it unconditionally — the provider is rarely useful at a glance and adds noise.

## Changes

- `extensions/the-last-harness/footer.ts` — drop the `getAvailableProviderCount() > 1` conditional; `modelPart` is now always just the model id. Inline contract comment updated.
- `tests/the-last-harness-footer-usage.test.mjs` — the "shows provider prefix when multiple providers" test is replaced with one that asserts the prefix is **never** shown, even with `providerCount: 2`.
- `CHANGELOG.md` — `[Unreleased]` › Changed entry.

## Tradeoff

When two providers expose colliding model ids (e.g. `gpt-5` under both `openai` and `openai-codex`), the footer no longer disambiguates them. Accepted: keep the footer compact.

## Validation

- `npm run validate` → 551/551 tests pass, eslint clean, dry-run pack succeeds.

🤖 Generated with [The Last Harness](https://github.com/diegopetrucci/the-last-harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The TLH footer's agent information line has been simplified—the model provider prefix is no longer displayed, even when multiple providers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->