### PR TITLE
Add validator subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ That last part matters: the architect does not disappear once work is delegated.
 
 TLH subagents are fresh child sessions, not a giant shared swarm. They get the task and project context they need, not the whole primary conversation. In practice that means less context pollution, clearer responsibilities, and easier review of what each agent was asked to do.
 
-Common roles include `repo-scout` for discovery, `diff-summarizer` for change overviews, `developer` for implementation, `code-reviewer` for review, `librarian` for repo knowledge, `web-scout` for web research, and `oracle` for a deeper second opinion.
+Common roles include `repo-scout` for discovery, `diff-summarizer` for change overviews, `developer` for implementation, `validator` for source-read-only validation, `code-reviewer` for review, `librarian` for repo knowledge, `web-scout` for web research, and `oracle` for a deeper second opinion.
 
 ## Why this workflow is useful
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The architect is the default, but it is not the only mode.
 
 Use `Shift+Tab` to cycle the current session through `architect` → `rush` → `product` → `bug-hunter` → `disabled`.
 
+Use `/switch-primary-agent [status|architect|rush|product|bug-hunter|disabled|reset|default architect|default rush|default product|default bug-hunter|default disabled|default reset]` for explicit switching, status, reset, and persistent default selection.
+
 When primary agents are disabled, TLH stops applying those primary-agent workflow/persona rules, but the underlying subagent machinery still exists.
 
 ## TLH is intentionally opinionated

--- a/VALIDATING.md
+++ b/VALIDATING.md
@@ -1,0 +1,18 @@
+# Validating TLH changes
+
+Run `npm run validate` before considering repository changes ready. It is the aggregate check for this repo.
+
+## Useful targeted checks
+
+```sh
+bash -n install.sh
+node --check scripts/tlh-gnosis.mjs
+bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
+bash -s -- --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)" < install.sh
+```
+
+## Safety notes
+
+- Prefer temporary `--agent-dir` and `--bin-dir` values for installer validation.
+- Do not run a real install into home directories unless explicitly requested.
+- Never point validation at normal user config such as `~/.pi/agent`.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -28,6 +28,7 @@ Use the `subagent` tool for minor agents:
 - `repo-scout`: scan an unfamiliar repository for stack, conventions, and commands.
 - `diff-summarizer`: summarize existing local diffs and risk hotspots.
 - `developer`: implement exactly one approved task at a time.
+- `validator`: run source-read-only validation commands and report exact commands, outcomes, skipped commands, git status before/after, and failure triage.
 - `code-reviewer`: review diffs against the active task(s) and report findings.
 - `librarian`: research external GitHub repositories, issues, pull requests, releases, or docs read-only when outside evidence is needed.
 - `web-scout`: research the general web outside GitHub via Exa-backed search and fetch in an isolated read-only context.
@@ -82,9 +83,11 @@ For each ready task:
 
 After all tasks are complete:
 
-1. Delegate final review to `code-reviewer` against the full VCS diff and completed tickets.
-2. Evaluate findings; delegate fixes to `developer` if needed.
-3. Summarize implemented work, tradeoffs, validation, and remaining risks for the user.
+1. Delegate source-read-only validation to `validator` against the completed tickets and current worktree.
+2. Evaluate the validator report; delegate fixes to `developer` if needed.
+3. Delegate final review to `code-reviewer` against the full VCS diff, completed tickets, and validator findings.
+4. Evaluate findings; delegate fixes to `developer` if needed.
+5. Summarize implemented work, tradeoffs, validation, and remaining risks for the user.
 
 ## /review handoff
 

--- a/agents/subagents/validator.md
+++ b/agents/subagents/validator.md
@@ -1,0 +1,67 @@
+---
+name: validator
+description: Runs source-read-only validation commands and reports exact outcomes.
+tools: read, grep, find, ls, bash, contact_supervisor
+model: anthropic/claude-haiku-4-5
+tlhOpenaiModels: openai-codex/gpt-5.4-mini, openai/gpt-5.4-mini
+thinking: high
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+---
+You are the TLH validator. You run source-read-only validation after implementation and before final review, then report the results to the delegating primary agent.
+
+You are read-only. Do not modify files, stage changes, install dependencies, use autofix modes, update snapshots, run destructive migrations, start long-lived watchers, or rely on network-dependent commands unless the delegating primary agent explicitly approves that exact command.
+
+## Inputs
+
+- The assigned `tk` ticket IDs, task brief, changed files, developer report, or specific validation request supplied by the delegating primary agent.
+- The current repository state and relevant project instructions.
+- Optional repo-specific validation guidance from repo-root `VALIDATING.md`.
+
+## Source-read-only invariant
+
+1. Identify the repository root before choosing commands.
+2. If repo-root `VALIDATING.md` exists, read it first and treat it as validation guidance.
+3. Prefer the narrowest meaningful validation for the assigned task.
+4. Skip any command that would edit source, write lockfiles, install packages, update snapshots, apply autofixes, run destructive migrations, launch watchers/servers, or depend on network access without explicit approval.
+5. If a useful command has both safe and mutating forms, use only the safe read-only form.
+6. If a required validation step appears to need approval because it is not source-read-only, stop and escalate instead of guessing.
+
+## Validation process
+
+1. Identify the repository root.
+2. If repo-root `VALIDATING.md` exists, read it before collecting git status or choosing commands.
+3. Collect `git status --short --untracked-files=all` before running validation.
+4. Discover candidate commands from the ticket scope, project docs, repository config, and any `VALIDATING.md` guidance.
+5. Run only source-read-only commands that are justified by the task.
+6. Record the exact commands you ran, their exit status, and concise outcomes.
+7. Record any skipped commands with the exact command and the reason it was skipped.
+8. Collect `git status --short --untracked-files=all` after validation.
+9. If git status changes after validation, report that immediately as a validation safety failure.
+10. If a command fails, do read-only triage: identify whether it looks like a product bug, test expectation issue, environment problem, missing prerequisite, flaky behavior, or another category supported by evidence.
+
+## Escalation
+
+Use `contact_supervisor` only when:
+
+- a required validation command is unsafe without approval,
+- validation is blocked by missing tools, permissions, or environment setup,
+- repository instructions conflict about which safe command to run, or
+- failure triage requires a decision from the delegating primary agent.
+
+If blocking escalation is unavailable, fails, or times out, report the blocker clearly and stop.
+
+## Output
+
+Return a concise markdown validation report with:
+
+- Validation scope.
+- Whether `VALIDATING.md` was present and read first.
+- Git status before validation.
+- Commands run: exact commands, exit codes, and outcomes.
+- Commands skipped: exact commands and why they were skipped.
+- Git status after validation.
+- Failure triage for any non-zero exits or safety anomalies.
+- Overall result: pass, fail, or blocked.

--- a/extensions/the-last-harness-subagent-safety.mjs
+++ b/extensions/the-last-harness-subagent-safety.mjs
@@ -1,8 +1,15 @@
 export const ALLOWED_SUBAGENTS = Object.freeze(["developer", "validator", "code-reviewer", "repo-scout", "diff-summarizer", "librarian", "web-scout", "oracle"]);
+export const PRIMARY_SUBAGENT_ALLOWLISTS = Object.freeze({
+	architect: ALLOWED_SUBAGENTS,
+	product: Object.freeze(["repo-scout", "librarian"]),
+	"bug-hunter": Object.freeze(["repo-scout", "librarian", "oracle"]),
+	rush: Object.freeze(["repo-scout", "diff-summarizer", "librarian", "code-reviewer", "oracle"]),
+});
 export const SAFE_SUBAGENT_ACTIONS = Object.freeze(["list", "get", "status", "interrupt", "doctor"]);
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 
 const SAFE_SUBAGENT_ACTION_SET = new Set(SAFE_SUBAGENT_ACTIONS);
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
 
 function isRecord(value) {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -10,6 +17,22 @@ function isRecord(value) {
 
 function stringField(value) {
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizePrimaryAgent(value) {
+	return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+}
+
+export function allowedSubagentsForPrimary(primaryAgent) {
+	const normalizedPrimaryAgent = normalizePrimaryAgent(primaryAgent);
+	return normalizedPrimaryAgent && hasOwn(PRIMARY_SUBAGENT_ALLOWLISTS, normalizedPrimaryAgent)
+		? PRIMARY_SUBAGENT_ALLOWLISTS[normalizedPrimaryAgent]
+		: ALLOWED_SUBAGENTS;
+}
+
+function delegationPolicyLabel(primaryAgent) {
+	const normalizedPrimaryAgent = normalizePrimaryAgent(primaryAgent);
+	return normalizedPrimaryAgent && hasOwn(PRIMARY_SUBAGENT_ALLOWLISTS, normalizedPrimaryAgent) ? `TLH ${normalizedPrimaryAgent}` : "TLH primary agents";
 }
 
 function collectSubagentTargets(input) {
@@ -118,7 +141,7 @@ function validateNestedFreshSubagentContexts(input) {
 	return undefined;
 }
 
-export function validateSubagentToolInput(input) {
+export function validateSubagentToolInput(input, { primaryAgent } = {}) {
 	if (!isRecord(input)) {
 		return "TLH primary-agent subagent calls must use an object input.";
 	}
@@ -154,6 +177,12 @@ export function validateSubagentToolInput(input) {
 	const disallowed = targets.filter((agent) => !ALLOWED_SUBAGENTS.includes(agent));
 	if (disallowed.length > 0) {
 		return `TLH primary agents may delegate only to: ${ALLOWED_SUBAGENTS.join(", ")}. Disallowed target(s): ${disallowed.join(", ")}.`;
+	}
+
+	const primaryAllowedSubagents = allowedSubagentsForPrimary(primaryAgent);
+	const primaryDisallowed = targets.filter((agent) => !primaryAllowedSubagents.includes(agent));
+	if (primaryDisallowed.length > 0) {
+		return `${delegationPolicyLabel(primaryAgent)} may delegate only to: ${primaryAllowedSubagents.join(", ")}. Disallowed target(s): ${primaryDisallowed.join(", ")}.`;
 	}
 
 	return undefined;

--- a/extensions/the-last-harness-subagent-safety.mjs
+++ b/extensions/the-last-harness-subagent-safety.mjs
@@ -1,4 +1,4 @@
-export const ALLOWED_SUBAGENTS = Object.freeze(["developer", "code-reviewer", "repo-scout", "diff-summarizer", "librarian", "web-scout", "oracle"]);
+export const ALLOWED_SUBAGENTS = Object.freeze(["developer", "validator", "code-reviewer", "repo-scout", "diff-summarizer", "librarian", "web-scout", "oracle"]);
 export const SAFE_SUBAGENT_ACTIONS = Object.freeze(["list", "get", "status", "interrupt", "doctor"]);
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -585,7 +585,7 @@ function createTlhPrimaryAgentRuntime(
 			if (selection === "rush" && subagentCallTargetsAgent(event.input, "developer")) {
 				return { block: true, reason: rushDeveloperDelegationReason() };
 			}
-			const reason = validateSubagentToolInput(event.input);
+			const reason = validateSubagentToolInput(event.input, { primaryAgent: selection });
 			return reason ? { block: true, reason } : undefined;
 		});
 	}

--- a/extensions/the-last-harness/prompts.ts
+++ b/extensions/the-last-harness/prompts.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { SELECTABLE_PRIMARY_AGENTS } from "../the-last-harness-primary-agent.mjs";
-import { ALLOWED_SUBAGENTS } from "../the-last-harness-subagent-safety.mjs";
+import { allowedSubagentsForPrimary } from "../the-last-harness-subagent-safety.mjs";
 import { CHILD_SUBAGENT_PROMPT, HARNESS_PROMPT } from "./constants.js";
 import { readMarkdownFilesRecursive, readText } from "./common.js";
 import { packageRoot } from "./package-version.js";
@@ -99,8 +99,8 @@ export function loadSubagentMetadata(): SubagentMetadata[] {
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-function formatAllowedSubagents(subagents: SubagentMetadata[]): string {
-	const allowed = new Set(ALLOWED_SUBAGENTS);
+function formatAllowedSubagents(primary: AgentPrompt | undefined, subagents: SubagentMetadata[]): string {
+	const allowed = new Set(allowedSubagentsForPrimary(primary?.name));
 	const lines = subagents
 		.filter((agent) => allowed.has(agent.name))
 		.map((agent) => `- ${agent.name}: ${agent.description}`);
@@ -117,7 +117,7 @@ export function buildTlhSystemPrompt(
 ): string {
 	const prompts = [HARNESS_PROMPT.trim()];
 	if (primaryEnabled) {
-		prompts.push(primary?.systemPrompt.trim(), formatAllowedSubagents(subagents));
+		prompts.push(primary?.systemPrompt.trim(), formatAllowedSubagents(primary, subagents));
 	}
 	return prompts.filter(Boolean).join("\n\n");
 }

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ UPDATE_TRACK_INPUT="${TLH_UPDATE_TRACK:-}"
 RAW_BASE_INPUT="${TLH_RAW_BASE:-}"
 TMP_DIR=""
 ORIGINAL_ARGS=("$@")
-TLH_SUBAGENT_PROMPTS=(developer.md code-reviewer.md repo-scout.md diff-summarizer.md librarian.md oracle.md web-scout.md)
+TLH_SUBAGENT_PROMPTS=(developer.md validator.md code-reviewer.md repo-scout.md diff-summarizer.md librarian.md oracle.md web-scout.md)
 
 usage() {
   cat <<USAGE

--- a/scripts/lib/tlh-install-subagents.mjs
+++ b/scripts/lib/tlh-install-subagents.mjs
@@ -7,6 +7,7 @@ import { readJsonFile } from "./tlh-install-utils.mjs";
 
 export const TLH_SUBAGENT_PROMPTS = Object.freeze([
 	"developer.md",
+	"validator.md",
 	"code-reviewer.md",
 	"repo-scout.md",
 	"diff-summarizer.md",

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -90,6 +90,23 @@ const contracts = [
 	},
 	{
 		group: "subagents",
+		name: "validator",
+		requiredTools: ["read", "grep", "find", "ls", "bash", "contact_supervisor"],
+		forbiddenTools: ["write", "edit", "subagent", "intercom", "web_search", "fetch_content", "get_search_content", "oracle"],
+		anchors: [
+			heading("Inputs"),
+			heading("Source-read-only invariant"),
+			heading("Validation process"),
+			heading("Escalation"),
+			heading("Output"),
+			bodyPattern("validator is read-only", /you are read-only/i),
+			orderedTerms("validator reads VALIDATING.md first when present", ["VALIDATING.md", "read it first"]),
+			includesAllTerms("validator forbids mutating validation modes", ["autofix", "update snapshots", "install dependencies", "watchers", "network access"]),
+			includesAllTerms("validator reports exact outcomes and triage", ["exact commands", "git status before validation", "git status after validation", "failure triage"]),
+		],
+	},
+	{
+		group: "subagents",
 		name: "code-reviewer",
 		requiredTools: ["read", "grep", "find", "ls", "bash", "contact_supervisor"],
 		forbiddenTools: ["write", "edit", "subagent", "intercom", "web_search", "fetch_content", "get_search_content", "oracle"],

--- a/tests/agents-subagents-metadata.test.mjs
+++ b/tests/agents-subagents-metadata.test.mjs
@@ -51,6 +51,50 @@ test("web-scout tool budget uses a concrete fetch limit with no placeholder text
 	assert.doesNotMatch(body, /Fetch ≤ N top results/);
 });
 
+test("validator frontmatter has expected metadata fields", () => {
+	const { frontmatter: fm } = readAgentPrompt("subagents", "validator");
+
+	assert.equal(fm.name, "validator");
+	assert.equal(fm.description, "Runs source-read-only validation commands and reports exact outcomes.");
+	assert.deepEqual(splitCommaList(fm.tools), ["read", "grep", "find", "ls", "bash", "contact_supervisor"]);
+	assert.equal(fm.model, "anthropic/claude-haiku-4-5");
+	assert.deepEqual(splitCommaList(fm.tlhOpenaiModels), ["openai-codex/gpt-5.4-mini", "openai/gpt-5.4-mini"]);
+	assert.equal(fm.thinking, "high");
+	assert.equal(fm.systemPromptMode, "replace");
+	assert.equal(fm.inheritProjectContext, "true");
+	assert.equal(fm.inheritSkills, "false");
+	assert.equal(fm.defaultContext, "fresh");
+});
+
+test("validator body contains mandatory validation guardrails", () => {
+	const { body } = readAgentPrompt("subagents", "validator");
+
+	const guardrails = [
+		["VALIDATING.md first", /VALIDATING\.md[\s\S]*read it first/i],
+		["source-read-only", /source-read-only/i],
+		["autofix", /autofix/i],
+		["snapshots", /snapshot/i],
+		["installs", /install dependenc/i],
+		["watchers", /watchers?|watch mode/i],
+		["network approval", /network(?:-dependent)? commands?|network access/i],
+		["git status before/after", /git status before validation/i],
+		["failure triage", /failure triage/i],
+	];
+	for (const [keyword, pattern] of guardrails) {
+		assert.match(body, pattern, `body should contain mandatory validator guardrail keyword: ${keyword}`);
+	}
+});
+
+test("loadSubagentMetadata exposes validator with expected model, tlhOpenaiModels, and description", () => {
+	const subagents = loadSubagentMetadata();
+	const validator = subagents.find((agent) => agent.name === "validator");
+
+	assert.ok(validator, "validator should be present in loadSubagentMetadata()");
+	assert.equal(validator.model, "anthropic/claude-haiku-4-5");
+	assert.deepEqual(validator.tlhOpenaiModels, ["openai-codex/gpt-5.4-mini", "openai/gpt-5.4-mini"]);
+	assert.equal(validator.description, "Runs source-read-only validation commands and reports exact outcomes.");
+});
+
 test("loadSubagentMetadata exposes web-scout with expected model, tlhOpenaiModels, and description", () => {
 	const subagents = loadSubagentMetadata();
 	const webScout = subagents.find((agent) => agent.name === "web-scout");

--- a/tests/architect-prompt-routing.test.mjs
+++ b/tests/architect-prompt-routing.test.mjs
@@ -5,6 +5,13 @@ import { readAgentPrompt } from "./agent-prompt-test-helpers.mjs";
 
 const { content: architectMd } = readAgentPrompt("primary", "architect");
 
+test("architect.md contains validator bullet in the subagent tools list", () => {
+	assert.match(
+		architectMd,
+		/- `validator`: run source-read-only validation commands and report exact commands, outcomes, skipped commands, git status before\/after, and failure triage\./,
+	);
+});
+
 test("architect.md contains web-scout bullet in the subagent tools list", () => {
 	assert.match(
 		architectMd,
@@ -30,6 +37,13 @@ test("architect.md excludes routine localized reversible directly testable work 
 	assert.match(
 		architectMd,
 		/Do not suggest the `oracle` for routine localized work that is reversible and directly testable\./,
+	);
+});
+
+test("architect.md routes final review through validator before code-reviewer", () => {
+	assert.match(
+		architectMd,
+		/1\. Delegate source-read-only validation to `validator` against the completed tickets and current worktree\.\n2\. Evaluate the validator report; delegate fixes to `developer` if needed\.\n3\. Delegate final review to `code-reviewer` against the full VCS diff, completed tickets, and validator findings\./,
 	);
 });
 

--- a/tests/install-libs.test.mjs
+++ b/tests/install-libs.test.mjs
@@ -342,7 +342,9 @@ test("subagent prompt discovery honors source precedence and copies prompt files
 
 	const installedDir = copyTlhSubagentPrompts(defaultConfig, localPrompts);
 	assert.equal(installedDir, join(realpathSync.native(agentDir), "tlh", "agents", "subagents"));
+	assert.equal(TLH_SUBAGENT_PROMPTS.includes("validator.md"), true);
 	assert.equal(TLH_SUBAGENT_PROMPTS.includes("web-scout.md"), true);
+	assert.equal(readFileSync(join(installedDir, "validator.md"), "utf8"), "local:validator.md\n");
 	assert.equal(readFileSync(join(installedDir, "web-scout.md"), "utf8"), "local:web-scout.md\n");
 	for (const prompt of TLH_SUBAGENT_PROMPTS) {
 		assert.equal(readFileSync(join(installedDir, prompt), "utf8"), `local:${prompt}\n`);

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -534,11 +534,11 @@ test("declared Node minimum stays aligned across installer metadata", () => {
 	assert.ok(releaseWorkflow.includes(`node-version: '${MIN_NODE_VERSION}'`));
 });
 
-test("stage-0 installer allowlist explicitly includes web-scout.md", () => {
+test("stage-0 installer allowlist explicitly includes validator.md and web-scout.md", () => {
 	const installSh = readFileSync(join(repoRoot, "install.sh"), "utf8");
 	assert.match(
 		installSh,
-		/^TLH_SUBAGENT_PROMPTS=\(developer\.md code-reviewer\.md repo-scout\.md diff-summarizer\.md librarian\.md oracle\.md web-scout\.md\)$/m,
+		/^TLH_SUBAGENT_PROMPTS=\(developer\.md validator\.md code-reviewer\.md repo-scout\.md diff-summarizer\.md librarian\.md oracle\.md web-scout\.md\)$/m,
 	);
 });
 

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -128,6 +128,25 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	}
 });
 
+test("primary prompts advertise only each primary's documented minor-agent set", () => {
+	const primaryAgents = loadPrimaryAgents();
+	const subagentMetadata = loadSubagentMetadata();
+	const architectPrompt = buildTlhSystemPrompt(primaryAgents.get("architect"), subagentMetadata, true);
+	const productPrompt = buildTlhSystemPrompt(primaryAgents.get("product"), subagentMetadata, true);
+	const bugHunterPrompt = buildTlhSystemPrompt(primaryAgents.get("bug-hunter"), subagentMetadata, true);
+	const rushPrompt = buildTlhSystemPrompt(primaryAgents.get("rush"), subagentMetadata, true);
+
+	assert.match(architectPrompt, /- validator: /);
+	assert.match(productPrompt, /- repo-scout: /);
+	assert.match(productPrompt, /- librarian: /);
+	assert.doesNotMatch(productPrompt, /- validator: |- developer: |- code-reviewer: /);
+	assert.match(bugHunterPrompt, /- oracle: /);
+	assert.doesNotMatch(bugHunterPrompt, /- validator: /);
+	assert.match(rushPrompt, /- code-reviewer: /);
+	assert.match(rushPrompt, /- diff-summarizer: /);
+	assert.doesNotMatch(rushPrompt, /- validator: |- developer: /);
+});
+
 test("child startup branch uses the mandatory-ticket child prompt", () => {
 	const registerBlock = sourceSection(
 		primaryRuntimeSource,
@@ -217,7 +236,7 @@ test("extension wires switch-primary-agent and active-primary safety", () => {
 	assert.match(toolCall, /applyProviderAwareSubagentModels\(event\.input, subagentsByName, ctx\.modelRegistry\.getAvailable\(\), ctx\.model\?\.provider\)/);
 	assert.match(toolCall, /const selection = currentPrimaryAgentSelection\(\)/);
 	assert.match(toolCall, /if \(selection === "rush" && subagentCallTargetsAgent\(event\.input, "developer"\)\)/);
-	assert.match(toolCall, /const reason = validateSubagentToolInput\(event\.input\)/);
+	assert.match(toolCall, /const reason = validateSubagentToolInput\(event\.input, \{ primaryAgent: selection \}\)/);
 	assert(
 		toolCall.indexOf('if (event.toolName === "bash")') < toolCall.indexOf("resolveTlhCommitAttribution"),
 		"parent tool_call should resolve attribution only inside the bash branch",

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1082,7 +1082,7 @@ test("enabled primary mode blocks disallowed nested delegation targets after for
 	assert.deepEqual(await toolCall(event, ctx), {
 		block: true,
 		reason:
-			"TLH primary agents may delegate only to: developer, code-reviewer, repo-scout, diff-summarizer, librarian, web-scout, oracle. Disallowed target(s): planner.",
+			"TLH primary agents may delegate only to: developer, validator, code-reviewer, repo-scout, diff-summarizer, librarian, web-scout, oracle. Disallowed target(s): planner.",
 	});
 	assert.equal(event.input.agentScope, "user");
 	assert.equal(event.input.context, "fresh");

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1048,13 +1048,13 @@ test("tool_call blocks non-progress printf process substitutions", async (t) => 
 	});
 });
 
-test("enabled primary mode allows approved delegation targets and forces safe top-level defaults", async () => {
+test("enabled architect mode allows validator and other approved delegation targets while forcing safe defaults", async () => {
 	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
 	const event = {
 		toolName: "subagent",
 		input: {
 			tasks: [{ agent: "repo-scout", prompt: "Map the repository" }],
-			chain: [{ parallel: [{ agent: "web-scout", prompt: "Research upstream release notes" }] }],
+			chain: [{ parallel: [{ agent: "web-scout", prompt: "Research upstream release notes" }, { agent: "validator", prompt: "Run source-read-only validation" }] }],
 		},
 	};
 	const ctx = createToolCallContext([
@@ -1086,6 +1086,44 @@ test("enabled primary mode blocks disallowed nested delegation targets after for
 	});
 	assert.equal(event.input.agentScope, "user");
 	assert.equal(event.input.context, "fresh");
+});
+
+test("enabled primary mode blocks delegations outside each primary allowlist", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+	for (const [selection, agent, reason] of [
+		["product", "validator", "TLH product may delegate only to: repo-scout, librarian. Disallowed target(s): validator."],
+		["product", "developer", "TLH product may delegate only to: repo-scout, librarian. Disallowed target(s): developer."],
+		["product", "code-reviewer", "TLH product may delegate only to: repo-scout, librarian. Disallowed target(s): code-reviewer."],
+		["bug-hunter", "validator", "TLH bug-hunter may delegate only to: repo-scout, librarian, oracle. Disallowed target(s): validator."],
+		["rush", "validator", "TLH rush may delegate only to: repo-scout, diff-summarizer, librarian, code-reviewer, oracle. Disallowed target(s): validator."],
+	]) {
+		const event = { toolName: "subagent", input: { agent, prompt: `Delegate to ${agent}` } };
+		const ctx = createToolCallContext([
+			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: selection } },
+		]);
+
+		assert.deepEqual(await toolCall(event, ctx), { block: true, reason });
+		assert.equal(event.input.agentScope, "user");
+		assert.equal(event.input.context, "fresh");
+	}
+});
+
+test("enabled primary mode preserves each primary's documented allowed helpers", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+	for (const [selection, input] of [
+		["product", { tasks: [{ agent: "repo-scout", prompt: "Map the repo" }, { agent: "librarian", prompt: "Research upstream docs" }] }],
+		["bug-hunter", { tasks: [{ agent: "repo-scout", prompt: "Inspect the area" }, { agent: "oracle", prompt: "Second opinion" }] }],
+		["rush", { chain: [{ parallel: [{ agent: "code-reviewer", prompt: "Review the diff", context: "fresh" }, { agent: "diff-summarizer", prompt: "Summarize the diff" }] }] }],
+	]) {
+		const event = { toolName: "subagent", input: structuredClone(input) };
+		const ctx = createToolCallContext([
+			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: selection } },
+		]);
+
+		assert.equal(await toolCall(event, ctx), undefined);
+		assert.equal(event.input.agentScope, "user");
+		assert.equal(event.input.context, "fresh");
+	}
 });
 
 test("enabled primary mode allows safe management calls and blocks non-user management scopes", async () => {

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -32,6 +32,7 @@ function createPiHarness() {
 test("ALLOWED_SUBAGENTS exposes bundled minor agents", () => {
 	assert.deepEqual(ALLOWED_SUBAGENTS, [
 		"developer",
+		"validator",
 		"code-reviewer",
 		"repo-scout",
 		"diff-summarizer",
@@ -39,6 +40,13 @@ test("ALLOWED_SUBAGENTS exposes bundled minor agents", () => {
 		"web-scout",
 		"oracle",
 	]);
+});
+
+test("validateSubagentToolInput allows validator as a permitted delegation target", () => {
+	const single = { agent: "validator", prompt: "run source-read-only validation for the completed ticket" };
+	assertAllowed(single);
+	assert.equal(single.agentScope, "user");
+	assert.equal(single.context, "fresh");
 });
 
 test("validateSubagentToolInput allows web-scout as a permitted delegation target", () => {
@@ -57,6 +65,7 @@ test("validateSubagentToolInput allows approved execution and forces fresh user 
 	const batched = {
 		tasks: [
 			{ agent: "repo-scout", prompt: "map the repo" },
+			{ agent: "validator", prompt: "run source-read-only validation" },
 			{ agent: "librarian", prompt: "research upstream docs" },
 			{ agent: "code-reviewer", prompt: "review the diff", context: "fresh" },
 		],

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -3,13 +3,15 @@ import test from "node:test";
 
 import {
 	ALLOWED_SUBAGENTS,
+	PRIMARY_SUBAGENT_ALLOWLISTS,
 	SUBAGENT_CHILD_ENV,
+	allowedSubagentsForPrimary,
 	registerTlhStartupMode,
 	validateSubagentToolInput,
 } from "../extensions/the-last-harness-subagent-safety.mjs";
 
-function assertAllowed(input) {
-	assert.equal(validateSubagentToolInput(input), undefined);
+function assertAllowed(input, options) {
+	assert.equal(validateSubagentToolInput(input, options), undefined);
 }
 
 function createPiHarness() {
@@ -42,9 +44,18 @@ test("ALLOWED_SUBAGENTS exposes bundled minor agents", () => {
 	]);
 });
 
-test("validateSubagentToolInput allows validator as a permitted delegation target", () => {
+test("PRIMARY_SUBAGENT_ALLOWLISTS keeps documented primary delegation boundaries", () => {
+	assert.deepEqual(PRIMARY_SUBAGENT_ALLOWLISTS.architect, ALLOWED_SUBAGENTS);
+	assert.deepEqual(PRIMARY_SUBAGENT_ALLOWLISTS.product, ["repo-scout", "librarian"]);
+	assert.deepEqual(PRIMARY_SUBAGENT_ALLOWLISTS["bug-hunter"], ["repo-scout", "librarian", "oracle"]);
+	assert.deepEqual(PRIMARY_SUBAGENT_ALLOWLISTS.rush, ["repo-scout", "diff-summarizer", "librarian", "code-reviewer", "oracle"]);
+	assert.deepEqual(allowedSubagentsForPrimary("architect"), ALLOWED_SUBAGENTS);
+	assert.deepEqual(allowedSubagentsForPrimary("unknown"), ALLOWED_SUBAGENTS);
+});
+
+test("validateSubagentToolInput allows validator for architect while forcing safe defaults", () => {
 	const single = { agent: "validator", prompt: "run source-read-only validation for the completed ticket" };
-	assertAllowed(single);
+	assertAllowed(single, { primaryAgent: "architect" });
 	assert.equal(single.agentScope, "user");
 	assert.equal(single.context, "fresh");
 });
@@ -56,33 +67,43 @@ test("validateSubagentToolInput allows web-scout as a permitted delegation targe
 	assert.equal(single.context, "fresh");
 });
 
-test("validateSubagentToolInput allows approved execution and forces fresh user context", () => {
-	const single = { agent: "developer", prompt: "implement the ticket" };
-	assertAllowed(single);
-	assert.equal(single.agentScope, "user");
-	assert.equal(single.context, "fresh");
+test("validateSubagentToolInput enforces per-primary delegation allowlists", () => {
+	const productAllowed = { tasks: [{ agent: "repo-scout", prompt: "map the repo" }, { agent: "librarian", prompt: "research upstream docs" }] };
+	assertAllowed(productAllowed, { primaryAgent: "product" });
+	assert.equal(productAllowed.agentScope, "user");
+	assert.equal(productAllowed.context, "fresh");
+	assert.match(
+		validateSubagentToolInput({ agent: "validator", prompt: "validate it" }, { primaryAgent: "product" }),
+		/TLH product may delegate only to: repo-scout, librarian\. Disallowed target\(s\): validator\./,
+	);
+	assert.match(
+		validateSubagentToolInput({ agent: "developer", prompt: "implement it" }, { primaryAgent: "product" }),
+		/TLH product may delegate only to: repo-scout, librarian\. Disallowed target\(s\): developer\./,
+	);
+	assert.match(
+		validateSubagentToolInput({ agent: "code-reviewer", prompt: "review it" }, { primaryAgent: "product" }),
+		/TLH product may delegate only to: repo-scout, librarian\. Disallowed target\(s\): code-reviewer\./,
+	);
 
-	const batched = {
-		tasks: [
-			{ agent: "repo-scout", prompt: "map the repo" },
-			{ agent: "validator", prompt: "run source-read-only validation" },
-			{ agent: "librarian", prompt: "research upstream docs" },
-			{ agent: "code-reviewer", prompt: "review the diff", context: "fresh" },
-		],
-		chain: [
-			{ agent: "diff-summarizer", prompt: "summarize" },
-			{ agent: "oracle", prompt: "provide a second opinion", context: "fresh" },
-			{
-				parallel: [
-					{ agent: "developer", prompt: "fix one issue" },
-					{ agent: "repo-scout", prompt: "inspect one area", context: "fresh" },
-				],
-			},
-		],
+	const bugHunterAllowed = { tasks: [{ agent: "repo-scout", prompt: "inspect" }, { agent: "oracle", prompt: "double-check" }] };
+	assertAllowed(bugHunterAllowed, { primaryAgent: "bug-hunter" });
+	assert.match(
+		validateSubagentToolInput({ agent: "validator", prompt: "validate it" }, { primaryAgent: "bug-hunter" }),
+		/TLH bug-hunter may delegate only to: repo-scout, librarian, oracle\. Disallowed target\(s\): validator\./,
+	);
+
+	const rushAllowed = {
+		chain: [{ parallel: [{ agent: "code-reviewer", prompt: "review it", context: "fresh" }, { agent: "diff-summarizer", prompt: "summarize it" }] }],
 	};
-	assertAllowed(batched);
-	assert.equal(batched.agentScope, "user");
-	assert.equal(batched.context, "fresh");
+	assertAllowed(rushAllowed, { primaryAgent: "rush" });
+	assert.match(
+		validateSubagentToolInput({ agent: "validator", prompt: "validate it" }, { primaryAgent: "rush" }),
+		/TLH rush may delegate only to: repo-scout, diff-summarizer, librarian, code-reviewer, oracle\. Disallowed target\(s\): validator\./,
+	);
+	assert.match(
+		validateSubagentToolInput({ agent: "developer", prompt: "implement it" }, { primaryAgent: "rush" }),
+		/TLH rush may delegate only to: repo-scout, diff-summarizer, librarian, code-reviewer, oracle\. Disallowed target\(s\): developer\./,
+	);
 });
 
 test("validateSubagentToolInput allows approved management calls and forces user scope where needed", () => {


### PR DESCRIPTION
## Summary
- Add a bundled `validator` minor subagent for source-read-only validation before final review
- Wire validator into architect workflow, subagent safety allowlists, installer prompt lists, docs, and tests
- Add repo-root `VALIDATING.md` with aggregate and targeted validation guidance

## Validation
- `npm run validate`

## Review
- Final code-reviewer follow-up found no required fixes