### PR TITLE
hide more commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,9 +2,9 @@
 
 This document lists slash commands available in an interactive TLH session, grouped by origin.
 
-Type any command name with a leading `/` in the TLH TUI to trigger it. Autocomplete surfaces most commands as you type; a small set of bundled commands is hidden from autocomplete but remains triggerable by typing — see [Hidden bundled commands](#hidden-bundled-commands) below.
+Type any command name with a leading `/` in the TLH TUI to trigger it. Autocomplete surfaces most commands as you type; a small set of upstream and bundled commands is hidden from autocomplete but remains triggerable by typing — see [Hidden autocomplete commands](#hidden-autocomplete-commands) below.
 
-> **Note:** autocomplete hiding is not an execution block. Any command listed under [Hidden bundled commands](#hidden-bundled-commands) can still be run by typing it in full.
+> **Note:** autocomplete hiding is not an execution block. Any command listed under [Hidden autocomplete commands](#hidden-autocomplete-commands) can still be run by typing it in full.
 
 ---
 
@@ -15,13 +15,13 @@ These commands are provided by the upstream Pi runtime. They are available in ev
 | Command | Description |
 |---------|-------------|
 | `/changelog` | Show upstream Pi changelog entries — **hidden from TLH autocomplete**; use `/tlh-changelog` for TLH release notes |
-| `/clone` | Duplicate the current session at the current position |
+| `/clone` | Duplicate the current session at the current position — **hidden from TLH autocomplete** |
 | `/compact` | Manually compact the session context |
 | `/copy` | Copy the last agent message to the clipboard |
 | `/export` | Export the session (HTML by default; pass a `.html` or `.jsonl` path to specify format) |
 | `/fork` | Create a new fork from a previous user message |
 | `/hotkeys` | Show all keyboard shortcuts |
-| `/import` | Import and resume a session from a JSONL file |
+| `/import` | Import and resume a session from a JSONL file — **hidden from TLH autocomplete** |
 | `/login` | Configure provider authentication |
 | `/logout` | Remove provider authentication |
 | `/model` | Select the active model (opens a selector UI) |
@@ -44,7 +44,8 @@ These commands are registered by the TLH extension bundled with this profile.
 
 | Command | Description |
 |---------|-------------|
-| `/effort` | Pick the model reasoning effort or thinking level |
+| `/thinking` | Pick the model thinking level |
+| `/effort` | Supported alias for `/thinking` |
 | `/review` | Open an interactive code-review mode picker (requires the architect primary agent) |
 | `/switch-primary-agent` | Show or switch the active TLH primary agent (`architect`, `rush`, `product`, `bug-hunter`, `disabled`) |
 | `/tlh-changelog` | Show TLH release notes from the packaged `CHANGELOG.md` |
@@ -141,8 +142,6 @@ These commands are provided by bundled default extensions and are visible in TLH
 | `/mcp` | `pi-mcp-adapter` | Show MCP server status |
 | `/mcp-auth` | `pi-mcp-adapter` | Authenticate with an MCP server (OAuth) |
 | `/oracle` | `pi-oracle` | Configure the Oracle default model and thinking level |
-| `/oracle-model` | `pi-oracle` | Show which model the oracle would use right now |
-| `/quiet-tools` | `pi-quiet-tools` | Toggle one-line collapsed invocations for built-in tool rows |
 | `/rtk` | `pi-rtk` | Control pi-rtk shell-command rewriting |
 | `/subagents-doctor` | `pi-subagents` | Show subagent diagnostics |
 | `/triage-comments` | `pi-triage-comments` | Collect pasted feedback or PR comments, then start a triage investigation |
@@ -161,9 +160,19 @@ Use the command explicitly to inspect or override the current mode:
 
 ---
 
-## Hidden bundled commands
+## Hidden autocomplete commands
 
-The following commands are registered by bundled extensions but are deliberately excluded from TLH autocomplete suggestions. They are still fully functional — type them in full to invoke them.
+These commands are registered and fully functional, but deliberately excluded from TLH autocomplete suggestions. Type them in full to invoke them.
+
+### Hidden upstream Pi built-ins
+
+| Command | Description |
+|---------|-------------|
+| `/changelog` | Show upstream Pi changelog entries; use `/tlh-changelog` for TLH release notes |
+| `/clone` | Duplicate the current session at the current position |
+| `/import` | Import and resume a session from a JSONL file |
+
+### Hidden bundled extension commands
 
 | Command | Extension | Description |
 |---------|-----------|-------------|
@@ -171,8 +180,8 @@ The following commands are registered by bundled extensions but are deliberately
 | `/fff-mode` | `pi-fff` | Show or set FFF mode (`tools-and-ui`, `tools-only`, `override`) |
 | `/fff-rescan` | `pi-fff` | Trigger FFF to rescan files |
 | `/intercom` | `pi-intercom` | Open the session intercom overlay (internal subagent communication) |
-
-The upstream `/changelog` command is also hidden from TLH autocomplete to reduce noise; use `/tlh-changelog` for TLH-specific release notes.
+| `/oracle-model` | `pi-oracle` | Show which model the oracle would use right now |
+| `/quiet-tools` | `pi-quiet-tools` | Toggle one-line collapsed invocations for built-in tool rows |
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,20 +44,21 @@ Test the extension directly from this checkout without installing it:
 pi --no-extensions -e ./extensions/the-last-harness.ts
 ```
 
-Then run the effort picker in the interactive UI:
+Then run the thinking picker in the interactive UI (or the supported `/effort` alias):
 
 ```text
-/effort
+/thinking
 ```
 
-You can also test direct arguments and validation:
+You can also test direct arguments, validation, and the alias:
 
 ```text
-/effort off
+/thinking off
+/thinking low
+/thinking high
+/thinking xhigh
+/thinking nope
 /effort low
-/effort high
-/effort xhigh
-/effort nope
 ```
 
 ## Test with an isolated temporary profile
@@ -78,7 +79,7 @@ PI_CODING_AGENT_DIR="$tmp/agent" pi
 Then run:
 
 ```text
-/effort
+/thinking
 ```
 
 ## Test the defaults manager

--- a/extensions/the-last-harness/autocomplete.ts
+++ b/extensions/the-last-harness/autocomplete.ts
@@ -1,7 +1,17 @@
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
 import { AUTOCOMPLETE_SOURCE_TAG_PATTERN } from "./constants.js";
 
-const HIDDEN_BUNDLED_COMMANDS = new Set(["fff-health", "fff-rescan", "fff-mode", "intercom"]);
+const HIDDEN_SLASH_COMMANDS = new Set([
+	"changelog",
+	"clone",
+	"import",
+	"oracle-model",
+	"quiet-tools",
+	"fff-health",
+	"fff-rescan",
+	"fff-mode",
+	"intercom",
+]);
 
 function stripAutocompleteSourceTag(description: string | undefined): string | undefined {
 	if (!description) {
@@ -28,10 +38,7 @@ function transformSuggestions(
 	let changed = false;
 	const items: AutocompleteItem[] = [];
 	for (const item of suggestions.items) {
-		if (
-			options.filterSlashCommandSuggestions &&
-			(HIDDEN_BUNDLED_COMMANDS.has(item.value) || item.value === "changelog")
-		) {
+		if (options.filterSlashCommandSuggestions && HIDDEN_SLASH_COMMANDS.has(item.value)) {
 			changed = true;
 			continue;
 		}

--- a/extensions/the-last-harness/effort.ts
+++ b/extensions/the-last-harness/effort.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { THINKING_LEVEL_DESCRIPTIONS, THINKING_LEVELS } from "./constants.js";
 import {
@@ -9,51 +9,60 @@ import {
 } from "./thinking.js";
 import type { ReasoningModel } from "./types.js";
 
+function getThinkingLevelCompletions(prefix: string) {
+	const normalizedPrefix = prefix.trim().toLowerCase();
+	const completions = THINKING_LEVELS.filter((level) => level.startsWith(normalizedPrefix)).map((level) => ({
+		value: level,
+		label: level,
+		description: THINKING_LEVEL_DESCRIPTIONS[level],
+	}));
+	return completions.length > 0 ? completions : null;
+}
+
+async function handleThinkingLevelCommand(pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void> {
+	const currentLevel = pi.getThinkingLevel();
+	const availableLevels = getAvailableThinkingLevels(ctx.model as ReasoningModel | undefined);
+	const requestedLevel = args.trim().toLowerCase();
+
+	if (requestedLevel) {
+		if (!isThinkingLevel(requestedLevel)) {
+			ctx.ui.notify(`Unknown thinking level "${args.trim()}". Available: ${availableLevels.join(", ")}.`, "error");
+			return;
+		}
+		if (!availableLevels.includes(requestedLevel)) {
+			ctx.ui.notify(
+				`Thinking level "${requestedLevel}" is not available for the current model. Available: ${availableLevels.join(", ")}.`,
+				"warning",
+			);
+			return;
+		}
+		pi.setThinkingLevel(requestedLevel);
+		ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
+		return;
+	}
+
+	if (!ctx.hasUI) {
+		ctx.ui.notify(`Available thinking levels: ${availableLevels.join(", ")}. Current: ${currentLevel}.`, "info");
+		return;
+	}
+
+	const options = availableLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
+	const selected = await ctx.ui.select("Pick thinking level", options);
+	const selectedLevel = selected ? parseThinkingLevelOption(selected) : undefined;
+	if (!selectedLevel) {
+		return;
+	}
+
+	pi.setThinkingLevel(selectedLevel);
+	ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
+}
+
 export function registerEffortCommand(pi: ExtensionAPI): void {
-	pi.registerCommand("effort", {
-		description: "Pick the model reasoning effort / thinking level",
-		getArgumentCompletions: (prefix) => {
-			const normalizedPrefix = prefix.trim().toLowerCase();
-			const completions = THINKING_LEVELS.filter((level) => level.startsWith(normalizedPrefix)).map((level) => ({
-				value: level,
-				label: level,
-				description: THINKING_LEVEL_DESCRIPTIONS[level],
-			}));
-			return completions.length > 0 ? completions : null;
-		},
-		handler: async (args, ctx) => {
-			const currentLevel = pi.getThinkingLevel();
-			const availableLevels = getAvailableThinkingLevels(ctx.model as ReasoningModel | undefined);
-			const requestedLevel = args.trim().toLowerCase();
-
-			if (requestedLevel) {
-				if (!isThinkingLevel(requestedLevel)) {
-					ctx.ui.notify(`Unknown effort "${args.trim()}". Available: ${availableLevels.join(", ")}.`, "error");
-					return;
-				}
-				if (!availableLevels.includes(requestedLevel)) {
-					ctx.ui.notify(`Effort "${requestedLevel}" is not available for the current model. Available: ${availableLevels.join(", ")}.`, "warning");
-					return;
-				}
-				pi.setThinkingLevel(requestedLevel);
-				ctx.ui.notify(`Effort set to ${pi.getThinkingLevel()}.`, "info");
-				return;
-			}
-
-			if (!ctx.hasUI) {
-				ctx.ui.notify(`Available efforts: ${availableLevels.join(", ")}. Current: ${currentLevel}.`, "info");
-				return;
-			}
-
-			const options = availableLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
-			const selected = await ctx.ui.select("Pick reasoning effort", options);
-			const selectedLevel = selected ? parseThinkingLevelOption(selected) : undefined;
-			if (!selectedLevel) {
-				return;
-			}
-
-			pi.setThinkingLevel(selectedLevel);
-			ctx.ui.notify(`Effort set to ${pi.getThinkingLevel()}.`, "info");
-		},
-	});
+	for (const commandName of ["effort", "thinking"] as const) {
+		pi.registerCommand(commandName, {
+			description: "Pick the model thinking level",
+			getArgumentCompletions: getThinkingLevelCompletions,
+			handler: (args, ctx) => handleThinkingLevelCommand(pi, args, ctx),
+		});
+	}
 }

--- a/tests/the-last-harness-autocomplete.test.mjs
+++ b/tests/the-last-harness-autocomplete.test.mjs
@@ -17,10 +17,14 @@ function createProvider(suggestions) {
 	};
 }
 
-test("autocomplete hides changelog and bundled maintenance commands in slash-command-name context", async () => {
+test("autocomplete hides configured slash commands only in slash-command-name context", async () => {
 	const suggestions = {
 		items: [
 			{ value: "changelog", label: "/changelog" },
+			{ value: "clone", label: "/clone" },
+			{ value: "import", label: "/import" },
+			{ value: "oracle-model", label: "/oracle-model" },
+			{ value: "quiet-tools", label: "/quiet-tools" },
 			{ value: "fff-health", label: "/fff-health" },
 			{ value: "fff-rescan", label: "/fff-rescan" },
 			{ value: "fff-mode", label: "/fff-mode" },
@@ -31,7 +35,7 @@ test("autocomplete hides changelog and bundled maintenance commands in slash-com
 	};
 	const provider = createTlhAutocompleteProvider(createProvider(suggestions));
 
-	const result = await provider.getSuggestions(["/f"], 0, 2, { signal: AbortSignal.abort() });
+	const result = await provider.getSuggestions(["/q"], 0, 2, { signal: AbortSignal.abort() });
 
 	assert.deepEqual(result?.items.map((item) => item.value), ["tlh-changelog", "agent"]);
 });
@@ -40,6 +44,10 @@ test("autocomplete keeps hidden commands outside slash-command-name context", as
 	const suggestions = {
 		items: [
 			{ value: "changelog", label: "/changelog" },
+			{ value: "clone", label: "/clone" },
+			{ value: "import", label: "/import" },
+			{ value: "oracle-model", label: "/oracle-model" },
+			{ value: "quiet-tools", label: "/quiet-tools" },
 			{ value: "fff-health", label: "/fff-health" },
 			{ value: "intercom", label: "/intercom" },
 			{ value: "agent", label: "/agent" },
@@ -47,7 +55,7 @@ test("autocomplete keeps hidden commands outside slash-command-name context", as
 	};
 	const provider = createTlhAutocompleteProvider(createProvider(suggestions));
 
-	const result = await provider.getSuggestions(["/agent fff"], 0, 10, { signal: AbortSignal.abort() });
+	const result = await provider.getSuggestions(["/agent quiet"], 0, 12, { signal: AbortSignal.abort() });
 
 	assert.strictEqual(result, suggestions);
 });
@@ -56,7 +64,14 @@ test("autocomplete returns null when filtering removes every slash-command sugge
 	const provider = createTlhAutocompleteProvider(createProvider({
 		items: [
 			{ value: "changelog", label: "/changelog" },
+			{ value: "clone", label: "/clone" },
+			{ value: "import", label: "/import" },
+			{ value: "oracle-model", label: "/oracle-model" },
+			{ value: "quiet-tools", label: "/quiet-tools" },
 			{ value: "fff-health", label: "/fff-health" },
+			{ value: "fff-rescan", label: "/fff-rescan" },
+			{ value: "fff-mode", label: "/fff-mode" },
+			{ value: "intercom", label: "/intercom" },
 		],
 	}));
 

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -172,6 +172,15 @@ test("extension imports extracted shared helpers from nested TypeScript modules"
 	assert.doesNotMatch(extensionSource, /async function applyPrimaryModel/);
 });
 
+test("thinking alias shares the effort command thinking-level behavior", () => {
+	assert.match(effortSource, /\["effort", "thinking"\] as const/);
+	assert.match(effortSource, /description: "Pick the model thinking level"/);
+	assert.match(effortSource, /Unknown thinking level/);
+	assert.match(effortSource, /Thinking level set to/);
+	assert.match(effortSource, /Available thinking levels/);
+	assert.match(effortSource, /Pick thinking level/);
+});
+
 test("extension delegates launch update and telemetry services to feature modules", () => {
 	const sessionStart = sourceSection(extensionSource, 'pi.on("session_start"', "\n\t});\n}");
 


### PR DESCRIPTION
## Summary
- Hide noisy upstream/session-management and bundled power-user commands from TLH slash-command autocomplete while keeping them manually runnable
- Add `/thinking` as an alias for the existing `/effort` thinking-level picker
- Update command docs and tests for the hidden autocomplete set and alias

## Validation
- `npm run validate`
- final code-reviewer pass: no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/thinking` command to control reasoning level, with `/effort` as an alias. Supports `off`, `low`, `high`, `xhigh`, and `nope` arguments.

* **Documentation**
  * Updated command documentation to reflect new `/thinking` command and reorganized hidden command listings for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->