### PR TITLE
Force-remove retired confirmation extensions

### DIFF
--- a/.tickets/tlha-blg8.md
+++ b/.tickets/tlha-blg8.md
@@ -1,0 +1,18 @@
+---
+id: tlha-blg8
+status: open
+deps: []
+links: []
+created: 2026-06-05T09:35:41Z
+type: chore
+priority: 3
+assignee: Diego Petrucci
+---
+# Post-release: remove unconditional confirmation-extension purge
+
+After the next TLH release that includes the forced removal of permission-gate and confirm-destructive has shipped, remove the temporary unconditional identity-based purge for npm:@diegopetrucci/pi-permission-gate and npm:@diegopetrucci/pi-confirm-destructive. The replacement behavior should rely on provenance-aware retired-default cleanup so manually re-added packages are respected.
+
+## Acceptance Criteria
+
+Do not implement until after the first release containing the force-removal ships; unconditional identity-based removal for these two packages is gone; cleanup respects tlh.defaultExtensionProvenance/managed TLH defaults; tests cover preserving manually re-added package identities after provenance exists.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to The Last Harness will be documented in this file.
 - The footer no longer shows the model provider name; the provider prefix is always hidden.
 - Context cap is now a built-in TLH feature (no longer a bundled default extension). The bundled `@diegopetrucci/pi-context-cap` default extension has been removed and will be force-uninstalled from existing isolated profiles on the next `tlh` install or update. Previous `tlh.disabledDefaultExtensions: ["context-cap"]` opt-outs are intentionally **not** preserved — those entries are silently pruned on upgrade. To opt out of the cap again, run `/toggle-context-cap` or set `tlh.contextCap.disabled: true` in your isolated settings.
 - TLH now records bundled default-extension provenance in `tlh.defaultExtensionProvenance.managedPackageIdentities` so retired-default cleanup can distinguish TLH-managed packages from later manual re-adds. Older installs migrate this metadata on update; legacy Plannotator is still cleaned up once during that migration.
+- `tlh` install/update now force-removes the retired bundled `permission-gate` and `confirm-destructive` confirmation packages from existing isolated TLH profiles. New installs already omit both packages, and this cleanup only touches the isolated TLH profile (for example `~/.the-last-harness/agent/settings.json`), not normal Pi config under `~/.pi/agent`.
 
 ### Added
 
@@ -29,7 +30,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Removed
 
-- Removed the bundled `confirm-destructive` default extension. New installs no longer ship destructive-action confirmation prompts. Existing installs are unaffected by the upgrade — the package will remain in your isolated `~/.the-last-harness/agent/settings.json` `packages` array until you remove that line manually.
+- Removed the bundled `confirm-destructive` default extension. New installs no longer ship destructive-action confirmation prompts. Existing installs were initially unaffected by the 0.16.0 upgrade, but a later `tlh` install/update now force-removes that retired package from the isolated `~/.the-last-harness/agent/settings.json` `packages` array. Normal Pi config under `~/.pi/agent` is unchanged.
 
 ## [0.15.0] - 2026-06-01
 

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -320,15 +320,23 @@ function applyDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds
 	);
 }
 
-// Source of the retired upstream context-cap extension. Hardcoded because it
-// is no longer in the manifest and cannot be read dynamically.
-const RETIRED_CONTEXT_CAP_SOURCE = "npm:@diegopetrucci/pi-context-cap";
-const RETIRED_CONTEXT_CAP_IDENTITY = packageIdentity(RETIRED_CONTEXT_CAP_SOURCE);
+// Sources of retired default extensions that TLH now removes unconditionally
+// from isolated settings because they should no longer stay installed after
+// install/update reruns.
+const FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES = Object.freeze([
+	"npm:@diegopetrucci/pi-context-cap",
+	"npm:@diegopetrucci/pi-permission-gate",
+	"npm:@diegopetrucci/pi-confirm-destructive",
+]);
 
-function purgeRetiredContextCapPackage(settings, changes) {
-	if (!RETIRED_CONTEXT_CAP_IDENTITY || !Array.isArray(settings.packages)) return;
-	while (removePackageByIdentity(settings, RETIRED_CONTEXT_CAP_IDENTITY)) {
-		changes.push(`force-remove retired default extension package: ${RETIRED_CONTEXT_CAP_SOURCE}`);
+function purgeForceRemovedRetiredDefaultExtensionPackages(settings, changes) {
+	if (!Array.isArray(settings.packages)) return;
+	for (const source of FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES) {
+		const identity = packageIdentity(source);
+		if (!identity) continue;
+		while (removePackageByIdentity(settings, identity)) {
+			changes.push(`force-remove retired default extension package: ${source}`);
+		}
 	}
 }
 
@@ -573,7 +581,7 @@ function main() {
 	applyDefaultExtensionLoadOrder(next, defaultExtensions, disabledIds, changes);
 	removeCriticalDisabledDefaultExtensionOptOuts(next, defaultExtensions, changes);
 	scrubGnosisSettings(next, changes);
-	purgeRetiredContextCapPackage(next, changes);
+	purgeForceRemovedRetiredDefaultExtensionPackages(next, changes);
 	pruneContextCapDisabledDefaultExtension(next, changes);
 	syncDefaultExtensionProvenance(next, defaultExtensions, disabledIds, changes);
 

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -10,6 +10,8 @@ const mergeScript = join(repoRoot, "scripts", "merge-settings.mjs");
 const settingsDefaultsPath = join(repoRoot, "config", "settings.defaults.json");
 const harnessPackage = "git:github.com/diegopetrucci/the-last-harness";
 const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
+const retiredPermissionGatePackage = "npm:@diegopetrucci/pi-permission-gate";
+const retiredConfirmDestructivePackage = "npm:@diegopetrucci/pi-confirm-destructive";
 const changelogSentinel = "9999.0.0";
 
 function tempFixture(defaultsValue, settingsValue, extensionsValue = []) {
@@ -423,6 +425,30 @@ test("merge defers bundled pi-web-access when an upstream package is already ins
 	]);
 });
 
+test("merge force-removes retired confirmation packages by identity while preserving unrelated packages", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				`${retiredPermissionGatePackage}@1.2.3`,
+				{ source: `${retiredConfirmDestructivePackage}@0.4.0`, extensions: ["legacy-filter"] },
+				"npm:@diegopetrucci/pi-notify",
+			],
+		},
+	);
+
+	const output = runMerge(fixture, { quiet: false });
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(settings.packages, [
+		harnessPackage,
+		"npm:@diegopetrucci/pi-notify",
+	]);
+	assert.match(output, /force-remove retired default extension package: npm:@diegopetrucci\/pi-permission-gate/);
+	assert.match(output, /force-remove retired default extension package: npm:@diegopetrucci\/pi-confirm-destructive/);
+});
+
 test("merge removes npm:@diegopetrucci/pi-context-cap package and emits a changes line", () => {
 	const fixture = tempFixture(
 		{ packages: [] },
@@ -491,6 +517,29 @@ test("merge is a no-op when settings have neither pi-context-cap nor context-cap
 
 	assert.match(output, /No settings changes needed\./);
 	assert.equal(readFileSync(fixture.settings, "utf8"), afterFirst, "settings should be unchanged");
+});
+
+test("merge cleanup of retired confirmation packages is idempotent after first run", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				retiredPermissionGatePackage,
+				retiredConfirmDestructivePackage,
+			],
+		},
+	);
+
+	runMerge(fixture);
+
+	const afterFirst = readFileSync(fixture.settings, "utf8");
+	const firstSettings = readJson(fixture.settings);
+	assert.deepEqual(firstSettings.packages, [harnessPackage], "retired confirmation packages removed on first run");
+
+	const secondOutput = runMerge(fixture, { quiet: false });
+	assert.match(secondOutput, /No settings changes needed\./);
+	assert.equal(readFileSync(fixture.settings, "utf8"), afterFirst, "settings unchanged on second run");
 });
 
 test("merge cleanup of pi-context-cap is idempotent after first run", () => {


### PR DESCRIPTION
## Summary
- force-remove retired permission-gate and confirm-destructive package identities during isolated TLH settings merges
- document the existing-profile cleanup behavior in the changelog
- add a post-release follow-up ticket to remove the temporary unconditional purge and return to provenance-aware cleanup

## Validation
- npm run validate
- final code-reviewer pass with no actionable findings