### PR TITLE
Fix TLH package dedupe for slash refs

### DIFF
--- a/scripts/lib/default-extensions.mjs
+++ b/scripts/lib/default-extensions.mjs
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 
+import { parseGitSource } from "./tlh-install-package-source.mjs";
+
 function isPlainObject(value) {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -48,6 +50,9 @@ function npmIdentity(spec) {
 }
 
 function gitIdentity(source) {
+	const parsed = parseGitSource(source);
+	if (parsed) return `git:${parsed.host.toLowerCase()}/${parsed.path.toLowerCase()}`;
+
 	let value = source.trim();
 	if (value.startsWith("git:")) value = value.slice("git:".length).trim();
 	value = value.replace(/^https?:\/\//i, "");
@@ -58,9 +63,8 @@ function gitIdentity(source) {
 	value = value.replace(/\.git$/, "");
 	value = value.replace(/\.git(?=@)/, "");
 
-	const lastSlash = value.lastIndexOf("/");
-	const refAt = lastSlash === -1 ? -1 : value.indexOf("@", lastSlash + 1);
-	if (refAt !== -1) value = value.slice(0, refAt);
+	const firstAt = value.indexOf("@");
+	if (firstAt !== -1) value = value.slice(0, firstAt);
 
 	return `git:${value.toLowerCase()}`;
 }

--- a/scripts/lib/tlh-install-support-manifest.mjs
+++ b/scripts/lib/tlh-install-support-manifest.mjs
@@ -21,7 +21,7 @@ const BASE_SUPPORT_FILES = Object.freeze([
 		requirement: REQUIRED,
 		relativePath: "scripts/lib/tlh-install-package-source.mjs",
 		tempPath: "lib/tlh-install-package-source.mjs",
-		installName: "",
+		installName: "lib/tlh-install-package-source.mjs",
 	},
 	{
 		variable: "TLH_INSTALL_PATHS_LIB",

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -205,6 +205,13 @@ function removeDuplicatePackagesByIdentity(settings, identity) {
 	return removedSources;
 }
 
+function applyHarnessPackageDedupes(settings, ensuredSource, changes) {
+	if (!Array.isArray(settings.packages)) return;
+	for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
+		changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
+	}
+}
+
 function applyReplacedDefaultExtensions(settings, defaultExtensions, disabledIds, changes, { force }) {
 	if (!Array.isArray(settings.packages)) return;
 
@@ -567,8 +574,10 @@ function main() {
 	const rawDefaults = readJsonFile(defaultsPath);
 	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath, { allowMissing: true });
 	const disabledIds = disabledDefaultExtensionIds(existing, defaultExtensions);
+	const ensuredHarnessSource = args.packageSource || DEFAULT_PACKAGE_SOURCE;
 	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
 	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
+	applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
 	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, { force: args.force });
 	applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
 	applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -56,6 +56,13 @@ test("shared package identity keeps npm, git, and local source semantics", () =>
 	assert.equal(packageIdentity("https://github.com/TLH/helper.git#pin"), "git:github.com/tlh/helper");
 	assert.equal(packageIdentity("git@github.com:TLH/helper.git"), "git:github.com/tlh/helper");
 	assert.equal(packageIdentity("../local-helper@pin"), "local:../local-helper@pin");
+
+	const harnessIdentity = packageIdentity("git:github.com/diegopetrucci/the-last-harness");
+	assert.equal(packageIdentity("git:github.com/diegopetrucci/the-last-harness@tlh-v0.16.0"), harnessIdentity);
+	assert.equal(
+		packageIdentity("git:github.com/diegopetrucci/the-last-harness@feature/curated-startup-tips"),
+		harnessIdentity,
+	);
 });
 
 test("shared default-extension reader trims descriptions and can allow missing manifests", () => {
@@ -133,6 +140,7 @@ test("installed tlh-defaults helper can resolve its copied default-extension lib
 	const supportDir = join(fixture.dir, "agent", "tlh");
 	const copiedVariables = new Set([
 		"TLH_DEFAULTS_SCRIPT",
+		"TLH_INSTALL_PACKAGE_SOURCE_LIB",
 		"TLH_INSTALL_PATHS_LIB",
 		"TLH_INSTALL_UTILS_LIB",
 		"DEFAULT_EXTENSIONS_LIB",

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -9,6 +9,7 @@ const repoRoot = resolve(import.meta.dirname, "..");
 const mergeScript = join(repoRoot, "scripts", "merge-settings.mjs");
 const settingsDefaultsPath = join(repoRoot, "config", "settings.defaults.json");
 const harnessPackage = "git:github.com/diegopetrucci/the-last-harness";
+const branchHarnessPackage = "git:github.com/diegopetrucci/the-last-harness@feature/curated-startup-tips";
 const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
 const retiredPermissionGatePackage = "npm:@diegopetrucci/pi-permission-gate";
 const retiredConfirmDestructivePackage = "npm:@diegopetrucci/pi-confirm-destructive";
@@ -25,13 +26,14 @@ function tempFixture(defaultsValue, settingsValue, extensionsValue = []) {
 	return { defaults, extensions, settings };
 }
 
-function runMerge(fixture, { dryRun = false, force = false, quiet = true } = {}) {
+function runMerge(fixture, { dryRun = false, force = false, quiet = true, packageSource = "" } = {}) {
 	const args = [
 		mergeScript,
 		fixture.defaults,
 		"--settings", fixture.settings,
 		"--default-extensions", fixture.extensions,
 	];
+	if (packageSource) args.push("--package-source", packageSource);
 	if (dryRun) args.push("--dry-run");
 	if (force) args.push("--force");
 	if (quiet) args.push("--quiet");
@@ -398,6 +400,62 @@ test("critical source updates dedupe stale same-identity filtered packages", () 
 	]);
 });
 
+test("merge replaces the harness package when a slash ref keeps the same git identity", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [harnessPackage],
+		},
+	);
+
+	runMerge(fixture, { packageSource: branchHarnessPackage });
+
+	assert.deepEqual(readJson(fixture.settings).packages, [branchHarnessPackage]);
+});
+
+test("merge dedupes duplicate harness entries when rerun with a branch package source", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				branchHarnessPackage,
+				harnessPackage,
+				"npm:unrelated-package@1.0.0",
+				"npm:unrelated-package",
+			],
+		},
+	);
+
+	runMerge(fixture, { packageSource: branchHarnessPackage });
+
+	assert.deepEqual(readJson(fixture.settings).packages, [
+		branchHarnessPackage,
+		"npm:unrelated-package@1.0.0",
+		"npm:unrelated-package",
+	]);
+});
+
+test("merge dedupes duplicate harness entries when rerun from main", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				branchHarnessPackage,
+				harnessPackage,
+				"npm:unrelated-package@1.0.0",
+				"npm:unrelated-package",
+			],
+		},
+	);
+
+	runMerge(fixture);
+
+	assert.deepEqual(readJson(fixture.settings).packages, [
+		harnessPackage,
+		"npm:unrelated-package@1.0.0",
+		"npm:unrelated-package",
+	]);
+});
 
 test("merge defers bundled pi-web-access when an upstream package is already installed", () => {
 	const fixture = tempFixture(


### PR DESCRIPTION
## Summary
- normalize git package identities with the shared package-source parser so slash-containing refs match the unpinned TLH package
- dedupe existing duplicate TLH package entries during settings merges while leaving unrelated package duplicates alone
- ship the parser dependency with installed helper support files and add regression coverage

## Validation
- npm run validate

## Notes
This fixes main-track to branch reinstall cases where isolated settings could keep both the branch package and the unpinned TLH package, causing startup to load main code instead of the requested branch.