### PR TITLE
Force architect thinking level to be medium+, lock levels for product/bug-hunter/rush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Fixed
 
-- Primary-agent thinking is now asserted on every primary switch. Previously, switching back to architect after a Rush session could leave thinking at Rush's low level instead of restoring architect's declared high.
+- Primary-agent thinking is now asserted on every primary switch. Previously, switching back to architect after a Rush session could leave thinking at Rush's low level instead of reapplying architect's default when Rush had left the session below architect's medium floor.
 
 ### Changed
 
-- Rush, product, and bug-hunter now run at fixed thinking levels. Attempting to change thinking under these primaries with `/effort` returns a clear error: `Thinking is locked at "<level>" for the <name> primary agent.` The locked levels are: rush → low (off on OpenAI/OpenAI-Codex), product → high, bug-hunter → high.
-- Architect now enforces a minimum thinking floor of medium. `/effort` cannot set architect thinking below medium. Any session currently running architect below medium will be bumped to architect's declared high on the next primary apply (session start or primary switch).
+- Rush, product, and bug-hunter now run at fixed thinking levels. Attempting to change thinking under these primaries with `/thinking` or `/effort` returns a clear error: `Thinking is locked at "<level>" for the <name> primary agent.` The locked levels are: rush → low (off on OpenAI/OpenAI-Codex), product → high, bug-hunter → high.
+- Architect now enforces a minimum thinking floor of medium. `/thinking` and `/effort` cannot set architect thinking below medium. Any session currently running architect below medium will be bumped to architect's default thinking on the next primary apply (session start or primary switch).
 
 ## [0.17.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Primary-agent thinking is now asserted on every primary switch. Previously, switching back to architect after a Rush session could leave thinking at Rush's low level instead of restoring architect's declared high.
+
+### Changed
+
+- Rush, product, and bug-hunter now run at fixed thinking levels. Attempting to change thinking under these primaries with `/effort` returns a clear error: `Thinking is locked at "<level>" for the <name> primary agent.` The locked levels are: rush → low (off on OpenAI/OpenAI-Codex), product → high, bug-hunter → high.
+- Architect now enforces a minimum thinking floor of medium. `/effort` cannot set architect thinking below medium. Any session currently running architect below medium will be bumped to architect's declared high on the next primary apply (session start or primary switch).
+
 ## [0.17.0] - 2026-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The architect is the default, but it is not the only mode.
 - **product** is for product framing, tradeoffs, strategy, and implementation-ready ticket shaping. It does not implement code.
 - **bug-hunter** is for read-only debugging and root-cause analysis before you decide how to fix something.
 
+**Thinking levels are fixed for some primaries.** Rush, product, and bug-hunter each run at a locked thinking level — `/effort` is blocked while they are active. Architect requires at least medium thinking; `/effort` cannot drop it below that floor.
+
 Use `Shift+Tab` to cycle the current session through `architect` → `rush` → `product` → `bug-hunter` → `disabled`.
 
 When primary agents are disabled, TLH stops applying those primary-agent workflow/persona rules, but the underlying subagent machinery still exists.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The architect is the default, but it is not the only mode.
 - **product** is for product framing, tradeoffs, strategy, and implementation-ready ticket shaping. It does not implement code.
 - **bug-hunter** is for read-only debugging and root-cause analysis before you decide how to fix something.
 
-**Thinking levels are fixed for some primaries.** Rush, product, and bug-hunter each run at a locked thinking level — `/effort` is blocked while they are active. Architect requires at least medium thinking; `/effort` cannot drop it below that floor.
+**Thinking levels are fixed for some primaries.** Rush, product, and bug-hunter each run at a locked thinking level — `/thinking` and `/effort` are blocked while they are active. Architect requires at least medium thinking; `/thinking` and `/effort` cannot drop it below that floor.
 
 Use `Shift+Tab` to cycle the current session through `architect` → `rush` → `product` → `bug-hunter` → `disabled`.
 

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -4,6 +4,9 @@ description: Clarifies requirements, manages implementation tasks, and orchestra
 model: anthropic/claude-opus-4-7
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
+applyModel: true
+applyThinking: true
+minThinking: medium
 tools: read, write, edit, grep, find, ls, bash, subagent, intercom
 systemPromptMode: append
 inheritProjectContext: true

--- a/agents/primary/bug-hunter.md
+++ b/agents/primary/bug-hunter.md
@@ -4,6 +4,9 @@ description: Investigates reported bugs, identifies root causes, and recommends 
 model: anthropic/claude-opus-4-7
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
+applyModel: true
+applyThinking: true
+lockThinking: true
 tools: read, grep, find, ls, bash, subagent, intercom
 systemPromptMode: append
 inheritProjectContext: true

--- a/agents/primary/product.md
+++ b/agents/primary/product.md
@@ -4,6 +4,9 @@ description: Guides product strategy, decisions, product docs, and implementatio
 model: anthropic/claude-opus-4-6
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
+applyModel: true
+applyThinking: true
+lockThinking: true
 tools: read, grep, find, ls, bash, write, edit, subagent, intercom
 systemPromptMode: append
 inheritProjectContext: true

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -8,6 +8,7 @@ tlhOpenaiThinking: off
 preferCurrentOpenaiModel: true
 applyModel: true
 applyThinking: true
+lockThinking: true
 tools: read, write, edit, grep, find, ls, bash, subagent, intercom
 systemPromptMode: append
 inheritProjectContext: true

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,8 +46,8 @@ These commands are registered by the TLH extension bundled with this profile.
 
 | Command | Description |
 |---------|-------------|
-| `/thinking` | Pick the model thinking level |
-| `/effort` | Supported alias for `/thinking`; blocked for locked primaries (rush, product, bug-hunter), and architect enforces a medium floor |
+| `/thinking` | Pick the model thinking level, subject to the active primary-agent thinking constraints |
+| `/effort` | Supported alias for `/thinking`, subject to the same active primary-agent thinking constraints |
 | `/experimental` | List or change TLH experimental features |
 | `/review` | Open an interactive code-review mode picker (requires the architect primary agent) |
 | `/switch-primary-agent` | Show or switch the active TLH primary agent (`architect`, `rush`, `product`, `bug-hunter`, `disabled`) |
@@ -57,9 +57,9 @@ These commands are registered by the TLH extension bundled with this profile.
 | `/usage` | Show or change TLH subscription usage-limit footer preferences |
 | `/version` | Show the installed TLH version and the upstream Pi runtime version |
 
-### `/effort`
+### `/thinking` and `/effort`
 
-`/effort` is blocked for **locked** primaries: rush, product, and bug-hunter each run at a fixed thinking level and return an error if you try to change it (`Thinking is locked at "<level>" for the <name> primary agent.`). **Architect** has a medium floor: `/effort off`, `/effort minimal`, and `/effort low` are rejected with `architect requires at least medium thinking.` The floor does not apply when the primary is disabled.
+Both `/thinking` and `/effort` are subject to the active primary-agent thinking constraints. **Locked** primaries — rush, product, and bug-hunter — each run at a fixed thinking level and return an error if you try to change it (`Thinking is locked at "<level>" for the <name> primary agent.`). **Architect** enforces a medium floor: `/thinking off`, `/thinking minimal`, `/thinking low`, `/effort off`, `/effort minimal`, and `/effort low` are rejected with `architect requires at least medium thinking.` The floor does not apply when the primary is disabled.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,7 @@ These commands are registered by the TLH extension bundled with this profile.
 | Command | Description |
 |---------|-------------|
 | `/thinking` | Pick the model thinking level |
-| `/effort` | Supported alias for `/thinking` |
+| `/effort` | Supported alias for `/thinking`; blocked for locked primaries (rush, product, bug-hunter), and architect enforces a medium floor |
 | `/experimental` | List or change TLH experimental features |
 | `/review` | Open an interactive code-review mode picker (requires the architect primary agent) |
 | `/switch-primary-agent` | Show or switch the active TLH primary agent (`architect`, `rush`, `product`, `bug-hunter`, `disabled`) |
@@ -56,6 +56,10 @@ These commands are registered by the TLH extension bundled with this profile.
 | `/toggle-tlh-git-attribution` | Toggle the TLH commit attribution footer for agent-created git commits |
 | `/usage` | Show or change TLH subscription usage-limit footer preferences |
 | `/version` | Show the installed TLH version and the upstream Pi runtime version |
+
+### `/effort`
+
+`/effort` is blocked for **locked** primaries: rush, product, and bug-hunter each run at a fixed thinking level and return an error if you try to change it (`Thinking is locked at "<level>" for the <name> primary agent.`). **Architect** has a medium floor: `/effort off`, `/effort minimal`, and `/effort low` are rejected with `architect requires at least medium thinking.` The floor does not apply when the primary is disabled.
 
 ---
 

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -35,7 +35,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 	installTlhPackageUpdateNotificationOverride();
 	registerToggleTlhGitAttributionCommand(pi);
 	registerAnnotateLastMessageCommand(pi);
-	registerEffortCommand(pi);
+	registerEffortCommand(pi, primaryAgentRuntime);
 	registerExperimentalCommand(pi);
 	registerReviewCommand(pi);
 	registerTlhChangelogCommand(pi);

--- a/extensions/the-last-harness/effort.ts
+++ b/extensions/the-last-harness/effort.ts
@@ -1,17 +1,31 @@
 import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { THINKING_LEVEL_DESCRIPTIONS, THINKING_LEVELS } from "./constants.js";
+import { selectProviderAwareAgentDefaults } from "./model-defaults.js";
+import type { TlhPrimaryAgentRuntime } from "./primary-agent-runtime.js";
 import {
 	formatThinkingLevelOption,
 	getAvailableThinkingLevels,
 	isThinkingLevel,
 	parseThinkingLevelOption,
+	thinkingLevelAtLeast,
 } from "./thinking.js";
 import type { ReasoningModel } from "./types.js";
 
-function getThinkingLevelCompletions(prefix: string) {
+function getThinkingLevelCompletions(prefix: string, runtime?: TlhPrimaryAgentRuntime) {
+	const primary = runtime?.activePrimaryAgentPrompt();
 	const normalizedPrefix = prefix.trim().toLowerCase();
-	const completions = THINKING_LEVELS.filter((level) => level.startsWith(normalizedPrefix)).map((level) => ({
+
+	if (primary?.lockThinking) {
+		return [];
+	}
+
+	const minThinking = primary?.minThinking;
+	const filteredLevels =
+		minThinking !== undefined
+			? THINKING_LEVELS.filter((level) => thinkingLevelAtLeast(level, minThinking))
+			: THINKING_LEVELS;
+	const completions = filteredLevels.filter((level) => level.startsWith(normalizedPrefix)).map((level) => ({
 		value: level,
 		label: level,
 		description: THINKING_LEVEL_DESCRIPTIONS[level],
@@ -19,10 +33,25 @@ function getThinkingLevelCompletions(prefix: string) {
 	return completions.length > 0 ? completions : null;
 }
 
-async function handleThinkingLevelCommand(pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void> {
+async function handleThinkingLevelCommand(
+	pi: ExtensionAPI,
+	args: string,
+	ctx: ExtensionCommandContext,
+	runtime?: TlhPrimaryAgentRuntime,
+): Promise<void> {
+	const primary = runtime?.activePrimaryAgentPrompt();
+
+	if (primary?.lockThinking) {
+		const defaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
+		const level = defaults.thinking ?? "off";
+		ctx.ui.notify(`Thinking is locked at "${level}" for the ${primary.name} primary agent.`, "error");
+		return;
+	}
+
 	const currentLevel = pi.getThinkingLevel();
 	const availableLevels = getAvailableThinkingLevels(ctx.model as ReasoningModel | undefined);
 	const requestedLevel = args.trim().toLowerCase();
+	const minThinking = primary?.minThinking;
 
 	if (requestedLevel) {
 		if (!isThinkingLevel(requestedLevel)) {
@@ -36,17 +65,26 @@ async function handleThinkingLevelCommand(pi: ExtensionAPI, args: string, ctx: E
 			);
 			return;
 		}
+		if (minThinking !== undefined && !thinkingLevelAtLeast(requestedLevel, minThinking)) {
+			ctx.ui.notify(`${primary!.name} requires at least ${minThinking} thinking.`, "error");
+			return;
+		}
 		pi.setThinkingLevel(requestedLevel);
 		ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
 		return;
 	}
 
+	const pickerLevels =
+		minThinking !== undefined
+			? availableLevels.filter((level) => thinkingLevelAtLeast(level, minThinking))
+			: availableLevels;
+
 	if (!ctx.hasUI) {
-		ctx.ui.notify(`Available thinking levels: ${availableLevels.join(", ")}. Current: ${currentLevel}.`, "info");
+		ctx.ui.notify(`Available thinking levels: ${pickerLevels.join(", ")}. Current: ${currentLevel}.`, "info");
 		return;
 	}
 
-	const options = availableLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
+	const options = pickerLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
 	const selected = await ctx.ui.select("Pick thinking level", options);
 	const selectedLevel = selected ? parseThinkingLevelOption(selected) : undefined;
 	if (!selectedLevel) {
@@ -57,12 +95,12 @@ async function handleThinkingLevelCommand(pi: ExtensionAPI, args: string, ctx: E
 	ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
 }
 
-export function registerEffortCommand(pi: ExtensionAPI): void {
+export function registerEffortCommand(pi: ExtensionAPI, runtime?: TlhPrimaryAgentRuntime): void {
 	for (const commandName of ["effort", "thinking"] as const) {
 		pi.registerCommand(commandName, {
 			description: "Pick the model thinking level",
-			getArgumentCompletions: getThinkingLevelCompletions,
-			handler: (args, ctx) => handleThinkingLevelCommand(pi, args, ctx),
+			getArgumentCompletions: (prefix) => getThinkingLevelCompletions(prefix, runtime),
+			handler: (args, ctx) => handleThinkingLevelCommand(pi, args, ctx, runtime),
 		});
 	}
 }

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -23,6 +23,7 @@ import { GNOSIS_PROMPT, PRIMARY_AGENT_CYCLE_SHORTCUT, TLH_NAME, TLH_PACKAGE_NAME
 import { buildPrimaryExperimentalPrompt } from "./experimental.js";
 import { shouldAppendGnosisPrompt } from "./gnosis.js";
 import { applyProviderAwareSubagentModels, selectProviderAwareAgentDefaults } from "./model-defaults.js";
+import { isThinkingLevel, thinkingLevelAtLeast } from "./thinking.js";
 import {
 	buildChildSubagentSystemPrompt,
 	buildTlhSystemPrompt,
@@ -377,8 +378,19 @@ function createTlhPrimaryAgentRuntime(
 		return model;
 	}
 
-	function applyPrimaryThinking(thinking: AgentPrompt["thinking"]): void {
-		if (!thinking || pi.getThinkingLevel() === thinking) {
+	function currentThinkingSatisfiesPrimaryFloor(primary: AgentPrompt, currentThinking: string): boolean {
+		return primary.lockThinking !== true
+			&& primary.minThinking !== undefined
+			&& isThinkingLevel(currentThinking)
+			&& thinkingLevelAtLeast(currentThinking, primary.minThinking);
+	}
+
+	function applyPrimaryThinking(primary: AgentPrompt, thinking: AgentPrompt["thinking"]): void {
+		if (!thinking) {
+			return;
+		}
+		const currentThinking = pi.getThinkingLevel();
+		if (currentThinking === thinking || currentThinkingSatisfiesPrimaryFloor(primary, currentThinking)) {
 			return;
 		}
 		pi.setThinkingLevel(thinking);
@@ -407,7 +419,7 @@ function createTlhPrimaryAgentRuntime(
 		const currentProviderDefaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
 		const activePrimaryModel = shouldApplyModel ? await applyPrimaryModel(ctx, primary, primaryDefaults.model) : undefined;
 		if (shouldApplyThinking) {
-			applyPrimaryThinking(activePrimaryModel ? primaryDefaults.thinking : currentProviderDefaults.thinking);
+			applyPrimaryThinking(primary, activePrimaryModel ? primaryDefaults.thinking : currentProviderDefaults.thinking);
 		}
 	}
 

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -50,6 +50,7 @@ type TlhPrimaryAgentRuntimeOptions = {
 export type TlhPrimaryAgentRuntime = {
 	applySessionStart(ctx: ExtensionContext): Promise<void>;
 	currentPrimaryAgentLabel(): string;
+	activePrimaryAgentPrompt(): AgentPrompt | undefined;
 };
 
 function getTlhGlobalSettings(cwd: string): TlhSettings {
@@ -75,6 +76,10 @@ function resolvePrimaryAutoApplySetting(
 		return configured;
 	}
 	return primary[key] === true;
+}
+
+function shouldForceApplyForLock(primary: AgentPrompt): boolean {
+	return primary.lockThinking === true;
 }
 
 function parseTlhSettingsContent(content: string | undefined): Record<string, unknown> {
@@ -395,8 +400,9 @@ function createTlhPrimaryAgentRuntime(
 		applyPrimaryTools(ctx, primary);
 
 		const primaryConfig = getTlhPrimaryAgentConfig(ctx.cwd);
-		const shouldApplyModel = resolvePrimaryAutoApplySetting(primaryConfig, primary, "applyModel");
-		const shouldApplyThinking = resolvePrimaryAutoApplySetting(primaryConfig, primary, "applyThinking");
+		const forceApply = shouldForceApplyForLock(primary);
+		const shouldApplyModel = forceApply || resolvePrimaryAutoApplySetting(primaryConfig, primary, "applyModel");
+		const shouldApplyThinking = forceApply || resolvePrimaryAutoApplySetting(primaryConfig, primary, "applyThinking");
 		const primaryDefaults = selectProviderAwareAgentDefaults(primary, ctx.modelRegistry.getAvailable(), ctx.model?.provider);
 		const currentProviderDefaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
 		const activePrimaryModel = shouldApplyModel ? await applyPrimaryModel(ctx, primary, primaryDefaults.model) : undefined;
@@ -592,7 +598,7 @@ function createTlhPrimaryAgentRuntime(
 		});
 	}
 
-	return { applySessionStart, currentPrimaryAgentLabel, registerCommands, registerLifecycleHooks };
+	return { applySessionStart, currentPrimaryAgentLabel, activePrimaryAgentPrompt: activePrimaryAgent, registerCommands, registerLifecycleHooks };
 }
 
 export function registerTlhPrimaryAgentRuntime(

--- a/extensions/the-last-harness/prompts.ts
+++ b/extensions/the-last-harness/prompts.ts
@@ -72,6 +72,8 @@ function parseAgentPrompt(filePath: string): AgentPrompt | undefined {
 		preferCurrentOpenaiModel: parseBooleanValue(frontmatter.preferCurrentOpenaiModel),
 		applyModel: parseBooleanValue(frontmatter.applyModel),
 		applyThinking: parseBooleanValue(frontmatter.applyThinking),
+		lockThinking: parseBooleanValue(frontmatter.lockThinking),
+		minThinking: parseThinkingLevelValue(frontmatter.minThinking),
 		tools: splitCommaList(frontmatter.tools),
 		systemPrompt: body,
 		filePath,

--- a/extensions/the-last-harness/thinking.ts
+++ b/extensions/the-last-harness/thinking.ts
@@ -33,3 +33,7 @@ export function formatThinkingLevelOption(level: ThinkingLevel, currentLevel: Th
 export function parseThinkingLevelOption(option: string): ThinkingLevel | undefined {
 	return THINKING_LEVELS.find((level) => option.includes(` ${level} —`));
 }
+
+export function thinkingLevelAtLeast(level: ThinkingLevel, floor: ThinkingLevel): boolean {
+	return THINKING_LEVELS.indexOf(level) >= THINKING_LEVELS.indexOf(floor);
+}

--- a/extensions/the-last-harness/types.ts
+++ b/extensions/the-last-harness/types.ts
@@ -199,6 +199,8 @@ export type AgentPrompt = {
 	preferCurrentOpenaiModel?: boolean;
 	applyModel?: boolean;
 	applyThinking?: boolean;
+	lockThinking?: boolean;
+	minThinking?: ThinkingLevel;
 	tools: string[];
 	systemPrompt: string;
 	filePath: string;

--- a/tests/the-last-harness-effort.test.mjs
+++ b/tests/the-last-harness-effort.test.mjs
@@ -1,0 +1,401 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { registerEffortCommand } = await jiti.import("../extensions/the-last-harness/effort.ts");
+
+// ---------------------------------------------------------------------------
+// Minimal harness and helpers
+// ---------------------------------------------------------------------------
+
+function createPiHarness() {
+	const commands = new Map();
+	return {
+		commands,
+		thinkingLevel: "medium",
+		registerCommand(name, options) {
+			commands.set(name, options);
+		},
+		getThinkingLevel() {
+			return this.thinkingLevel;
+		},
+		setThinkingLevel(level) {
+			this.thinkingLevel = level;
+		},
+	};
+}
+
+function createFakeRuntime(agentPrompt) {
+	return {
+		activePrimaryAgentPrompt() {
+			return agentPrompt;
+		},
+	};
+}
+
+/**
+ * Creates a minimal ctx for the effort handler.
+ * @param {object} opts
+ * @param {string|undefined} opts.provider  model provider (e.g. "anthropic", "openai")
+ * @param {object|undefined} opts.model     full model object — if given, overrides provider
+ * @param {boolean}          opts.hasUI     whether the ctx has interactive UI (default: false)
+ */
+function createCtx({ provider, model, hasUI = false } = {}) {
+	const notifications = [];
+	const resolvedModel = model !== undefined ? model : provider ? { provider, id: "test-model" } : undefined;
+	return {
+		notifications,
+		ctx: {
+			model: resolvedModel,
+			hasUI,
+			ui: {
+				notify(message, type = "info") {
+					notifications.push({ message, type });
+				},
+				async select(_prompt, _options) {
+					return null;
+				},
+			},
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Agent-prompt factories matching actual frontmatter (T1)
+// ---------------------------------------------------------------------------
+
+function rushPrimary() {
+	return {
+		name: "rush",
+		description: "Rush primary",
+		model: "anthropic/claude-opus-4-7",
+		tlhOpenaiModels: ["openai-codex/gpt-5.5", "openai/gpt-5.5"],
+		thinking: "low",
+		tlhOpenaiThinking: "off",
+		preferCurrentOpenaiModel: true,
+		lockThinking: true,
+		tools: [],
+		systemPrompt: "rush",
+		filePath: "agents/primary/rush.md",
+	};
+}
+
+function productPrimary() {
+	return {
+		name: "product",
+		description: "Product primary",
+		model: "anthropic/claude-opus-4-6",
+		thinking: "high",
+		lockThinking: true,
+		tools: [],
+		systemPrompt: "product",
+		filePath: "agents/primary/product.md",
+	};
+}
+
+function bugHunterPrimary() {
+	return {
+		name: "bug-hunter",
+		description: "Bug-hunter primary",
+		model: "anthropic/claude-opus-4-7",
+		thinking: "high",
+		lockThinking: true,
+		tools: [],
+		systemPrompt: "bug-hunter",
+		filePath: "agents/primary/bug-hunter.md",
+	};
+}
+
+function architectPrimary() {
+	return {
+		name: "architect",
+		description: "Architect primary",
+		model: "anthropic/claude-opus-4-7",
+		thinking: "high",
+		minThinking: "medium",
+		tools: [],
+		systemPrompt: "architect",
+		filePath: "agents/primary/architect.md",
+	};
+}
+
+/** A reasoning model whose thinkingLevelMap supports xhigh. */
+function reasoningModel(provider = "anthropic") {
+	return { provider, id: "claude-opus-4-7", reasoning: true, thinkingLevelMap: { xhigh: "max" } };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Locked primaries — rush, product, bug-hunter
+// ---------------------------------------------------------------------------
+
+test("getArgumentCompletions returns empty list for locked primary: rush", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(completions, []);
+});
+
+test("getArgumentCompletions returns empty list for locked primary: product", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(productPrimary()));
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(completions, []);
+});
+
+test("getArgumentCompletions returns empty list for locked primary: bug-hunter", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(bugHunterPrimary()));
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(completions, []);
+});
+
+test("getArgumentCompletions returns empty list for locked primary regardless of prefix", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const command = pi.commands.get("effort");
+	assert.deepEqual(command.getArgumentCompletions("m"), []);
+	assert.deepEqual(command.getArgumentCompletions("hi"), []);
+});
+
+test("handler errors with exact message for rush on anthropic (thinking: low)", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "anthropic" });
+	await pi.commands.get("effort").handler("low", ctx);
+	assert.equal(notifications.length, 1);
+	assert.deepEqual(notifications[0], {
+		message: 'Thinking is locked at "low" for the rush primary agent.',
+		type: "error",
+	});
+});
+
+test("handler errors with 'off' (not 'low') for rush on OpenAI", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "openai" });
+	await pi.commands.get("effort").handler("medium", ctx);
+	assert.equal(notifications.length, 1);
+	assert.deepEqual(notifications[0], {
+		message: 'Thinking is locked at "off" for the rush primary agent.',
+		type: "error",
+	});
+});
+
+test("handler errors with 'off' for rush on openai-codex provider", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "openai-codex" });
+	await pi.commands.get("effort").handler("high", ctx);
+	assert.deepEqual(notifications[0], {
+		message: 'Thinking is locked at "off" for the rush primary agent.',
+		type: "error",
+	});
+});
+
+test("handler errors with exact message for product (thinking: high)", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(productPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "anthropic" });
+	await pi.commands.get("effort").handler("low", ctx);
+	assert.equal(notifications.length, 1);
+	assert.deepEqual(notifications[0], {
+		message: 'Thinking is locked at "high" for the product primary agent.',
+		type: "error",
+	});
+});
+
+test("handler errors with exact message for bug-hunter (thinking: high)", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(bugHunterPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "anthropic" });
+	await pi.commands.get("effort").handler("off", ctx);
+	assert.equal(notifications.length, 1);
+	assert.deepEqual(notifications[0], {
+		message: 'Thinking is locked at "high" for the bug-hunter primary agent.',
+		type: "error",
+	});
+});
+
+test("locked handler also fires with no args (handler called without a level)", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(rushPrimary()));
+	const { notifications, ctx } = createCtx({ provider: "anthropic" });
+	await pi.commands.get("effort").handler("", ctx);
+	assert.equal(notifications.length, 1);
+	assert.equal(notifications[0].type, "error");
+	assert.match(notifications[0].message, /Thinking is locked at "low" for the rush primary agent\./);
+});
+
+// ---------------------------------------------------------------------------
+// 2. minThinking floor — architect (minThinking: medium)
+// ---------------------------------------------------------------------------
+
+test("getArgumentCompletions for architect returns only medium/high/xhigh when no prefix", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(
+		completions.map((c) => c.value),
+		["medium", "high", "xhigh"],
+	);
+});
+
+test("getArgumentCompletions for architect filters correctly with prefix 'h'", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const completions = pi.commands.get("effort").getArgumentCompletions("h");
+	assert.deepEqual(
+		completions.map((c) => c.value),
+		["high"],
+	);
+});
+
+test("getArgumentCompletions for architect returns null for prefix below floor (not null vs empty)", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	// "l" matches "low" but low is below the floor — nothing matches
+	const completions = pi.commands.get("effort").getArgumentCompletions("l");
+	assert.equal(completions, null);
+});
+
+test("architect handler accepts medium", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("medium", ctx);
+	assert.equal(pi.thinkingLevel, "medium");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("architect handler accepts high", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("high", ctx);
+	assert.equal(pi.thinkingLevel, "high");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("architect handler accepts xhigh when model supports it", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("xhigh", ctx);
+	assert.equal(pi.thinkingLevel, "xhigh");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("architect handler rejects off with exact error message", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("off", ctx);
+	assert.deepEqual(notifications.at(-1), {
+		message: "architect requires at least medium thinking.",
+		type: "error",
+	});
+});
+
+test("architect handler rejects minimal with exact error message", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("minimal", ctx);
+	assert.deepEqual(notifications.at(-1), {
+		message: "architect requires at least medium thinking.",
+		type: "error",
+	});
+});
+
+test("architect handler rejects low with exact error message", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("low", ctx);
+	assert.deepEqual(notifications.at(-1), {
+		message: "architect requires at least medium thinking.",
+		type: "error",
+	});
+});
+
+test("architect handler does not change thinking level when rejecting a below-floor selection", async () => {
+	const pi = createPiHarness();
+	pi.thinkingLevel = "high";
+	registerEffortCommand(pi, createFakeRuntime(architectPrimary()));
+	const { ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("off", ctx);
+	// Level must be unchanged
+	assert.equal(pi.thinkingLevel, "high");
+});
+
+// ---------------------------------------------------------------------------
+// 3. Disabled primary (no active primary) — passthrough regression guard
+// ---------------------------------------------------------------------------
+
+test("getArgumentCompletions with no primary returns all thinking levels", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(undefined));
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(
+		completions.map((c) => c.value),
+		["off", "minimal", "low", "medium", "high", "xhigh"],
+	);
+});
+
+test("getArgumentCompletions with no primary filters by prefix normally", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(undefined));
+	const completions = pi.commands.get("effort").getArgumentCompletions("m");
+	// THINKING_LEVELS order: off, minimal, low, medium, high, xhigh — so minimal precedes medium
+	assert.deepEqual(
+		completions.map((c) => c.value),
+		["minimal", "medium"],
+	);
+});
+
+test("disabled primary handler accepts off", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(undefined));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("off", ctx);
+	assert.equal(pi.thinkingLevel, "off");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("disabled primary handler accepts medium", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(undefined));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("medium", ctx);
+	assert.equal(pi.thinkingLevel, "medium");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("disabled primary handler accepts high", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi, createFakeRuntime(undefined));
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("high", ctx);
+	assert.equal(pi.thinkingLevel, "high");
+	assert.equal(notifications.at(-1)?.type, "info");
+});
+
+test("no runtime passed behaves identically to disabled primary (full completions)", () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi); // no runtime argument
+	const completions = pi.commands.get("effort").getArgumentCompletions("");
+	assert.deepEqual(
+		completions.map((c) => c.value),
+		["off", "minimal", "low", "medium", "high", "xhigh"],
+	);
+});
+
+test("no runtime passed handler accepts any valid level", async () => {
+	const pi = createPiHarness();
+	registerEffortCommand(pi); // no runtime argument
+	const { notifications, ctx } = createCtx({ model: reasoningModel() });
+	await pi.commands.get("effort").handler("low", ctx);
+	assert.equal(pi.thinkingLevel, "low");
+	assert.equal(notifications.at(-1)?.type, "info");
+});

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -88,7 +88,12 @@ test("annotate-git-diff user-facing source copy uses the renamed command", () =>
 test("before_agent_start reapplies primary defaults without a one-shot model gate", () => {
 	const lifecycleHooks = sourceSection(primaryRuntimeSource, "function registerLifecycleHooks()", "\n\n\treturn { applySessionStart");
 	const beforeAgentStart = sourceSection(lifecycleHooks, 'pi.on("before_agent_start"', 'pi.on("tool_call"');
-	const applyPrimaryModel = sourceSection(primaryRuntimeSource, "async function applyPrimaryModel", "function applyPrimaryThinking");
+	const applyPrimaryModel = sourceSection(primaryRuntimeSource, "async function applyPrimaryModel", "function currentThinkingSatisfiesPrimaryFloor");
+	const currentThinkingSatisfiesPrimaryFloor = sourceSection(
+		primaryRuntimeSource,
+		"function currentThinkingSatisfiesPrimaryFloor",
+		"function applyPrimaryThinking",
+	);
 	const applyPrimaryThinking = sourceSection(primaryRuntimeSource, "function applyPrimaryThinking", "async function applyPrimaryDefaults");
 	const applyPrimaryDefaults = sourceSection(primaryRuntimeSource, "async function applyPrimaryDefaults", "async function applyPrimaryModeChange");
 
@@ -98,7 +103,10 @@ test("before_agent_start reapplies primary defaults without a one-shot model gat
 	assert.match(applyPrimaryDefaults, /resolvePrimaryAutoApplySetting\(primaryConfig, primary, "applyModel"\)/);
 	assert.match(applyPrimaryDefaults, /resolvePrimaryAutoApplySetting\(primaryConfig, primary, "applyThinking"\)/);
 	assert.match(applyPrimaryModel, /ctx\.model\?\.provider === model\.provider && ctx\.model\?\.id === model\.id/);
-	assert.match(applyPrimaryThinking, /pi\.getThinkingLevel\(\) === thinking/);
+	assert.match(currentThinkingSatisfiesPrimaryFloor, /thinkingLevelAtLeast\(currentThinking, primary\.minThinking\)/);
+	assert.match(applyPrimaryThinking, /const currentThinking = pi\.getThinkingLevel\(\);/);
+	assert.match(applyPrimaryThinking, /currentThinking === thinking/);
+	assert.match(applyPrimaryThinking, /currentThinkingSatisfiesPrimaryFloor\(primary, currentThinking\)/);
 	assert.match(promptsSource, /preferCurrentOpenaiModel: parseBooleanValue\(frontmatter\.preferCurrentOpenaiModel\)/);
 	assert.match(promptsSource, /applyModel: parseBooleanValue\(frontmatter\.applyModel\)/);
 	assert.match(promptsSource, /applyThinking: parseBooleanValue\(frontmatter\.applyThinking\)/);

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -239,7 +239,7 @@ test("extension runs primary session_start work before UI startup in one handler
 
 	assert.match(sessionStart, /await primaryAgentRuntime\.applySessionStart\(ctx\);[\s\S]*if \(!ctx\.hasUI\)/);
 	assert.match(primaryRuntimeSource, /async function applySessionStart\(ctx: ExtensionContext\): Promise<void>/);
-	assert.match(primaryRuntimeSource, /return \{ applySessionStart, currentPrimaryAgentLabel, registerCommands, registerLifecycleHooks \};/);
+	assert.match(primaryRuntimeSource, /return \{ applySessionStart, currentPrimaryAgentLabel, activePrimaryAgentPrompt: activePrimaryAgent, registerCommands, registerLifecycleHooks \};/);
 	assert.doesNotMatch(lifecycleHooks, /pi\.on\("session_start"/);
 });
 

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -102,6 +102,8 @@ test("before_agent_start reapplies primary defaults without a one-shot model gat
 	assert.match(promptsSource, /preferCurrentOpenaiModel: parseBooleanValue\(frontmatter\.preferCurrentOpenaiModel\)/);
 	assert.match(promptsSource, /applyModel: parseBooleanValue\(frontmatter\.applyModel\)/);
 	assert.match(promptsSource, /applyThinking: parseBooleanValue\(frontmatter\.applyThinking\)/);
+	assert.match(promptsSource, /lockThinking: parseBooleanValue\(frontmatter\.lockThinking\)/);
+	assert.match(promptsSource, /minThinking: parseThinkingLevelValue\(frontmatter\.minThinking\)/);
 });
 
 test("before_agent_start activates ticket runtime without disabled-ticket prompt branching", () => {
@@ -129,6 +131,24 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	assert.equal(architect.preferCurrentOpenaiModel, undefined);
 	assert.equal(rush.applyModel, true);
 	assert.equal(rush.applyThinking, true);
+	assert.equal(rush.lockThinking, true);
+	assert.equal(architect.applyModel, true);
+	assert.equal(architect.applyThinking, true);
+	assert.equal(architect.minThinking, "medium");
+	assert.equal(architect.lockThinking, undefined);
+
+	const product = primaryAgents.get("product");
+	assert.ok(product, "product primary prompt should load");
+	assert.equal(product.applyModel, true);
+	assert.equal(product.applyThinking, true);
+	assert.equal(product.lockThinking, true);
+
+	const bugHunter = primaryAgents.get("bug-hunter");
+	assert.ok(bugHunter, "bug-hunter primary prompt should load");
+	assert.equal(bugHunter.applyModel, true);
+	assert.equal(bugHunter.applyThinking, true);
+	assert.equal(bugHunter.lockThinking, true);
+
 	assert.match(rush.systemPrompt, /Do not delegate implementation to `developer`/);
 	assert.deepEqual(
 		loadSubagentMetadata().find((agent) => agent.name === "developer")?.tlhOpenaiModels,

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1324,11 +1324,12 @@ test("primary runtime respects explicit false settings over Rush-like metadata d
 	}
 });
 
-test("architect -> rush -> architect cycle restores architect's declared thinking", async (t) => {
+test("architect before_agent_start preserves medium floor selection but restores declared default after rush", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
 		model: "anthropic/claude-opus-4-7",
 		thinking: "high",
+		minThinking: "medium",
 		applyModel: true,
 		applyThinking: true,
 	});
@@ -1345,7 +1346,7 @@ test("architect -> rush -> architect cycle restores architect's declared thinkin
 	]);
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
-		const { pi, runtime } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
+		const { pi, runtime, beforeAgentStart } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
 		assert.ok(runtime, "runtime should register outside child sessions");
 
 		const makeCtx = (branch) => ({
@@ -1356,19 +1357,21 @@ test("architect -> rush -> architect cycle restores architect's declared thinkin
 			model: { provider: "anthropic", id: "claude-opus-4-7" },
 		});
 
-		// Step 1: start with architect (default, no branch override)
 		await runtime.applySessionStart(makeCtx([]));
-		assert.equal(pi.thinkingLevel, "high", "architect starts at high thinking");
+		assert.equal(pi.thinkingLevel, "high", "architect starts at its declared default");
 
-		// Step 2: switch to rush
-		await runtime.applySessionStart(makeCtx([
-			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } },
-		]));
-		assert.equal(pi.thinkingLevel, "low", "rush sets thinking to low");
+		pi.thinkingLevel = "medium";
+		await beforeAgentStart({ systemPrompt: "base prompt" }, makeCtx([]));
+		assert.equal(pi.thinkingLevel, "medium", "before_agent_start preserves a current level that satisfies architect's floor");
 
-		// Step 3: switch back to architect — declared thinking must be restored
-		await runtime.applySessionStart(makeCtx([]));
-		assert.equal(pi.thinkingLevel, "high", "architect's declared thinking is restored after rush cycle");
+		await beforeAgentStart(
+			{ systemPrompt: "base prompt" },
+			makeCtx([{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } }]),
+		);
+		assert.equal(pi.thinkingLevel, "low", "locked rush still forces low thinking");
+
+		await beforeAgentStart({ systemPrompt: "base prompt" }, makeCtx([]));
+		assert.equal(pi.thinkingLevel, "high", "architect restores its declared default after returning from rush");
 	});
 });
 

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1323,3 +1323,117 @@ test("primary runtime respects explicit false settings over Rush-like metadata d
 		cleanupTempDir(fixture);
 	}
 });
+
+test("architect -> rush -> architect cycle restores architect's declared thinking", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
+	const architectPrimary = createPrimaryPrompt("architect", {
+		model: "anthropic/claude-opus-4-7",
+		thinking: "high",
+		applyModel: true,
+		applyThinking: true,
+	});
+	const rushPrimary = createPrimaryPrompt("rush", {
+		model: "anthropic/claude-opus-4-7",
+		thinking: "low",
+		applyModel: true,
+		applyThinking: true,
+		lockThinking: true,
+	});
+	const primaryAgents = new Map([
+		["architect", architectPrimary],
+		["rush", rushPrimary],
+	]);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		const { pi, runtime } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
+		assert.ok(runtime, "runtime should register outside child sessions");
+
+		const makeCtx = (branch) => ({
+			cwd: fixture.cwd,
+			sessionManager: { getBranch: () => branch },
+			ui: { notify() {} },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
+			model: { provider: "anthropic", id: "claude-opus-4-7" },
+		});
+
+		// Step 1: start with architect (default, no branch override)
+		await runtime.applySessionStart(makeCtx([]));
+		assert.equal(pi.thinkingLevel, "high", "architect starts at high thinking");
+
+		// Step 2: switch to rush
+		await runtime.applySessionStart(makeCtx([
+			{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } },
+		]));
+		assert.equal(pi.thinkingLevel, "low", "rush sets thinking to low");
+
+		// Step 3: switch back to architect — declared thinking must be restored
+		await runtime.applySessionStart(makeCtx([]));
+		assert.equal(pi.thinkingLevel, "high", "architect's declared thinking is restored after rush cycle");
+	});
+});
+
+test("locked primary (rush) overrides global applyThinking=false and applyModel=false", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
+	const rushPrimary = createPrimaryPrompt("rush", {
+		model: "anthropic/claude-opus-4-7",
+		thinking: "low",
+		applyModel: true,
+		applyThinking: true,
+		lockThinking: true,
+	});
+	const primaryAgents = new Map([["rush", rushPrimary]]);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		// Global opt-outs that the lock should override
+		writePrimaryConfig(fixture.agent, { applyModel: false, applyThinking: false });
+
+		const { pi, runtime } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
+		assert.ok(runtime, "runtime should register outside child sessions");
+
+		// Use a different initial model so applyPrimaryModel actually calls setModel
+		await runtime.applySessionStart({
+			cwd: fixture.cwd,
+			sessionManager: { getBranch: () => [
+				{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } },
+			]},
+			ui: { notify() {} },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
+			model: { provider: "anthropic", id: "claude-opus-4-6" },
+		});
+
+		// lockThinking: true forces both model and thinking regardless of global opt-outs
+		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-7" });
+		assert.equal(pi.thinkingLevel, "low");
+	});
+});
+
+test("non-locked primary (architect) honors global applyThinking=false override", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
+	const architectPrimary = createPrimaryPrompt("architect", {
+		model: "anthropic/claude-opus-4-7",
+		thinking: "high",
+		applyModel: true,
+		applyThinking: true,
+		// no lockThinking
+	});
+	const primaryAgents = new Map([["architect", architectPrimary]]);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		// User opts out of thinking auto-apply for architect
+		writePrimaryConfig(fixture.agent, { applyThinking: false });
+
+		const { pi, runtime } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
+		assert.ok(runtime, "runtime should register outside child sessions");
+
+		await runtime.applySessionStart({
+			cwd: fixture.cwd,
+			sessionManager: { getBranch: () => [] },
+			ui: { notify() {} },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
+			model: { provider: "anthropic", id: "claude-opus-4-7" },
+		});
+
+		// Global applyThinking: false is respected for non-locked primary
+		assert.equal(pi.thinkingLevel, "normal");
+	});
+});


### PR DESCRIPTION
## Problem

With architect at `high` thinking, switching to Rush dropped to `low` (correct), but switching back to architect left thinking stuck at `low` (wrong — architect's declared `high` should be restored).

Root cause: `applyPrimaryDefaults()` only re-applied thinking/model when the active primary's frontmatter had `applyThinking: true` / `applyModel: true`. Only Rush opted in, so architect/product/bug-hunter never re-asserted their declared defaults on switch.

## Approved policy

- **Rush, product, bug-hunter**: thinking is **fixed**. `/effort` refuses any change with `Thinking is locked at "<level>" for the <name> primary agent.` (provider-aware: Rush on OpenAI reports `off`, on Anthropic reports `low`).
- **Architect**: thinking is user-modifiable but **medium or higher only**. `/effort off|minimal|low` rejected with `architect requires at least medium thinking.`
- The lock wins over the user-level `settings.tlh.primaryAgent.applyThinking` opt-out. The architect floor (non-locked) still honors that opt-out.
- Mechanism is declarative in agent frontmatter (`lockThinking`, `minThinking`), not hardcoded in runtime.

## Commits

1. `f03c04d` Declare `lockThinking` and `minThinking` in primary-agent frontmatter; add applyModel/applyThinking to architect/product/bug-hunter.
2. `fac2ff2` Assert declared model/thinking on every primary switch; lock overrides the global opt-out. Fixes the reported bug.
3. `e854e05` Constrain `/effort` by active primary: block under locked primaries; enforce architect medium floor; filter completions and interactive picker accordingly.
4. `9fcb263` README, docs/commands.md, and CHANGELOG entries.

## Validation

`npm run validate` → 576 tests pass (30 new). ESLint clean. Installer smoke + `npm pack --dry-run` succeed.

New tests cover:

- The original bug: architect → rush → architect cycle restores architect's declared thinking.
- Lock overrides global `applyThinking: false` / `applyModel: false` opt-outs.
- Non-locked architect still honors a user-level `applyThinking: false` override.
- `/effort` under each locked primary: empty completions and exact error wording (including the OpenAI `off` variant for Rush).
- `/effort` under architect: filtered completions, acceptance of medium/high/xhigh, rejection of off/minimal/low with exact error wording.
- `/effort` under disabled primary: regression guard for unchanged behavior.

## User-visible behavior change

Any existing session currently running architect below medium will be bumped to architect's declared `high` on the next primary apply (session start or `Shift+Tab`). Called out in the CHANGELOG `Changed` entry.

## Review

Final `code-reviewer` pass: 0 Must Fix, 0 Should Fix. Three Optional items reviewed and rejected with rationale (CHANGELOG caveat noise, cosmetic non-null assertion refactor, inconsistent `Readonly<>` wrapping).

🤖 Generated with [The Last Harness](https://github.com/diegopetrucci/the-last-harness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rush, Product, and Bug-Hunter primaries run at locked thinking levels; `/thinking`/`/effort` are blocked and return explicit errors while they are active
  * Architect primary enforces a minimum medium thinking level; attempts to lower it are rejected and sessions below medium are bumped to architect’s default on next primary apply
  * Thinking-level restoration improved when switching primaries so architect returns to its declared level

* **Documentation**
  * Updated `/thinking` and `/effort` docs to explain locking, minimum-floor rules, and command behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->