### PR TITLE
Document TLH command and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can add your own skills, prompts, extensions, and packages to TLH.
 User-level:
 - `~/.the-last-harness/agent/skills/`
 - `~/.the-last-harness/agent/prompts/`
-- `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo‘)
+- `~/.the-last-harness/agent/extensions/` (or via `tlh install github-user/repo`)
 
 Repo settings:
 - `.pi/skills/`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,6 +48,7 @@ These commands are registered by the TLH extension bundled with this profile.
 |---------|-------------|
 | `/thinking` | Pick the model thinking level |
 | `/effort` | Supported alias for `/thinking` |
+| `/experimental` | List or change TLH experimental features |
 | `/review` | Open an interactive code-review mode picker (requires the architect primary agent) |
 | `/switch-primary-agent` | Show or switch the active TLH primary agent (`architect`, `rush`, `product`, `bug-hunter`, `disabled`) |
 | `/tlh-changelog` | Show TLH release notes from the packaged `CHANGELOG.md` |

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,6 +59,8 @@ You can just run `tlh update`.
 
 This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
 
+If TLH starts with the notice ``TLH extension updates are available. Run `tlh update --extensions` to update them.``, that notice refers to isolated extension/package updates only. `tlh update --extensions` runs the upstream package refresh against the TLH profile without changing installer-managed checkout state, wrapper files, or update-track metadata. Installer-track and installer-owned options such as `--track`, `--ref`, `--repo`, `--package-source`, `--force`, `--no-settings`, and `--no-wrapper` require plain `tlh update` instead.
+
 At launch, TLH also shows that `Warning: running TLH from {name} track` header warning above `Context:` when your install metadata says you are not on the official latest stable path, or when it cannot verify that metadata. The warning is informational only; it does not change your isolated install or auto-update anything.
 
 - If you installed from a pinned release tag, a non-stable git ref, or another custom update track while still using the default TLH repo/package source, return to the official latest stable release track with:
@@ -87,7 +89,7 @@ Release builds with TelemetryDeck identifiers configured also send at most one p
 
 To opt out persistently, set `"tlh": { "telemetry": { "enabled": false } }` in `~/.the-last-harness/agent/settings.json`. This opt-out is user-owned and survives `tlh update` and installer reruns. Per-run opt-outs are `PI_OFFLINE=1`, `TLH_SKIP_TELEMETRY=1`, `TLH_TELEMETRY_DISABLED=1`, or `PI_TELEMETRY=0`. To reset only the pseudonymous install ID, remove `~/.the-last-harness/agent/tlh/telemetry-state.json`.
 
-To update bundled default extension packages too, run `tlh update`; it refreshes pinned critical defaults safely before updating other enabled defaults.
+Plain `tlh update` also refreshes bundled default extension packages; it refreshes pinned critical defaults safely before updating other enabled defaults.
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary
- fix a stray README quote in the `tlh install github-user/repo` example
- add visible `/experimental` to the TLH slash command reference
- document `tlh update --extensions` as the isolated extension/package-only update path

## Validation
- `git diff --check -- README.md docs/commands.md docs/install.md`
- code-reviewer checkpoint: no findings

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/docs-tlh-update-commands/install.sh | bash -s -- --ref docs-tlh-update-commands --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed formatting in README documentation for installation path instructions
  * Added new `/experimental` command to TLH commands documentation, enabling users to list and manage experimental features
  * Enhanced clarity in update instructions by distinguishing between isolated extension-only updates and installer-level option updates, clarifying when the plain `tlh update` command is required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->