### PR TITLE
Add MCP support to Architect

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -4,7 +4,7 @@ description: Clarifies requirements, manages implementation tasks, and orchestra
 model: anthropic/claude-opus-4-7
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
-tools: read, write, edit, grep, find, ls, bash, subagent, intercom
+tools: read, write, edit, grep, find, ls, bash, subagent, intercom, mcp
 systemPromptMode: append
 inheritProjectContext: true
 inheritSkills: false


### PR DESCRIPTION
## Summary

Adds the `mcp` tool to the architect primary agent's allowed tools list, enabling architect sessions to interact with MCP (Model Context Protocol) servers directly.

## Change

`agents/primary/architect.md`: append `mcp` to the `tools:` frontmatter.

```diff
- tools: read, write, edit, grep, find, ls, bash, subagent, intercom
+ tools: read, write, edit, grep, find, ls, bash, subagent, intercom, mcp
```

## Motivation

The architect previously had no way to query or call MCP-backed tools (e.g. Atlassian, other connected MCP servers) during clarify/plan phases. Discovery had to be delegated through subagents even for simple read-only MCP lookups, adding latency and context overhead for work that's a natural fit for the architect itself.

## Scope & safety

- One-line frontmatter change; no logic, no other agents touched.
- The `mcp` tool is read/gateway by nature — actual side effects still depend on which MCP server/tool is invoked.
- Other primaries (rush, product, bug-hunter) are unchanged.
- No changes to subagent allowlists or delegation rules.

## Validation

- `npm run validate` — 591/591 tests pass, eslint clean, settings merge dry-run clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Architect agent now includes an additional tool to expand its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->