### PR TITLE
Ship pause-handling pin bump

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -19,6 +19,7 @@ Your job is to clarify the requested outcome, design the smallest correct approa
 ## Core rules
 
 - Do not directly edit source files. Implementation belongs to `developer`.
+- A paused or interrupted developer/subagent dispatch is a recoverable paused run, not authorization to edit directly. Resume by run id/index when appropriate, re-dispatch an approved ticket if replacing the paused run, ask the user when the next step is ambiguous, or stop. Do not treat `doctor` showing no active run as proof the pause was stale or failed.
 - Use direct codebase inspection for discovery; do not ask the user questions the repository can answer.
 - Prefer simple, correct, reviewable changes. Avoid speculative abstractions and YAGNI violations.
 - Treat only the exact word `approved` as approval when you ask for signoff.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -82,7 +82,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-5",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-6",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -22,6 +22,10 @@ const contracts = [
 			heading("Planning and task tracking"),
 			heading("Implementation loop"),
 			bodyPattern("delegates implementation to developer", /do not directly edit source files/i),
+			bodyPattern(
+				"paused dispatch stays recoverable and non-authorizing",
+				/paused or interrupted developer\/subagent dispatch.*recoverable paused run.*not authorization to edit directly.*resume by run id\/index.*re-dispatch an approved ticket.*ask the user.*or stop.*doctor.*no active run.*stale or failed/i,
+			),
 			orderedTerms("exact approved signoff gate", ["exact word", "approved"]),
 			orderedTerms("developer waits for approved tickets", ["do not launch", "developer", "until", "approves", "tickets"]),
 			includesAllTerms("high-risk oracle gating", ["high-stakes", "broad blast radius", "explicitly agrees"]),

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -939,7 +939,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-5");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-6");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary
- add architect guidance that a paused or interrupted developer/subagent dispatch remains recoverable and does not authorize direct edits
- pin the bundled `pi-subagents` default extension to tag `tlh-v0.26.0-6` at `fecb1a830bd2d170099b5113426728792a47be8d`
- update prompt-contract and default-extension coverage for the paused-dispatch guidance and new pin

## Upstream
- ships the reviewed pause-message fix from pi-subagents PR #5

## Validation
- `npm run validate`
