### PR TITLE
Merge TLH header Context and toggle hint into one line

### DIFF
--- a/extensions/the-last-harness/header.ts
+++ b/extensions/the-last-harness/header.ts
@@ -98,11 +98,13 @@ export function createTlhHeader(
 			: color.dim(`${continuationIndent}${line}`));
 	};
 
-	const collapsedHintLine = (width: number): string => truncateToWidth(
-		color.dim(`${TLH_HEADER_TOGGLE_SHORTCUT_LABEL} to show skills, prompts, extensions, themes`),
-		width,
-		color.dim("..."),
-	);
+	const collapsedContextHintLines = (width: number): string[] => {
+		const hint = `Press ${TLH_HEADER_TOGGLE_SHORTCUT_LABEL} to show loaded skills, prompts, and extensions`;
+		const plainText = resources.context.length === 0
+			? hint
+			: `Context: ${resources.context.join(", ")}. ${hint}`;
+		return wrapTextWithAnsi(plainText, width).map((line) => color.dim(line));
+	};
 
 	const headerDetails = (width: number): string[] => [
 		...installWarningLine(width),
@@ -110,7 +112,7 @@ export function createTlhHeader(
 	];
 
 	const renderCollapsed = (width: number) => {
-		const lines = [logo, "", ...headerDetails(width), collapsedHintLine(width), ...startupTipLine(width)];
+		const lines = [logo, "", ...installWarningLine(width), ...collapsedContextHintLines(width), ...startupTipLine(width)];
 		return lines;
 	};
 

--- a/tests/the-last-harness-extension-startup-warning.test.mjs
+++ b/tests/the-last-harness-extension-startup-warning.test.mjs
@@ -240,7 +240,7 @@ test("Ctrl+Shift+E toggles the TLH header without changing the default collapsed
 
 	assert.ok(header);
 	assert.ok(headerLines);
-	assert.ok(headerLines.includes("Ctrl+Shift+E to show skills, prompts, extensions, themes"));
+	assert.ok(headerLines.includes("Press Ctrl+Shift+E to show loaded skills, prompts, and extensions"));
 
 	const shortcut = shortcuts.get(TLH_HEADER_TOGGLE_SHORTCUT);
 	assert.ok(shortcut, "expected TLH header toggle shortcut to be registered");
@@ -250,12 +250,12 @@ test("Ctrl+Shift+E toggles the TLH header without changing the default collapsed
 
 	await shortcut.handler(shortcutCtx);
 	const expandedLines = header.render(200);
-	assert.equal(expandedLines.includes("Ctrl+Shift+E to show skills, prompts, extensions, themes"), false);
+	assert.equal(expandedLines.includes("Press Ctrl+Shift+E to show loaded skills, prompts, and extensions"), false);
 	assert.ok(expandedLines.includes("Warning: running TLH from v0.10.0 track"));
 	assert.equal(requestRenderCalls(), 1);
 
 	await shortcut.handler(shortcutCtx);
-	assert.ok(header.render(200).includes("Ctrl+Shift+E to show skills, prompts, extensions, themes"));
+	assert.ok(header.render(200).includes("Press Ctrl+Shift+E to show loaded skills, prompts, and extensions"));
 	assert.equal(requestRenderCalls(), 2);
 });
 

--- a/tests/the-last-harness-header-warning.test.mjs
+++ b/tests/the-last-harness-header-warning.test.mjs
@@ -48,8 +48,7 @@ test("collapsed header renders the install-track warning above Context and inclu
 		"<bold><accent>tlh</accent></bold>",
 		"",
 		"<warning>Warning</warning><dim>: running TLH from main track</dim>",
-		"<dim>Context: AGENTS.md</dim>",
-		"<dim>Ctrl+Shift+E to show skills, prompts, extensions, themes</dim>",
+		"<dim>Context: AGENTS.md. Press Ctrl+Shift+E to show loaded skills, prompts, and extensions</dim>",
 	]);
 });
 
@@ -61,8 +60,7 @@ test("collapsed header renders the startup tip as the final header line with a l
 	assert.deepEqual(header.render(200), [
 		"<bold><accent>tlh</accent></bold>",
 		"",
-		"<dim>Context: AGENTS.md</dim>",
-		"<dim>Ctrl+Shift+E to show skills, prompts, extensions, themes</dim>",
+		"<dim>Context: AGENTS.md. Press Ctrl+Shift+E to show loaded skills, prompts, and extensions</dim>",
 		"<muted>Tip</muted><dim>: Use /switch-primary-agent to pick architect, rush, product, bug-hunter, or disabled for this session.</dim>",
 	]);
 });
@@ -118,7 +116,11 @@ test("startup tips wrap without truncation and stay last in collapsed and expand
 
 	assert.deepEqual(collapsedTipBlock, expectedTipBlock);
 	assert.deepEqual(expandedTipBlock, expectedTipBlock);
-	assert.match(collapsedLines.at(-expectedTipBlock.length - 1) ?? "", /^Ctrl\+Shift\+E/u);
+	const collapsedNonTipLines = collapsedLines.slice(0, -expectedTipBlock.length);
+	assert.ok(
+		collapsedNonTipLines.some((line) => /^Press Ctrl\+Shift\+E/u.test(line)),
+		"collapsed header should contain the standalone Ctrl+Shift+E hint",
+	);
 	assert.equal(expandedLines.at(-expectedTipBlock.length - 1), "");
 	assert.equal(collapsedTipBlock.some((line) => line.includes("...")), false);
 	assert.equal(expandedTipBlock.some((line) => line.includes("...")), false);


### PR DESCRIPTION
## Summary

Combine the collapsed-mode `Context:` line and the `Ctrl+Shift+E` discoverability hint into a single wrapped line in the TLH header.

Before:
```
Warning: running TLH from main track
Context: CLAUDE.md
Ctrl+Shift+E to show skills, prompts, extensions, themes
Tip: …
```

After:
```
Warning: running TLH from main track
Context: CLAUDE.md. Press Ctrl+Shift+E to show loaded skills, prompts, and extensions
Tip: …
```

## Behavior

- **Collapsed + context present** → one merged wrapped line (shown above).
- **Collapsed + no context** → standalone `Press Ctrl+Shift+E to show loaded skills, prompts, and extensions`, wrapped.
- **Expanded** → bare `Context: <files>` only; no `Press Ctrl+Shift+E …` suffix and no standalone hint.
- **"themes" dropped from the hint copy.** The `[Themes]` section is still rendered when the header is expanded.
- **Long lines wrap** via `wrapTextWithAnsi` instead of truncating with an ellipsis, matching the existing Tip line behavior.

## Implementation notes

- `extensions/the-last-harness/header.ts`: replaced `collapsedHintLine` (single truncated string) with `collapsedContextHintLines` (`string[]` via `wrapTextWithAnsi`). `renderCollapsed` now emits `installWarningLine` + `collapsedContextHintLines` directly; `headerDetails` and the expanded renderer are unchanged.
- `tests/the-last-harness-header-warning.test.mjs`: updated three `deepEqual` expectations to the new copy; the "startup tips wrap" test now uses a `some(/^Press Ctrl\+Shift\+E/)` search instead of positional indexing because the hint itself wraps to multiple lines at narrow widths.
- `tests/the-last-harness-extension-startup-warning.test.mjs`: updated three string assertions to the new copy.

## Validation

`npm run validate` → 632 tests pass, ESLint clean.