### PR TITLE
Bump pi-subagents fork pin to tlh-v0.26.0-7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - TLH now requires upstream Pi >=0.79.1. Installer checks, wrapper defaults, package metadata, and current install/update docs all use the raised runtime floor.
+- Bundled pi-subagents fork pin bumped to `tlh-v0.26.0-7`. The compact (non-expanded) subagent view now hides the artifact-path line — press Ctrl+O for the expanded view that still shows it — and renders the current tool command (e.g. long `bash` invocations) in full, wrapped to terminal width and capped at 3 lines with `…` on overflow instead of mid-flag `...` truncation.
 
 ### Fixed
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -82,7 +82,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-6",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-7",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -939,7 +939,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-6");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-7");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary

Bumps the bundled `pi-subagents` fork pin from `tlh-v0.26.0-6` to `tlh-v0.26.0-7`. The new tag ships a compact-view UX change in the subagent widget.

## What changes for end users

In any running subagent's compact (non-expanded) view:

- The trailing `output: ~/.the-last-harness/agent/sessions/.../subagent-artifacts/...md` line is no longer shown. Press `Ctrl+O` to see the expanded view, which still shows the artifact path under `Artifacts: …`.
- The current tool command (e.g. long `bash` / `xcodebuild` invocations) renders in full, wrapped to terminal width, capped at 3 lines with `…` on overflow — instead of the previous mid-arg `...` truncation that often hid the meaningful part of the command.

## Files

- `config/default-extensions.json` — `subagents.source` bumped to `git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-7`.
- `tests/default-extensions.test.mjs` — pin-string assertion updated in lockstep.
- `CHANGELOG.md` — bullet added under `[Unreleased] → ### Changed`.

## Fork side

- Tag `tlh-v0.26.0-7` → `a286f7fc` on commit `2b02dc8` (squash-merged from [diegopetrucci/pi-subagents#7](https://github.com/diegopetrucci/pi-subagents/pull/7)), reachable from `diegopetrucci/pi-subagents:main`.
- Fork CI on PR #7 passed (test + CodeRabbit) before tagging.

## Validation

- `npm run validate` ✅ — 632 tests pass, 0 failures, clean smoke + lint + merge-settings dry-run + pack dry-run.

## Tradeoffs / known cosmetic edge cases

- If a wrapped line happens to exactly fill terminal width minus prefix, the truncated 3rd line can render a double-ellipsis. `wrapTextWithAnsi`'s word-boundary wrapping makes this rare; trivial follow-up if it surfaces.
- The duration suffix (`| 6m20s`) may fall inside the truncated tail for long commands; the same value already appears in the agent header stats, so it isn't lost.
