### PR TITLE
When using anthropic models for architect/dev, prefer, if present, gpt 5.5 for reviewing

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Clarifies requirements, manages implementation tasks, and orchestrates minor subagents.
-model: anthropic/claude-opus-4-7
+model: anthropic/claude-opus-4-8
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
 applyModel: true

--- a/agents/primary/bug-hunter.md
+++ b/agents/primary/bug-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: bug-hunter
 description: Investigates reported bugs, identifies root causes, and recommends fixes without changing code.
-model: anthropic/claude-opus-4-7
+model: anthropic/claude-opus-4-8
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
 applyModel: true

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -1,7 +1,7 @@
 ---
 name: rush
 description: Implements small bounded changes directly with narrow validation and optional review when warranted.
-model: anthropic/claude-opus-4-7
+model: anthropic/claude-opus-4-8
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: low
 tlhOpenaiThinking: off

--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -2,8 +2,9 @@
 name: code-reviewer
 description: Reviews diffs against assigned tasks for correctness, security, and maintainability.
 tools: read, grep, find, ls, bash, contact_supervisor
-model: anthropic/claude-opus-4-7
+model: openai-codex/gpt-5.5
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
+tlhAnthropicModels: anthropic/claude-opus-4-8
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true

--- a/agents/subagents/oracle.md
+++ b/agents/subagents/oracle.md
@@ -2,7 +2,7 @@
 name: oracle
 description: Provides read-only high-reasoning second opinions using the oracle extension tool.
 tools: oracle, read, grep, find, ls, contact_supervisor, bash
-model: anthropic/claude-opus-4-7
+model: anthropic/claude-opus-4-8
 tlhOpenaiModels: openai-codex/gpt-5.5, openai/gpt-5.5
 thinking: high
 systemPromptMode: replace

--- a/extensions/the-last-harness/model-defaults.ts
+++ b/extensions/the-last-harness/model-defaults.ts
@@ -9,6 +9,7 @@ export type AgentModelDefaults = {
 	name: string;
 	model?: string;
 	tlhOpenaiModels?: string[];
+	tlhAnthropicModels?: string[];
 	thinking?: ThinkingLevel;
 	tlhOpenaiThinking?: ThinkingLevel;
 	preferCurrentOpenaiModel?: boolean;
@@ -20,6 +21,7 @@ export type ProviderAwareAgentDefaults<T extends ProviderModelReference = Provid
 };
 
 const OPENAI_PROVIDERS = new Set(["openai-codex", "openai"]);
+const ANTHROPIC_PROVIDERS = new Set(["anthropic"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -39,6 +41,10 @@ export function formatProviderModelReference(model: ProviderModelReference): str
 
 function isOpenaiProvider(provider: string | undefined): boolean {
 	return Boolean(provider && OPENAI_PROVIDERS.has(provider));
+}
+
+function isAnthropicProvider(provider: string | undefined): boolean {
+	return Boolean(provider && ANTHROPIC_PROVIDERS.has(provider));
 }
 
 export function findAvailableProviderModel<T extends ProviderModelReference>(
@@ -63,6 +69,17 @@ function availableOpenaiCandidate<T extends ProviderModelReference>(
 	return findAvailableProviderModel(availableModels, candidate);
 }
 
+function availableAnthropicCandidate<T extends ProviderModelReference>(
+	availableModels: readonly T[],
+	candidate: string | undefined,
+): T | undefined {
+	const parsed = parseProviderModelReference(candidate);
+	if (!parsed || !isAnthropicProvider(parsed.provider)) {
+		return undefined;
+	}
+	return findAvailableProviderModel(availableModels, candidate);
+}
+
 function currentProviderOpenaiCandidate<T extends ProviderModelReference>(
 	agent: AgentModelDefaults | undefined,
 	availableModels: readonly T[],
@@ -75,6 +92,20 @@ function currentProviderOpenaiCandidate<T extends ProviderModelReference>(
 		(candidate) => parseProviderModelReference(candidate)?.provider === currentProvider,
 	);
 	return availableOpenaiCandidate(availableModels, currentProviderCandidate);
+}
+
+function currentProviderAnthropicCandidate<T extends ProviderModelReference>(
+	agent: AgentModelDefaults | undefined,
+	availableModels: readonly T[],
+	currentProvider?: string,
+): T | undefined {
+	if (!isAnthropicProvider(currentProvider)) {
+		return undefined;
+	}
+	const currentProviderCandidate = agent?.tlhAnthropicModels?.find(
+		(candidate) => parseProviderModelReference(candidate)?.provider === currentProvider,
+	);
+	return availableAnthropicCandidate(availableModels, currentProviderCandidate);
 }
 
 export function selectProviderAwareAgentModel<T extends ProviderModelReference>(
@@ -91,13 +122,22 @@ export function selectProviderAwareAgentModel<T extends ProviderModelReference>(
 		return defaultModel;
 	}
 
-	const currentProviderModel = currentProviderOpenaiCandidate(agent, availableModels, currentProvider);
+	const currentProviderModel =
+		currentProviderOpenaiCandidate(agent, availableModels, currentProvider)
+		?? currentProviderAnthropicCandidate(agent, availableModels, currentProvider);
 	if (currentProviderModel) {
 		return currentProviderModel;
 	}
 
 	for (const candidate of agent.tlhOpenaiModels ?? []) {
 		const model = availableOpenaiCandidate(availableModels, candidate);
+		if (model) {
+			return model;
+		}
+	}
+
+	for (const candidate of agent.tlhAnthropicModels ?? []) {
+		const model = availableAnthropicCandidate(availableModels, candidate);
 		if (model) {
 			return model;
 		}

--- a/extensions/the-last-harness/prompts.ts
+++ b/extensions/the-last-harness/prompts.ts
@@ -67,6 +67,7 @@ function parseAgentPrompt(filePath: string): AgentPrompt | undefined {
 		description,
 		model: frontmatter.model?.trim() || undefined,
 		tlhOpenaiModels: splitCommaList(frontmatter.tlhOpenaiModels),
+		tlhAnthropicModels: splitCommaList(frontmatter.tlhAnthropicModels),
 		thinking: parseThinkingLevelValue(frontmatter.thinking),
 		tlhOpenaiThinking: parseThinkingLevelValue(frontmatter.tlhOpenaiThinking),
 		preferCurrentOpenaiModel: parseBooleanValue(frontmatter.preferCurrentOpenaiModel),
@@ -97,6 +98,7 @@ export function loadSubagentMetadata(): SubagentMetadata[] {
 			description: agent.description,
 			model: agent.model,
 			tlhOpenaiModels: agent.tlhOpenaiModels,
+			tlhAnthropicModels: agent.tlhAnthropicModels,
 		}))
 		.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/extensions/the-last-harness/types.ts
+++ b/extensions/the-last-harness/types.ts
@@ -194,6 +194,7 @@ export type AgentPrompt = {
 	description: string;
 	model?: string;
 	tlhOpenaiModels?: string[];
+	tlhAnthropicModels?: string[];
 	thinking?: ThinkingLevel;
 	tlhOpenaiThinking?: ThinkingLevel;
 	preferCurrentOpenaiModel?: boolean;
@@ -211,6 +212,7 @@ export type SubagentMetadata = {
 	description: string;
 	model?: string;
 	tlhOpenaiModels?: string[];
+	tlhAnthropicModels?: string[];
 };
 
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";

--- a/tests/the-last-harness-effort.test.mjs
+++ b/tests/the-last-harness-effort.test.mjs
@@ -69,7 +69,7 @@ function rushPrimary() {
 	return {
 		name: "rush",
 		description: "Rush primary",
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		tlhOpenaiModels: ["openai-codex/gpt-5.5", "openai/gpt-5.5"],
 		thinking: "low",
 		tlhOpenaiThinking: "off",
@@ -98,7 +98,7 @@ function bugHunterPrimary() {
 	return {
 		name: "bug-hunter",
 		description: "Bug-hunter primary",
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "high",
 		lockThinking: true,
 		tools: [],
@@ -111,7 +111,7 @@ function architectPrimary() {
 	return {
 		name: "architect",
 		description: "Architect primary",
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "high",
 		minThinking: "medium",
 		tools: [],
@@ -122,7 +122,7 @@ function architectPrimary() {
 
 /** A reasoning model whose thinkingLevelMap supports xhigh. */
 function reasoningModel(provider = "anthropic") {
-	return { provider, id: "claude-opus-4-7", reasoning: true, thinkingLevelMap: { xhigh: "max" } };
+	return { provider, id: "claude-opus-4-8", reasoning: true, thinkingLevelMap: { xhigh: "max" } };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/the-last-harness-model-defaults.test.mjs
+++ b/tests/the-last-harness-model-defaults.test.mjs
@@ -17,13 +17,14 @@ const developer = {
 
 const codeReviewer = {
 	name: "code-reviewer",
-	model: "anthropic/claude-opus-4-7",
+	model: "openai-codex/gpt-5.5",
 	tlhOpenaiModels: ["openai-codex/gpt-5.5", "openai/gpt-5.5"],
+	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 };
 
 const rushLikePrimary = {
 	name: "rush",
-	model: "anthropic/claude-opus-4-7",
+	model: "anthropic/claude-opus-4-8",
 	tlhOpenaiModels: ["openai-codex/gpt-5.5", "openai/gpt-5.5"],
 	thinking: "low",
 	tlhOpenaiThinking: "off",
@@ -43,7 +44,7 @@ const agents = new Map([
 
 const anthropicAvailable = [
 	{ provider: "anthropic", id: "claude-sonnet-4-6" },
-	{ provider: "anthropic", id: "claude-opus-4-7" },
+	{ provider: "anthropic", id: "claude-opus-4-8" },
 ];
 
 const codexAvailable = [
@@ -115,24 +116,87 @@ test("provider-aware primary defaults keep the Anthropic default first without t
 	const mixedOpenaiAvailable = [...anthropicAvailable, ...openaiAvailable];
 
 	assert.deepEqual(selectProviderAwareAgentDefaults(anthropicFirstPrimary, mixedCodexAvailable, "openai-codex"), {
-		model: { provider: "anthropic", id: "claude-opus-4-7" },
+		model: { provider: "anthropic", id: "claude-opus-4-8" },
 		thinking: "low",
 	});
 	assert.deepEqual(selectProviderAwareAgentDefaults(anthropicFirstPrimary, mixedOpenaiAvailable, "openai"), {
-		model: { provider: "anthropic", id: "claude-opus-4-7" },
+		model: { provider: "anthropic", id: "claude-opus-4-8" },
 		thinking: "low",
 	});
 });
 
 test("provider-aware primary defaults fall back to Anthropic thinking when OpenAI models are unavailable", () => {
 	assert.deepEqual(selectProviderAwareAgentDefaults(rushLikePrimary, anthropicAvailable, "openai-codex"), {
-		model: { provider: "anthropic", id: "claude-opus-4-7" },
+		model: { provider: "anthropic", id: "claude-opus-4-8" },
 		thinking: "low",
 	});
 	assert.deepEqual(selectProviderAwareAgentDefaults({ ...rushLikePrimary, tlhOpenaiThinking: undefined }, codexAvailable, "openai-codex"), {
 		model: { provider: "openai-codex", id: "gpt-5.5" },
 		thinking: "low",
 	});
+});
+
+// --- tlhAnthropicModels: new tests (ticket tlht-k7h8) ---
+
+test("tlhAnthropicModels: selects Anthropic fallback when primary OpenAI model is absent from registry", () => {
+	const agentWithAnthropicFallback = {
+		name: "test-agent",
+		model: "openai/gpt-5.5",
+		tlhAnthropicModels: ["anthropic/claude-sonnet-4-6"],
+	};
+	// No currentProvider given — iterates tlhAnthropicModels and finds the Anthropic model
+	assert.equal(
+		selectProviderAwareAgentModelId(agentWithAnthropicFallback, anthropicAvailable, undefined),
+		"anthropic/claude-sonnet-4-6",
+	);
+	// Same result when currentProvider is explicitly "anthropic"
+	assert.equal(
+		selectProviderAwareAgentModelId(agentWithAnthropicFallback, anthropicAvailable, "anthropic"),
+		"anthropic/claude-sonnet-4-6",
+	);
+});
+
+test("tlhAnthropicModels: current-provider Anthropic candidate preferred on Anthropic session", () => {
+	const agentWithBothFallbacks = {
+		name: "test-agent",
+		model: "openai/gpt-5.5",
+		tlhOpenaiModels: ["openai/gpt-5.5"],
+		tlhAnthropicModels: ["anthropic/claude-opus-4-8", "anthropic/claude-sonnet-4-6"],
+	};
+	// currentProvider="anthropic": step-2 current-provider check picks first matching entry
+	assert.equal(
+		selectProviderAwareAgentModelId(agentWithBothFallbacks, anthropicAvailable, "anthropic"),
+		"anthropic/claude-opus-4-8",
+	);
+	// When only the second candidate is available the fallback iteration finds it
+	const sonetOnly = [{ provider: "anthropic", id: "claude-sonnet-4-6" }];
+	assert.equal(
+		selectProviderAwareAgentModelId(agentWithBothFallbacks, sonetOnly, "anthropic"),
+		"anthropic/claude-sonnet-4-6",
+	);
+});
+
+test("tlhAnthropicModels: regression – agents with only tlhOpenaiModels are unaffected", () => {
+	const agentOpenaiOnly = {
+		name: "openai-only",
+		model: "openai/gpt-5.5",
+		tlhOpenaiModels: ["openai-codex/gpt-5.4"],
+		// no tlhAnthropicModels
+	};
+	// Codex available: selects the OpenAI fallback
+	assert.equal(
+		selectProviderAwareAgentModelId(agentOpenaiOnly, codexAvailable, "openai-codex"),
+		"openai-codex/gpt-5.4",
+	);
+	// Anthropic-only environment: no tlhAnthropicModels declared → returns undefined
+	assert.equal(
+		selectProviderAwareAgentModelId(agentOpenaiOnly, anthropicAvailable, "anthropic"),
+		undefined,
+	);
+	// applyProviderAwareSubagentModels: existing developer agent still works exactly as before
+	const input = { agent: "developer", task: "Implement the ticket" };
+	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 1);
+	assert.equal(input.model, "openai-codex/gpt-5.4");
 });
 
 test("provider-aware subagent mutation preserves explicit model values", () => {
@@ -145,14 +209,14 @@ test("provider-aware subagent mutation handles parallel tasks", () => {
 	const input = {
 		tasks: [
 			{ agent: "developer", task: "Implement" },
-			{ agent: "code-reviewer", task: "Review", model: "anthropic/claude-opus-4-7" },
+			{ agent: "code-reviewer", task: "Review", model: "anthropic/claude-opus-4-8" },
 			{ agent: "unknown", task: "Leave alone" },
 		],
 	};
 
 	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 1);
 	assert.equal(input.tasks[0].model, "openai-codex/gpt-5.4");
-	assert.equal(input.tasks[1].model, "anthropic/claude-opus-4-7");
+	assert.equal(input.tasks[1].model, "anthropic/claude-opus-4-8");
 	assert.equal(input.tasks[2].model, undefined);
 });
 
@@ -169,8 +233,8 @@ test("provider-aware subagent mutation handles chain sequential and parallel ste
 		],
 	};
 
-	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 2);
+	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 1);
 	assert.equal(input.chain[0].model, "openai-codex/gpt-5.4");
-	assert.equal(input.chain[1].parallel[0].model, "openai-codex/gpt-5.5");
+	assert.equal(input.chain[1].parallel[0].model, undefined); // code-reviewer default already matches; no injection needed
 	assert.equal(input.chain[1].parallel[1].model, "openai/gpt-5.4");
 });

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -108,7 +108,7 @@ function selectablePrimaryAgents() {
 
 function rushLikePrimary(name = "architect") {
 	return createPrimaryPrompt(name, {
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		tlhOpenaiModels: ["openai-codex/gpt-5.5", "openai/gpt-5.5"],
 		thinking: "low",
 		tlhOpenaiThinking: "off",
@@ -1298,11 +1298,11 @@ test("primary runtime falls back to Anthropic Rush-like metadata defaults when o
 				cwd: fixture.cwd,
 				sessionManager: { getBranch: () => [] },
 				ui: { notify() {} },
-				modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
+				modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
 				model: { provider: "openai-codex", id: "gpt-5.4" },
 			});
 
-			assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-7" });
+			assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-8" });
 			assert.equal(pi.thinkingLevel, "low");
 		});
 	} finally {
@@ -1339,14 +1339,14 @@ test("primary runtime respects explicit false settings over Rush-like metadata d
 test("architect before_agent_start preserves medium floor selection but restores declared default after rush", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "high",
 		minThinking: "medium",
 		applyModel: true,
 		applyThinking: true,
 	});
 	const rushPrimary = createPrimaryPrompt("rush", {
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "low",
 		applyModel: true,
 		applyThinking: true,
@@ -1365,8 +1365,8 @@ test("architect before_agent_start preserves medium floor selection but restores
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => branch },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
-			model: { provider: "anthropic", id: "claude-opus-4-7" },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
+			model: { provider: "anthropic", id: "claude-opus-4-8" },
 		});
 
 		await runtime.applySessionStart(makeCtx([]));
@@ -1390,7 +1390,7 @@ test("architect before_agent_start preserves medium floor selection but restores
 test("locked primary (rush) overrides global applyThinking=false and applyModel=false", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const rushPrimary = createPrimaryPrompt("rush", {
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "low",
 		applyModel: true,
 		applyThinking: true,
@@ -1412,12 +1412,12 @@ test("locked primary (rush) overrides global applyThinking=false and applyModel=
 				{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } },
 			]},
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
 			model: { provider: "anthropic", id: "claude-opus-4-6" },
 		});
 
 		// lockThinking: true forces both model and thinking regardless of global opt-outs
-		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-7" });
+		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-8" });
 		assert.equal(pi.thinkingLevel, "low");
 	});
 });
@@ -1425,7 +1425,7 @@ test("locked primary (rush) overrides global applyThinking=false and applyModel=
 test("non-locked primary (architect) honors global applyThinking=false override", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
-		model: "anthropic/claude-opus-4-7",
+		model: "anthropic/claude-opus-4-8",
 		thinking: "high",
 		applyModel: true,
 		applyThinking: true,
@@ -1444,8 +1444,8 @@ test("non-locked primary (architect) honors global applyThinking=false override"
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => [] },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-7" }] },
-			model: { provider: "anthropic", id: "claude-opus-4-7" },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
+			model: { provider: "anthropic", id: "claude-opus-4-8" },
 		});
 
 		// Global applyThinking: false is respected for non-locked primary


### PR DESCRIPTION
## Summary

Adds a symmetric `tlhAnthropicModels` frontmatter field mirroring the existing `tlhOpenaiModels`, then uses it to invert `code-reviewer`'s preference: GPT-5.5 first, Anthropic Opus 4-8 as fallback. Other agents keep Anthropic-first behavior because they don't declare the new field. Also bumps every remaining `claude-opus-4-7` reference to `claude-opus-4-8`.

## Motivation

The reviewer subagent has historically used the same Anthropic default as the architect. Decoupling the reviewer's model choice from the architect's lets the reviewer run on a different model family with provider-aware fallback. The asymmetric design of the existing fallback machinery (OpenAI-only) prevented this cleanly, so the new field generalizes it without changing existing semantics.

## Behavior matrix

After this change the reviewer resolves as follows:

| Session provider                          | Reviewer model                                          |
|-------------------------------------------|---------------------------------------------------------|
| `openai-codex`                            | `openai-codex/gpt-5.5` (exact `model:` match)           |
| `openai`                                  | `openai/gpt-5.5` (current-provider OpenAI candidate)    |
| `anthropic`                               | `anthropic/claude-opus-4-8` (new tlhAnthropicModels)    |
| None of the above available               | undefined → session default                             |

Other primary/subagents (architect, bug-hunter, rush, oracle) are unchanged in behavior — they continue to prefer Anthropic Opus, just at version 4-8.

## Selection algorithm

`selectProviderAwareAgentModel` resolution order:

1. `agent.model` exact match in the available-models registry.
2. Current-provider candidate from whichever family list matches the session (`tlhOpenaiModels` for OpenAI sessions, `tlhAnthropicModels` for Anthropic sessions).
3. Iterate `tlhOpenaiModels` in declared order.
4. Iterate `tlhAnthropicModels` in declared order.

`preferCurrentOpenaiModel` and `tlhOpenaiThinking` semantics are intentionally unchanged; they remain OpenAI-only.

## Files of interest

- `extensions/the-last-harness/model-defaults.ts` — symmetric Anthropic helpers and extended selection algorithm.
- `extensions/the-last-harness/{prompts.ts,types.ts}` — parse + propagate `tlhAnthropicModels`.
- `agents/subagents/code-reviewer.md` — inverted frontmatter.
- `tests/the-last-harness-model-defaults.test.mjs` — three new tests covering the new field; one existing chain-traversal test adjusted because the new reviewer primary model already matches on Codex sessions so `applyModelToRunnableTarget` short-circuits (mutation count 2 → 1, assertion updated to `undefined`).

## Back-compat

- Agents without `tlhAnthropicModels` behave identically (regression test added).
- Existing `model:` override behavior on subagent calls still wins (explicit `model:` is never overwritten).
- The Gnosis-recorded contract that "model-default injection remains opt-out via explicit `model:` on the call" (`uzgrkg`) is preserved.

## Validation

- `npm run validate` → 635 pass, 0 fail, lint clean, pack dry-run clean.
- Final `code-reviewer` pass: no required changes.

## Residual risk (non-blocking)

No symmetric `tlhAnthropicThinking` field was added. If a future Anthropic-only agent ever needs per-family thinking control, the asymmetry will need revisiting — intentionally out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable Anthropic model fallbacks in agent configurations, enabling multi-provider model selection.

* **Updates**
  * Updated agent models from Claude Opus 4.7 to Claude Opus 4.8.
  * Enhanced model selection logic to intelligently choose between OpenAI and Anthropic providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->