### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 - TLH now requires upstream Pi >=0.79.1. Installer checks, wrapper defaults, package metadata, and current install/update docs all use the raised runtime floor.
 - The compact (non-expanded) subagent view now hides the artifact-path line — press Ctrl+O for the expanded view that still shows it — and renders the current tool command (e.g. long `bash` invocations) in full, wrapped to terminal width and capped at 3 lines with `…` on overflow instead of mid-flag `...` truncation.
+- `code-reviewer` now prefers `openai-codex/gpt-5.5` by default when available, keeps `openai/gpt-5.5` as the OpenAI API fallback, and falls back to Anthropic Opus when running in Anthropic-only environments.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Repo settings:
 - `.pi/prompts/`
 - `.pi/extensions/`
 
-With upstream Pi 0.79.1 and newer, `AGENTS.md` and `CLAUDE.md` still load as context even before project trust is resolved, but trust-gated repo-local resources wait until the project is trusted. That includes `.pi/settings.json`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/`, `.pi/themes/`, project-local `.agents/skills/`, and project-local packages. Interactive `tlh` sessions prompt for project trust when needed; follow that prompt to save a decision for future sessions. Saved trust decisions live in the isolated TLH profile, not normal `~/.pi/agent`. Non-interactive runs need a saved trust decision before trust-gated repo-local resources are loaded.
 
 After adding files, installing a package, or saving project trust, run `/reload` in TLH (or restart it) so the new resources are picked up.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Repo settings:
 - `.pi/prompts/`
 - `.pi/extensions/`
 
-With upstream Pi 0.79.1 and newer, `AGENTS.md` and `CLAUDE.md` still load as context even before project trust is resolved, but trust-gated repo-local resources wait until the project is trusted. That includes `.pi/settings.json`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/`, `.pi/themes/`, project-local `.agents/skills/`, and project-local packages. Interactive `tlh` sessions prompt for project trust when needed; use `/trust` to save a decision for future sessions. Saved trust decisions live in the isolated TLH profile, not normal `~/.pi/agent`. Non-interactive runs need a saved trust decision or `--approve`.
+With upstream Pi 0.79.1 and newer, `AGENTS.md` and `CLAUDE.md` still load as context even before project trust is resolved, but trust-gated repo-local resources wait until the project is trusted. That includes `.pi/settings.json`, `.pi/skills/`, `.pi/prompts/`, `.pi/extensions/`, `.pi/themes/`, project-local `.agents/skills/`, and project-local packages. Interactive `tlh` sessions prompt for project trust when needed; follow that prompt to save a decision for future sessions. Saved trust decisions live in the isolated TLH profile, not normal `~/.pi/agent`. Non-interactive runs need a saved trust decision before trust-gated repo-local resources are loaded.
 
 After adding files, installing a package, or saving project trust, run `/reload` in TLH (or restart it) so the new resources are picked up.
 


### PR DESCRIPTION
## Summary

- Remove README guidance that referenced unavailable `/trust` and `--approve` project-trust controls.
- Document the latest `code-reviewer` model-default behavior in the Unreleased changelog.

## Why

The docs audit found README project-trust guidance had drifted from the checked Pi 0.79.1 runtime surface. The latest model-default change also needed a release-note entry so users can see that `code-reviewer` now prefers GPT-5.5 when available and falls back to Anthropic in Anthropic-only environments.

## Validation

- `npm run validate`

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/codex/update-docs-trust-model-defaults/install.sh | bash -s -- --ref codex/update-docs-trust-model-defaults --track ref
```
