### PR TITLE
Add safe primary-agent subagent resume support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+- Bundled the updated `pi-subagents` tag with the completion-guard fix for VCS/PR false positives.
+
 ## [0.20.0] - 2026-06-15
 
 ### Changed

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -82,7 +82,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-9",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-10",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/extensions/the-last-harness-subagent-safety.mjs
+++ b/extensions/the-last-harness-subagent-safety.mjs
@@ -1,5 +1,5 @@
 export const ALLOWED_SUBAGENTS = Object.freeze(["developer", "code-reviewer", "repo-scout", "diff-summarizer", "librarian", "web-scout", "oracle"]);
-export const SAFE_SUBAGENT_ACTIONS = Object.freeze(["list", "get", "status", "interrupt", "doctor"]);
+export const SAFE_SUBAGENT_ACTIONS = Object.freeze(["list", "get", "status", "interrupt", "doctor", "resume"]);
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 
 const SAFE_SUBAGENT_ACTION_SET = new Set(SAFE_SUBAGENT_ACTIONS);
@@ -65,15 +65,15 @@ function forceUserAgentScope(input, mode, { allowBoth = false } = {}) {
 	return undefined;
 }
 
-function forceFreshSubagentContext(input) {
+function forceFreshSubagentContext(input, mode = "execution") {
 	const rawContext = input.context;
 	if (rawContext !== undefined) {
 		if (typeof rawContext !== "string") {
-			return `TLH primary-agent subagent execution must use context: "fresh" or omit context.`;
+			return `TLH primary-agent subagent ${mode} must use context: "fresh" or omit context.`;
 		}
 		const context = rawContext.trim();
 		if (context && context !== "fresh") {
-			return `TLH primary-agent subagent execution may not use context: "${context}". TLH child sessions must start fresh so parent primary-agent/Gnosis context is not leaked.`;
+			return `TLH primary-agent subagent ${mode} may not use context: "${context}". TLH child sessions must start fresh so parent primary-agent/Gnosis context is not leaked.`;
 		}
 	}
 
@@ -129,7 +129,17 @@ export function validateSubagentToolInput(input) {
 		if (!SAFE_SUBAGENT_ACTION_SET.has(action)) {
 			return `TLH primary agents may not use subagent management action '${action}'. Allowed actions: ${SAFE_SUBAGENT_ACTIONS.join(", ")}.`;
 		}
-		return action === "list" || action === "get" ? forceUserAgentScope(input, action, { allowBoth: true }) : undefined;
+		if (action === "list" || action === "get") {
+			return forceUserAgentScope(input, action, { allowBoth: true });
+		}
+		if (action === "resume") {
+			const scopeReason = forceUserAgentScope(input, action, { allowBoth: true });
+			if (scopeReason) {
+				return scopeReason;
+			}
+			return forceFreshSubagentContext(input, action);
+		}
+		return undefined;
 	}
 
 	const scopeReason = forceUserAgentScope(input, "execution");

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -174,6 +174,10 @@ function matchesSubagentName(value: unknown, target: string): boolean {
 	return typeof value === "string" && value.trim().toLowerCase() === target;
 }
 
+function isSubagentResumeAction(input: unknown): boolean {
+	return isRecord(input) && matchesSubagentName(input.action, "resume");
+}
+
 function subagentCallTargetsAgent(input: unknown, target: string): boolean {
 	if (!isRecord(input)) {
 		return false;
@@ -199,6 +203,10 @@ function subagentCallTargetsAgent(input: unknown, target: string): boolean {
 		}
 	}
 	return false;
+}
+
+function rushResumeDelegationReason(): string {
+	return "TLH Rush may not use subagent action=resume because resuming by run id or index can continue a prior developer subagent without an explicit safe target. Rush must edit directly or start a new allowed subagent with an explicit agent target.";
 }
 
 function rushDeveloperDelegationReason(): string {
@@ -601,6 +609,9 @@ function createTlhPrimaryAgentRuntime(
 			const selection = currentPrimaryAgentSelection();
 			if (!isEnabledPrimaryAgentSelection(selection)) {
 				return undefined;
+			}
+			if (selection === "rush" && isSubagentResumeAction(event.input)) {
+				return { block: true, reason: rushResumeDelegationReason() };
 			}
 			if (selection === "rush" && subagentCallTargetsAgent(event.input, "developer")) {
 				return { block: true, reason: rushDeveloperDelegationReason() };

--- a/extensions/the-last-harness/prompts.ts
+++ b/extensions/the-last-harness/prompts.ts
@@ -113,7 +113,7 @@ function formatAllowedSubagents(subagents: SubagentMetadata[]): string {
 	if (lines.length === 0) {
 		return "";
 	}
-	return `## TLH Allowed Minor Subagents\n\nYou may delegate only to these minor agents via the subagent tool:\n\n${lines.join("\n")}\n\nFor subagent management \`action: "list"\`/\`"get"\` calls, omit \`agentScope\` or use \`"user"\`. TLH minor agents are isolated to the user scope.`;
+	return `## TLH Allowed Minor Subagents\n\nYou may delegate only to these minor agents via the subagent tool:\n\n${lines.join("\n")}\n\nFor subagent management \`action: "list"\`/\`"get"\`/\`"resume"\` calls, omit \`agentScope\` or use \`"user"\`. For \`action: "resume"\`, also omit \`context\` or use \`"fresh"\`. TLH minor agents are isolated to the user scope.`;
 }
 
 export function buildTlhSystemPrompt(

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -939,7 +939,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-9");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-10");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -210,7 +210,9 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	const childPrompt = buildChildSubagentSystemPrompt();
 
 	assert.match(primaryPrompt, /## TLH Allowed Minor Subagents/);
+	assert.match(primaryPrompt, /action: "list"`\/`"get"`\/`"resume"/);
 	assert.match(primaryPrompt, /omit `agentScope` or use `"user"`/);
+	assert.match(primaryPrompt, /action: "resume".*omit `context` or use `"fresh"`/);
 	assert.match(primaryPrompt, /TLH minor agents are isolated to the user scope/);
 
 	for (const prompt of [primaryPrompt, childPrompt]) {

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -319,6 +319,7 @@ test("extension wires switch-primary-agent and active-primary safety", () => {
 	assert.match(toolCall, /getTlhGitCommitAttributionBlockReason\(event\.input\.command, commitAttributionState\)/);
 	assert.match(toolCall, /applyProviderAwareSubagentModels\(event\.input, subagentsByName, ctx\.modelRegistry\.getAvailable\(\), ctx\.model\?\.provider\)/);
 	assert.match(toolCall, /const selection = currentPrimaryAgentSelection\(\)/);
+	assert.match(toolCall, /if \(selection === "rush" && isSubagentResumeAction\(event\.input\)\)/);
 	assert.match(toolCall, /if \(selection === "rush" && subagentCallTargetsAgent\(event\.input, "developer"\)\)/);
 	assert.match(toolCall, /const reason = validateSubagentToolInput\(event\.input\)/);
 	assert(
@@ -330,7 +331,11 @@ test("extension wires switch-primary-agent and active-primary safety", () => {
 		"provider-aware subagent defaults should run before the disabled-primary guard",
 	);
 	assert(
-		toolCall.indexOf('selection === "rush"') < toolCall.indexOf("validateSubagentToolInput"),
+		toolCall.indexOf("isSubagentResumeAction") < toolCall.indexOf("validateSubagentToolInput"),
+		"Rush resume guard should run before generic subagent validation",
+	);
+	assert(
+		toolCall.indexOf("subagentCallTargetsAgent") < toolCall.indexOf("validateSubagentToolInput"),
 		"Rush developer guard should run before generic subagent validation",
 	);
 });

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1170,6 +1170,24 @@ test("enabled primary mode normalizes safe management list/get/resume inputs and
 	});
 });
 
+test("Rush blocks subagent resume with a Rush-specific reason", async () => {
+	const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+	const event = {
+		toolName: "subagent",
+		input: { action: "resume", id: "run-123", message: "Continue the approved ticket.", agentScope: "", context: "" },
+	};
+	const ctx = createToolCallContext([
+		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "rush" } },
+	]);
+
+	const result = await toolCall(event, ctx);
+	assert.deepEqual(result, {
+		block: true,
+		reason:
+			"TLH Rush may not use subagent action=resume because resuming by run id or index can continue a prior developer subagent without an explicit safe target. Rush must edit directly or start a new allowed subagent with an explicit agent target.",
+	});
+});
+
 test("/switch-primary-agent includes Rush completions, usage, and status strings", async () => {
 	const { pi } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
 	const command = pi.commands.get("switch-primary-agent");

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1120,7 +1120,7 @@ test("enabled primary mode blocks disallowed nested delegation targets after for
 	assert.equal(event.input.context, "fresh");
 });
 
-test("enabled primary mode normalizes safe management list/get scopes and blocks non-user management scopes", async () => {
+test("enabled primary mode normalizes safe management list/get/resume inputs and blocks unsafe resume context or non-user scopes", async () => {
 	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
 	const ctx = createToolCallContext([
 		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
@@ -1129,7 +1129,17 @@ test("enabled primary mode normalizes safe management list/get scopes and blocks
 	const listBothEvent = { toolName: "subagent", input: { action: "list", agentScope: "both" } };
 	const getEvent = { toolName: "subagent", input: { action: "get", agentScope: "" } };
 	const getBothEvent = { toolName: "subagent", input: { action: "get", agentScope: "both" } };
-	const blockedEvent = { toolName: "subagent", input: { action: "get", agentScope: "project" } };
+	const resumeEvent = {
+		toolName: "subagent",
+		input: { action: "resume", id: "run-123", message: "Continue the approved ticket.", agentScope: "", context: "" },
+	};
+	const resumeBothEvent = {
+		toolName: "subagent",
+		input: { action: "resume", id: "run-456", message: "Continue the approved ticket.", agentScope: "both" },
+	};
+	const blockedGetEvent = { toolName: "subagent", input: { action: "get", agentScope: "project" } };
+	const blockedResumeScopeEvent = { toolName: "subagent", input: { action: "resume", id: "run-123", agentScope: "system" } };
+	const blockedResumeContextEvent = { toolName: "subagent", input: { action: "resume", id: "run-123", context: "resume" } };
 
 	assert.equal(await toolCall(listEvent, ctx), undefined);
 	assert.equal(listEvent.input.agentScope, "user");
@@ -1139,9 +1149,24 @@ test("enabled primary mode normalizes safe management list/get scopes and blocks
 	assert.equal(getEvent.input.agentScope, "user");
 	assert.equal(await toolCall(getBothEvent, ctx), undefined);
 	assert.equal(getBothEvent.input.agentScope, "user");
-	assert.deepEqual(await toolCall(blockedEvent, ctx), {
+	assert.equal(await toolCall(resumeEvent, ctx), undefined);
+	assert.equal(resumeEvent.input.agentScope, "user");
+	assert.equal(resumeEvent.input.context, "fresh");
+	assert.equal(await toolCall(resumeBothEvent, ctx), undefined);
+	assert.equal(resumeBothEvent.input.agentScope, "user");
+	assert.equal(resumeBothEvent.input.context, "fresh");
+	assert.deepEqual(await toolCall(blockedGetEvent, ctx), {
 		block: true,
 		reason: 'TLH primary-agent subagent get calls may not use agentScope: "project". TLH minor agents must run from the isolated user scope.',
+	});
+	assert.deepEqual(await toolCall(blockedResumeScopeEvent, ctx), {
+		block: true,
+		reason: 'TLH primary-agent subagent resume calls may not use agentScope: "system". TLH minor agents must run from the isolated user scope.',
+	});
+	assert.deepEqual(await toolCall(blockedResumeContextEvent, ctx), {
+		block: true,
+		reason:
+			'TLH primary-agent subagent resume may not use context: "resume". TLH child sessions must start fresh so parent primary-agent/Gnosis context is not leaked.',
 	});
 });
 

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -76,7 +76,7 @@ test("validateSubagentToolInput allows approved execution and forces fresh user 
 	assert.equal(batched.context, "fresh");
 });
 
-test("validateSubagentToolInput allows approved management calls and forces user scope where needed", () => {
+test("validateSubagentToolInput allows approved management calls and normalizes safe resume controls", () => {
 	const list = { action: "list" };
 	assertAllowed(list);
 	assert.equal(list.agentScope, "user");
@@ -93,13 +93,22 @@ test("validateSubagentToolInput allows approved management calls and forces user
 	assertAllowed(getBoth);
 	assert.equal(getBoth.agentScope, "user");
 
+	const resume = { action: "resume", id: "run-123", message: "Continue with the approved ticket.", agentScope: "", context: "" };
+	assertAllowed(resume);
+	assert.equal(resume.agentScope, "user");
+	assert.equal(resume.context, "fresh");
+
+	const resumeBoth = { action: "resume", id: "run-456", message: "Continue with the approved ticket.", agentScope: "both" };
+	assertAllowed(resumeBoth);
+	assert.equal(resumeBoth.agentScope, "user");
+	assert.equal(resumeBoth.context, "fresh");
+
 	for (const action of ["status", "interrupt", "doctor"]) {
 		assertAllowed({ action });
 	}
 });
 
-test("validateSubagentToolInput blocks unsafe actions and non-user scopes", () => {
-	assert.match(validateSubagentToolInput({ action: "resume" }), /may not use subagent management action 'resume'/);
+test("validateSubagentToolInput blocks unsafe actions, unsafe resume inputs, and non-user scopes", () => {
 	assert.match(validateSubagentToolInput({ action: "delete" }), /may not use subagent management action 'delete'/);
 	assert.match(validateSubagentToolInput({ agent: "developer", agentScope: "both" }), /may not use agentScope: "both"/);
 	assert.match(validateSubagentToolInput({ agent: "developer", agentScope: "project" }), /may not use agentScope: "project"/);
@@ -108,12 +117,17 @@ test("validateSubagentToolInput blocks unsafe actions and non-user scopes", () =
 	assert.match(validateSubagentToolInput({ action: "list", agentScope: "project" }), /may not use agentScope: "project"/);
 	assert.match(validateSubagentToolInput({ action: "list", agentScope: "system" }), /may not use agentScope: "system"/);
 	assert.match(validateSubagentToolInput({ action: "get", agentScope: "invalid" }), /may not use agentScope: "invalid"/);
+	assert.match(validateSubagentToolInput({ action: "resume", agentScope: "project" }), /resume calls may not use agentScope: "project"/);
+	assert.match(validateSubagentToolInput({ action: "resume", agentScope: "system" }), /resume calls may not use agentScope: "system"/);
+	assert.match(validateSubagentToolInput({ action: "resume", agentScope: "invalid" }), /resume calls may not use agentScope: "invalid"/);
+	assert.match(validateSubagentToolInput({ action: "resume", context: "resume" }), /subagent resume may not use context: "resume"/);
+	assert.match(validateSubagentToolInput({ action: "resume", context: 1 }), /subagent resume must use context: "fresh"/);
 });
 
 test("validateSubagentToolInput uses generic primary-agent wording", () => {
 	const reasons = [
 		validateSubagentToolInput(null),
-		validateSubagentToolInput({ action: "resume" }),
+		validateSubagentToolInput({ action: "delete" }),
 		validateSubagentToolInput({ agent: "developer", context: "resume" }),
 	].filter(Boolean);
 
@@ -138,6 +152,8 @@ test("validateSubagentToolInput rejects disallowed agents", () => {
 test("validateSubagentToolInput rejects non-fresh top-level and nested contexts", () => {
 	assert.match(validateSubagentToolInput({ agent: "developer", context: "resume" }), /may not use context: "resume"/);
 	assert.match(validateSubagentToolInput({ agent: "developer", context: 1 }), /must use context: "fresh"/);
+	assert.match(validateSubagentToolInput({ action: "resume", context: "resume" }), /subagent resume may not use context: "resume"/);
+	assert.match(validateSubagentToolInput({ action: "resume", context: 1 }), /subagent resume must use context: "fresh"/);
 
 	assert.match(
 		validateSubagentToolInput({ tasks: [{ agent: "developer", context: "resume" }] }),


### PR DESCRIPTION
## Summary
- add safe primary-agent `subagent({ action: "resume" })` support
- bump the bundled `pi-subagents` default pin to `tlh-v0.26.0-10`
- validation: `npm run validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved completion-guard issues causing false positives in version control and pull request processing.

* **New Features**
  * Introduced support for the "resume" subagent management action with enhanced validation and safety mechanisms.
  * Clarified subagent management action documentation in system prompts, detailing parameter usage and expected defaults for all supported actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->