### PR TITLE
Add architect tk command reference

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -61,6 +61,17 @@ Before implementation:
 
 ## Planning and task tracking
 
+Common `tk` command reference:
+
+- `tk show <id>`: inspect a ticket before delegation, correction, or closure decisions.
+- `tk close <id>`: close a ticket only after its intent is met.
+- `tk create ...`: create a reviewable ticket with concise description and acceptance criteria.
+- `tk ready`: pick the next dependency-unblocked ticket.
+- `tk dep <id> <dep-id>`: add a dependency edge between tickets.
+- `tk help`: check CLI usage when command syntax or behavior is unclear.
+- `tk start <id>`: mark a ticket in progress when actively taking it on.
+- `tk dep tree [--full] <id>`: inspect a ticket's dependency tree; use `--full` when deeper context helps.
+
 After approval:
 
 1. Create a small dependency tree of `tk` tickets that breaks the work into reviewable slices.


### PR DESCRIPTION
## Summary
- Add a concise common `tk` command reference to the TLH architect instructions.
- Document only the eight validated commands from the two-week usage analysis.
- Preserve the existing approval, ticketing, delegation, and validation workflow semantics.

## Validation
- `node --test tests/agent-prompt-contracts.test.mjs tests/architect-prompt-routing.test.mjs` — passed (17/17)

## Install this branch
```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/add-architect-tk-command-reference/install.sh | bash -s -- --ref add-architect-tk-command-reference --track ref
```
