### PR TITLE
Make queueing, not steering, the default for user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+- TLH now uses queue-first active-turn editor defaults in its isolated profile: while the agent is active, Enter queues follow-ups by default, Alt/Option+Enter steers or interjects, and Enter still submits normally once the agent is idle again.
 - Bundled the updated `pi-subagents` tag with the completion-guard fix for VCS/PR false positives.
 
 ## [0.20.0] - 2026-06-15

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ TLH also aims to make the day-to-day session experience calmer and safer:
 
 - isolated profile installation so your normal Pi setup stays separate,
 - quieter UI defaults so tools and bash output do not constantly fight for attention,
+- queue-first active-turn input defaults so, while the agent is active, Enter queues a follow-up by default and Alt/Option+Enter steers or interjects; when idle, Enter still submits normally,
 - a lightweight first-party `/annotate-last-message` command that opens a native annotation window for the latest assistant reply and turns submitted notes into agent feedback,
 - a first-party `/annotate-git-diff` command that opens a native review window and pastes submitted feedback back into the editor as a prompt,
 - bundled web-search support for research-heavy work,

--- a/config/keybindings.defaults.json
+++ b/config/keybindings.defaults.json
@@ -1,3 +1,4 @@
 {
+  "app.message.followUp": "enter",
   "app.thinking.cycle": []
 }

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -9,7 +9,7 @@ import { registerTlhChangelogCommand } from "./the-last-harness/changelog.js";
 import { registerEffortCommand } from "./the-last-harness/effort.js";
 import { registerExperimentalCommand } from "./the-last-harness/experimental.js";
 import { registerReviewCommand } from "./the-last-harness/review.js";
-import { TlhActiveTurnEditor } from "./the-last-harness/active-turn-controls.js";
+import { createTlhActiveTurnEditorFactory } from "./the-last-harness/active-turn-controls.js";
 import { createTlhFooter } from "./the-last-harness/footer.js";
 import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
@@ -108,7 +108,8 @@ export default function theLastHarness(pi: ExtensionAPI) {
 		}
 
 		ctx.ui.addAutocompleteProvider(createTlhAutocompleteProvider);
-		ctx.ui.setEditorComponent((tui, theme, keybindings) => new TlhActiveTurnEditor(tui, theme, keybindings, () => ctx.isIdle()));
+		const previousEditorFactory = ctx.ui.getEditorComponent?.();
+		ctx.ui.setEditorComponent(createTlhActiveTurnEditorFactory(previousEditorFactory, () => ctx.isIdle()));
 
 		let resources: StartupResources = { context: [], skills: [], prompts: [], extensions: [], themes: [] };
 		try {

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -9,6 +9,7 @@ import { registerTlhChangelogCommand } from "./the-last-harness/changelog.js";
 import { registerEffortCommand } from "./the-last-harness/effort.js";
 import { registerExperimentalCommand } from "./the-last-harness/experimental.js";
 import { registerReviewCommand } from "./the-last-harness/review.js";
+import { TlhActiveTurnEditor } from "./the-last-harness/active-turn-controls.js";
 import { createTlhFooter } from "./the-last-harness/footer.js";
 import { FooterGitCache } from "./the-last-harness/footer-git-cache.js";
 import { createTlhHeader } from "./the-last-harness/header.js";
@@ -107,6 +108,7 @@ export default function theLastHarness(pi: ExtensionAPI) {
 		}
 
 		ctx.ui.addAutocompleteProvider(createTlhAutocompleteProvider);
+		ctx.ui.setEditorComponent((tui, theme, keybindings) => new TlhActiveTurnEditor(tui, theme, keybindings, () => ctx.isIdle()));
 
 		let resources: StartupResources = { context: [], skills: [], prompts: [], extensions: [], themes: [] };
 		try {

--- a/extensions/the-last-harness/active-turn-controls.ts
+++ b/extensions/the-last-harness/active-turn-controls.ts
@@ -59,8 +59,12 @@ function shouldUseIdleEnterSubmitPath(
 	);
 }
 
-export function shouldRouteAltEnterToSubmit(keybindings: Pick<KeybindingsManager, "getKeys">, data: string) {
-	return usesSwappedTlhActiveTurnControls(keybindings) && matchesKey(data, TLH_ACTIVE_TURN_STEER_KEY);
+export function shouldRouteAltEnterToSubmit(
+	keybindings: Pick<KeybindingsManager, "getKeys">,
+	isIdle: boolean,
+	data: string,
+) {
+	return !isIdle && usesSwappedTlhActiveTurnControls(keybindings) && matchesKey(data, TLH_ACTIVE_TURN_STEER_KEY);
 }
 
 export class TlhActiveTurnEditor extends CustomEditor {
@@ -154,7 +158,7 @@ export class TlhActiveTurnEditor extends CustomEditor {
 			return;
 		}
 
-		if (!shouldRouteAltEnterToSubmit(this.tlhKeybindings, data)) {
+		if (!shouldRouteAltEnterToSubmit(this.tlhKeybindings, this.tlhIsIdle(), data)) {
 			super.handleInput(data);
 			return;
 		}

--- a/extensions/the-last-harness/active-turn-controls.ts
+++ b/extensions/the-last-harness/active-turn-controls.ts
@@ -1,5 +1,5 @@
-import { CustomEditor, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
-import { Editor, matchesKey, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
+import { CustomEditor, type EditorFactory, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { Editor, matchesKey, type EditorComponent, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
 
 const TLH_ACTIVE_TURN_QUEUE_KEY = "enter";
 const TLH_ACTIVE_TURN_STEER_KEY = "alt+enter";
@@ -65,6 +65,169 @@ export function shouldRouteAltEnterToSubmit(
 	data: string,
 ) {
 	return !isIdle && usesSwappedTlhActiveTurnControls(keybindings) && matchesKey(data, TLH_ACTIVE_TURN_STEER_KEY);
+}
+
+type TlhComposableEditor = EditorComponent & {
+	actionHandlers?: Map<string, () => void>;
+	onEscape?: () => void;
+	onCtrlD?: () => void;
+	onPasteImage?: () => void;
+	onExtensionShortcut?: (data: string) => boolean;
+	isShowingAutocomplete?: () => boolean;
+};
+
+function hasActionHandlers(editor: TlhComposableEditor): editor is TlhComposableEditor & { actionHandlers: Map<string, () => void> } {
+	return editor.actionHandlers instanceof Map;
+}
+
+function isShowingAutocomplete(editor: TlhComposableEditor): boolean {
+	return editor.isShowingAutocomplete?.() ?? false;
+}
+
+function hasIdleEnterAppActionBeforeFollowUp(
+	editor: TlhComposableEditor,
+	keybindings: Pick<KeybindingsManager, "matches">,
+	data: string,
+): boolean {
+	if (keybindings.matches(data, "app.clipboard.pasteImage")) {
+		return true;
+	}
+
+	if (keybindings.matches(data, "app.interrupt") && !isShowingAutocomplete(editor)) {
+		return true;
+	}
+
+	if (keybindings.matches(data, "app.exit") && editor.getText().length === 0) {
+		return true;
+	}
+
+	if (!hasActionHandlers(editor)) {
+		return false;
+	}
+
+	for (const action of editor.actionHandlers.keys()) {
+		if (action === "app.interrupt" || action === "app.exit") {
+			continue;
+		}
+
+		if (action === "app.message.followUp") {
+			break;
+		}
+
+		if (keybindings.matches(data, action)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function isUpstreamEditor(editor: EditorComponent): editor is TlhComposableEditor & Editor {
+	const candidate = editor as Partial<Editor> & {
+		state?: { lines?: unknown; cursorLine?: unknown; cursorCol?: unknown };
+	};
+
+	return (
+		typeof candidate.submitValue === "function" &&
+		typeof candidate.addNewLine === "function" &&
+		typeof candidate.handleBackspace === "function" &&
+		typeof candidate.isShowingAutocomplete === "function" &&
+		typeof candidate.requestAutocomplete === "function" &&
+		Array.isArray(candidate.state?.lines) &&
+		typeof candidate.state?.cursorLine === "number" &&
+		typeof candidate.state?.cursorCol === "number"
+	);
+}
+
+function handleComposedEditorPriorityInput(
+	editor: TlhComposableEditor,
+	keybindings: Pick<KeybindingsManager, "matches">,
+	data: string,
+): boolean {
+	if (editor.onExtensionShortcut?.(data)) {
+		return true;
+	}
+
+	if (keybindings.matches(data, "app.clipboard.pasteImage")) {
+		editor.onPasteImage?.();
+		return true;
+	}
+
+	if (keybindings.matches(data, "app.interrupt")) {
+		if (!isShowingAutocomplete(editor)) {
+			const handler = editor.onEscape ?? (hasActionHandlers(editor) ? editor.actionHandlers.get("app.interrupt") : undefined);
+			if (handler) {
+				handler();
+				return true;
+			}
+		}
+		Editor.prototype.handleInput.call(editor, data);
+		return true;
+	}
+
+	if (keybindings.matches(data, "app.exit")) {
+		if (editor.getText().length === 0) {
+			const handler = editor.onCtrlD ?? (hasActionHandlers(editor) ? editor.actionHandlers.get("app.exit") : undefined);
+			handler?.();
+			return true;
+		}
+		Editor.prototype.handleInput.call(editor, data);
+		return true;
+	}
+
+	if (!hasActionHandlers(editor)) {
+		return false;
+	}
+
+	for (const [action, handler] of editor.actionHandlers) {
+		if (action !== "app.interrupt" && action !== "app.exit" && keybindings.matches(data, action)) {
+			handler();
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function createTlhActiveTurnEditorFactory(
+	previousEditorFactory: EditorFactory | undefined,
+	isIdle: () => boolean,
+): EditorFactory {
+	return (tui, theme, keybindings) => {
+		if (!previousEditorFactory) {
+			return new TlhActiveTurnEditor(tui, theme, keybindings, isIdle);
+		}
+
+		const previousEditor = previousEditorFactory(tui, theme, keybindings);
+		if (!isUpstreamEditor(previousEditor)) {
+			return previousEditor;
+		}
+
+		const previousHandleInput = previousEditor.handleInput.bind(previousEditor);
+
+		previousEditor.handleInput = (data: string) => {
+			if (
+				shouldUseIdleEnterSubmitPath(keybindings, isIdle, data) &&
+				!hasIdleEnterAppActionBeforeFollowUp(previousEditor, keybindings, data)
+			) {
+				Editor.prototype.handleInput.call(previousEditor, data);
+				return;
+			}
+
+			if (!shouldRouteAltEnterToSubmit(keybindings, isIdle(), data)) {
+				previousHandleInput(data);
+				return;
+			}
+
+			if (handleComposedEditorPriorityInput(previousEditor, keybindings, data)) {
+				return;
+			}
+
+			Editor.prototype.handleInput.call(previousEditor, "\r");
+		};
+
+		return previousEditor;
+	};
 }
 
 export class TlhActiveTurnEditor extends CustomEditor {

--- a/extensions/the-last-harness/active-turn-controls.ts
+++ b/extensions/the-last-harness/active-turn-controls.ts
@@ -1,0 +1,168 @@
+import { CustomEditor, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { Editor, matchesKey, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
+
+const TLH_ACTIVE_TURN_QUEUE_KEY = "enter";
+const TLH_ACTIVE_TURN_STEER_KEY = "alt+enter";
+
+function hasKey(keys: readonly string[], expectedKey: string) {
+	return keys.some((key) => key.toLowerCase() === expectedKey);
+}
+
+function formatKeyText(key: string) {
+	return key
+		.split("/")
+		.map((binding) =>
+			binding
+				.split("+")
+				.map((part) => (process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part))
+				.join("+"),
+		)
+		.join("/");
+}
+
+function formatKeys(keys: readonly string[], fallback: string) {
+	return keys.length > 0 ? formatKeyText(keys.join("/")) : fallback;
+}
+
+export function usesSwappedTlhActiveTurnControls(keybindings: Pick<KeybindingsManager, "getKeys">) {
+	const followUpKeys = keybindings.getKeys("app.message.followUp").map((key) => key.toLowerCase());
+	return hasKey(followUpKeys, TLH_ACTIVE_TURN_QUEUE_KEY) && !hasKey(followUpKeys, TLH_ACTIVE_TURN_STEER_KEY);
+}
+
+export function getTlhActiveTurnHintKeys(keybindings: Pick<KeybindingsManager, "getKeys">) {
+	if (usesSwappedTlhActiveTurnControls(keybindings)) {
+		const queueKeys = keybindings.getKeys("app.message.followUp");
+		return {
+			queueKey: formatKeys(queueKeys, TLH_ACTIVE_TURN_QUEUE_KEY),
+			steerKey: formatKeyText(TLH_ACTIVE_TURN_STEER_KEY),
+			swapped: true,
+		};
+	}
+
+	return {
+		queueKey: formatKeys(keybindings.getKeys("app.message.followUp"), "alt+enter"),
+		steerKey: formatKeys(keybindings.getKeys("tui.input.submit"), "enter"),
+		swapped: false,
+	};
+}
+
+function shouldUseIdleEnterSubmitPath(
+	keybindings: Pick<KeybindingsManager, "getKeys" | "matches">,
+	isIdle: () => boolean,
+	data: string,
+) {
+	return (
+		usesSwappedTlhActiveTurnControls(keybindings) &&
+		isIdle() &&
+		matchesKey(data, TLH_ACTIVE_TURN_QUEUE_KEY) &&
+		keybindings.matches(data, "app.message.followUp")
+	);
+}
+
+export function shouldRouteAltEnterToSubmit(keybindings: Pick<KeybindingsManager, "getKeys">, data: string) {
+	return usesSwappedTlhActiveTurnControls(keybindings) && matchesKey(data, TLH_ACTIVE_TURN_STEER_KEY);
+}
+
+export class TlhActiveTurnEditor extends CustomEditor {
+	private readonly tlhKeybindings: KeybindingsManager;
+	private readonly tlhIsIdle: () => boolean;
+
+	constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, isIdle: () => boolean = () => false) {
+		super(tui, theme, keybindings);
+		this.tlhKeybindings = keybindings;
+		this.tlhIsIdle = isIdle;
+	}
+
+	private hasIdleEnterAppActionBeforeFollowUp(data: string): boolean {
+		if (this.tlhKeybindings.matches(data, "app.clipboard.pasteImage")) {
+			return true;
+		}
+
+		if (this.tlhKeybindings.matches(data, "app.interrupt") && !this.isShowingAutocomplete()) {
+			return true;
+		}
+
+		if (this.tlhKeybindings.matches(data, "app.exit") && this.getText().length === 0) {
+			return true;
+		}
+
+		for (const action of this.actionHandlers.keys()) {
+			if (action === "app.interrupt" || action === "app.exit") {
+				continue;
+			}
+
+			if (action === "app.message.followUp") {
+				break;
+			}
+
+			if (this.tlhKeybindings.matches(data, action)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private handleCustomEditorPriorityInput(data: string): boolean {
+		if (this.onExtensionShortcut?.(data)) {
+			return true;
+		}
+
+		if (this.tlhKeybindings.matches(data, "app.clipboard.pasteImage")) {
+			this.onPasteImage?.();
+			return true;
+		}
+
+		if (this.tlhKeybindings.matches(data, "app.interrupt")) {
+			if (!this.isShowingAutocomplete()) {
+				const handler = this.onEscape ?? this.actionHandlers.get("app.interrupt");
+				if (handler) {
+					handler();
+					return true;
+				}
+			}
+			Editor.prototype.handleInput.call(this, data);
+			return true;
+		}
+
+		if (this.tlhKeybindings.matches(data, "app.exit")) {
+			if (this.getText().length === 0) {
+				const handler = this.onCtrlD ?? this.actionHandlers.get("app.exit");
+				handler?.();
+				return true;
+			}
+			Editor.prototype.handleInput.call(this, data);
+			return true;
+		}
+
+		for (const [action, handler] of this.actionHandlers) {
+			if (action !== "app.interrupt" && action !== "app.exit" && this.tlhKeybindings.matches(data, action)) {
+				handler();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	override handleInput(data: string): void {
+		if (
+			shouldUseIdleEnterSubmitPath(this.tlhKeybindings, this.tlhIsIdle, data) &&
+			!this.hasIdleEnterAppActionBeforeFollowUp(data)
+		) {
+			Editor.prototype.handleInput.call(this, data);
+			return;
+		}
+
+		if (!shouldRouteAltEnterToSubmit(this.tlhKeybindings, data)) {
+			super.handleInput(data);
+			return;
+		}
+
+		if (this.handleCustomEditorPriorityInput(data)) {
+			return;
+		}
+
+		Editor.prototype.handleInput.call(this, "\r");
+	}
+}

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -1,12 +1,12 @@
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { getKeybindings, truncateToWidth } from "@earendil-works/pi-tui";
 import {
-	keyText,
 	type ExtensionAPI,
 	type ExtensionContext,
 	type ReadonlyFooterDataProvider,
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
+import { getTlhActiveTurnHintKeys } from "./active-turn-controls.js";
 import { DEFAULT_PRIMARY_AGENT } from "../the-last-harness-primary-agent.mjs";
 import { formatCompactTokenCount, formatHomePath, sanitizeStatusText } from "./common.js";
 import type { FooterGitCache } from "./footer-git-cache.js";
@@ -129,11 +129,13 @@ export function createTlhFooter(
 			// Hint line (conditional on pending editor text during an active turn)
 			const editorText = ctx.ui.getEditorText();
 			if (editorText.length > 0 && !ctx.isIdle()) {
-				const steerKey = keyText("tui.input.submit") || "enter";
-				const queueKey = keyText("app.message.followUp") || "alt+enter";
+				const { queueKey, steerKey, swapped } = getTlhActiveTurnHintKeys(getKeybindings());
 				const steeringHint = `${theme.fg("dim", steerKey)}${theme.fg("muted", " steer")}`;
 				const queueHint = `${theme.fg("dim", queueKey)}${theme.fg("muted", " queue follow-up")}`;
-				lines.push(truncateToWidth(`${steeringHint}${theme.fg("muted", " · ")}${queueHint}`, width, theme.fg("dim", "...")));
+				const hintText = swapped
+					? `${queueHint}${theme.fg("muted", " · ")}${steeringHint}`
+					: `${steeringHint}${theme.fg("muted", " · ")}${queueHint}`;
+				lines.push(truncateToWidth(hintText, width, theme.fg("dim", "...")));
 			}
 
 			// Extension status line (conditional on registered extension statuses)

--- a/scripts/merge-keybindings.mjs
+++ b/scripts/merge-keybindings.mjs
@@ -89,7 +89,10 @@ function clone(value) {
 	return JSON.parse(JSON.stringify(value));
 }
 
-const legacyKeybindingOwners = new Map([["app.thinking.cycle", ["cycleThinkingLevel"]]]);
+const legacyKeybindingOwners = new Map([
+	["app.message.followUp", ["followUp"]],
+	["app.thinking.cycle", ["cycleThinkingLevel"]],
+]);
 
 function hasExistingKeybindingOwner(keybindings, key) {
 	if (Object.hasOwn(keybindings, key)) return true;

--- a/tests/keybindings-merge.test.mjs
+++ b/tests/keybindings-merge.test.mjs
@@ -41,8 +41,11 @@ function symlinkFile(target, path) {
 	symlinkSync(target, path);
 }
 
-test("packaged keybinding defaults disable app.thinking.cycle", () => {
-	assert.deepEqual(readJson(keybindingDefaults), { "app.thinking.cycle": [] });
+test("packaged keybinding defaults swap active-turn follow-up to Enter and disable app.thinking.cycle", () => {
+	assert.deepEqual(readJson(keybindingDefaults), {
+		"app.message.followUp": "enter",
+		"app.thinking.cycle": [],
+	});
 });
 
 test("merge sets missing defaults, preserves existing keys, and backs up existing keybindings", () => {
@@ -55,6 +58,7 @@ test("merge sets missing defaults, preserves existing keys, and backs up existin
 	assert.equal(output, "");
 	assert.deepEqual(readJson(fixture.keybindings), {
 		"app.open": ["ctrl+o"],
+		"app.message.followUp": "enter",
 		"app.thinking.cycle": [],
 	});
 	const backups = backupFiles(fixture.agentDir);
@@ -93,9 +97,12 @@ test("merge rejects symlinked keybindings targets before creating backups", () =
 	assert.deepEqual(backupFiles(fixture.agentDir), []);
 });
 
-test("merge keeps a user-owned value for an existing default key", () => {
+test("merge keeps user-owned values for existing default keys", () => {
 	const fixture = tempFixture();
-	const original = { "app.thinking.cycle": ["shift+tab"] };
+	const original = {
+		"app.message.followUp": ["ctrl+j"],
+		"app.thinking.cycle": ["shift+tab"],
+	};
 	writeFileSync(fixture.keybindings, JSON.stringify(original, null, 2));
 
 	const output = runMerge(["--quiet"], fixture.agentDir);
@@ -113,6 +120,26 @@ test("merge treats legacy cycleThinkingLevel as user-owned app.thinking.cycle", 
 	const output = runMerge(["--quiet"], fixture.agentDir);
 
 	assert.equal(output, "");
+	assert.deepEqual(readJson(fixture.keybindings), {
+		...original,
+		"app.message.followUp": "enter",
+	});
+	const backups = backupFiles(fixture.agentDir);
+	assert.equal(backups.length, 1);
+	assert.deepEqual(readJson(join(fixture.agentDir, backups[0])), original);
+});
+
+test("merge treats legacy followUp as user-owned app.message.followUp", () => {
+	const fixture = tempFixture();
+	const original = {
+		followUp: ["ctrl+j"],
+		cycleThinkingLevel: ["ctrl+shift+t"],
+	};
+	writeFileSync(fixture.keybindings, JSON.stringify(original, null, 2));
+
+	const output = runMerge(["--quiet"], fixture.agentDir);
+
+	assert.equal(output, "");
 	assert.deepEqual(readJson(fixture.keybindings), original);
 	assert.deepEqual(backupFiles(fixture.agentDir), []);
 });
@@ -122,6 +149,7 @@ test("dry-run reports changes without writing keybindings", () => {
 
 	const output = runMerge(["--dry-run"], fixture.agentDir);
 
+	assert.match(output, /Would set app\.message\.followUp/);
 	assert.match(output, /Would set app\.thinking\.cycle/);
 	assert.match(output, /Dry run only/);
 	assert.equal(existsSync(fixture.keybindings), false);

--- a/tests/the-last-harness-active-turn-controls.test.mjs
+++ b/tests/the-last-harness-active-turn-controls.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { KeybindingsManager, getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { KEYBINDINGS } from "../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { createTlhFooter } = await jiti.import("../extensions/the-last-harness/footer.ts");
+const {
+	TlhActiveTurnEditor,
+	shouldRouteAltEnterToSubmit,
+	usesSwappedTlhActiveTurnControls,
+} = await jiti.import("../extensions/the-last-harness/active-turn-controls.ts");
+
+const theme = {
+	fg: (_color, text) => text,
+};
+
+const editorTheme = {
+	borderColor: (text) => text,
+	selectList: {},
+};
+
+const footerData = {
+	getGitBranch: () => undefined,
+	getAvailableProviderCount: () => 1,
+	getExtensionStatuses: () => new Map(),
+};
+
+const pi = {
+	getThinkingLevel: () => "medium",
+};
+
+function createFooterCtx() {
+	return {
+		hasUI: true,
+		cwd: "/tmp/the-last-harness",
+		model: {
+			provider: "anthropic",
+			id: "claude-sonnet-4-20250514",
+			contextWindow: 200000,
+		},
+		sessionManager: {
+			getEntries: () => [],
+			getCwd: () => "/tmp/the-last-harness",
+			getSessionName: () => undefined,
+		},
+		getContextUsage: () => ({ tokens: 1000, contextWindow: 200000, percent: 12.3 }),
+		ui: {
+			getEditorText: () => "Keep going",
+		},
+		isIdle: () => false,
+	};
+}
+
+async function withKeybindings(config, fn) {
+	const previous = getKeybindings();
+	const next = new KeybindingsManager(KEYBINDINGS, config);
+	setKeybindings(next);
+	try {
+		return await fn(next);
+	} finally {
+		setKeybindings(previous);
+	}
+}
+
+function createEditor(keybindings, isIdle = () => false) {
+	return new TlhActiveTurnEditor({ requestRender() {} }, editorTheme, keybindings, isIdle);
+}
+
+function createSlashAutocompleteProvider() {
+	return {
+		async getSuggestions() {
+			return {
+				prefix: "/rev",
+				items: [
+					{ value: "/review", label: "/review" },
+					{ value: "/revert", label: "/revert" },
+				],
+			};
+		},
+		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+			const currentLine = lines[cursorLine] ?? "";
+			return {
+				lines: [currentLine.slice(0, cursorCol - prefix.length) + item.value + currentLine.slice(cursorCol)],
+				cursorLine,
+				cursorCol: cursorCol - prefix.length + item.value.length,
+			};
+		},
+	};
+}
+
+async function flushEditorTasks() {
+	await new Promise((resolve) => setImmediate(resolve));
+	await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("active-turn footer hint shows Enter queue before Alt+Enter steer for TLH defaults", { concurrency: false }, async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async () => {
+		const footer = createTlhFooter(pi, createFooterCtx(), theme, () => "architect", footerData, {});
+		const altLabel = process.platform === "darwin" ? "option+enter" : "alt+enter";
+		assert.equal(footer.render(120).at(-1), `enter queue follow-up · ${altLabel} steer`);
+	});
+});
+
+test("idle Enter uses the normal editor submit path and confirms slash autocomplete before submitting", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings, () => true);
+		let followUpCalls = 0;
+		let submitted;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.onAction("app.message.followUp", () => {
+			followUpCalls += 1;
+			const text = (editor.getExpandedText?.() ?? editor.getText()).trim();
+			if (!text) {
+				return;
+			}
+			editor.setText("");
+			editor.onSubmit?.(text);
+		});
+		editor.setAutocompleteProvider(createSlashAutocompleteProvider());
+		editor.setText("/rev");
+		editor.requestAutocomplete({ force: true, explicitTab: false });
+		await flushEditorTasks();
+
+		assert.equal(editor.isShowingAutocomplete(), true);
+
+		editor.handleInput("\r");
+
+		assert.equal(followUpCalls, 0);
+		assert.equal(submitted, "/review");
+		assert.equal(editor.getText(), "");
+	});
+});
+
+test("idle Enter defers to empty-editor app.exit before bypassing follow-up", async () => {
+	await withKeybindings({ "app.message.followUp": "enter", "app.exit": "enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings, () => true);
+		let exitCalls = 0;
+		let followUpCalls = 0;
+		let submitted;
+		editor.onCtrlD = () => {
+			exitCalls += 1;
+		};
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.onAction("app.message.followUp", () => {
+			followUpCalls += 1;
+		});
+
+		editor.handleInput("\r");
+
+		assert.equal(exitCalls, 1);
+		assert.equal(followUpCalls, 0);
+		assert.equal(submitted, undefined);
+	});
+});
+
+test("active-turn editor routes Alt+Enter through the normal submit path when TLH defaults swap follow-up to Enter", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings);
+		let submitted;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.setText("/review --help");
+
+		editor.handleInput("\x1b\r");
+
+		assert.equal(submitted, "/review --help");
+		assert.equal(editor.getText(), "");
+	});
+});
+
+test("active-turn steering defers to extension shortcuts before Alt+Enter submit", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings);
+		let shortcutCalls = 0;
+		let submitted;
+		editor.onExtensionShortcut = (data) => {
+			shortcutCalls += 1;
+			assert.equal(data, "\x1b\r");
+			return true;
+		};
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.setText("/review --help");
+
+		editor.handleInput("\x1b\r");
+
+		assert.equal(shortcutCalls, 1);
+		assert.equal(submitted, undefined);
+		assert.equal(editor.getText(), "/review --help");
+	});
+});
+
+test("active-turn steering defers to special app bindings before Alt+Enter submit", async () => {
+	await withKeybindings({ "app.message.followUp": "enter", "app.exit": "alt+enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings);
+		let exitCalls = 0;
+		let submitted;
+		editor.onCtrlD = () => {
+			exitCalls += 1;
+		};
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		editor.handleInput("\x1b\r");
+
+		assert.equal(exitCalls, 1);
+		assert.equal(submitted, undefined);
+	});
+});
+
+test("active-turn steering override stays disabled when a user owns a different follow-up binding", () => {
+	const keybindings = new KeybindingsManager(KEYBINDINGS, { "app.message.followUp": "ctrl+j" });
+
+	assert.equal(usesSwappedTlhActiveTurnControls(keybindings), false);
+	assert.equal(shouldRouteAltEnterToSubmit(keybindings, "\x1b\r"), false);
+});

--- a/tests/the-last-harness-active-turn-controls.test.mjs
+++ b/tests/the-last-harness-active-turn-controls.test.mjs
@@ -160,6 +160,22 @@ test("idle Enter defers to empty-editor app.exit before bypassing follow-up", as
 	});
 });
 
+test("idle Alt+Enter preserves upstream newline insertion when TLH defaults swap follow-up to Enter", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		const editor = createEditor(keybindings, () => true);
+		let submitted;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.setText("/review --help");
+
+		editor.handleInput("\x1b\r");
+
+		assert.equal(submitted, undefined);
+		assert.equal(editor.getText(), "/review --help\n");
+	});
+});
+
 test("active-turn editor routes Alt+Enter through the normal submit path when TLH defaults swap follow-up to Enter", async () => {
 	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
 		const editor = createEditor(keybindings);
@@ -178,6 +194,9 @@ test("active-turn editor routes Alt+Enter through the normal submit path when TL
 
 test("active-turn steering defers to extension shortcuts before Alt+Enter submit", async () => {
 	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		assert.equal(shouldRouteAltEnterToSubmit(keybindings, false, "\x1b\r"), true);
+		assert.equal(shouldRouteAltEnterToSubmit(keybindings, true, "\x1b\r"), false);
+
 		const editor = createEditor(keybindings);
 		let shortcutCalls = 0;
 		let submitted;
@@ -222,5 +241,5 @@ test("active-turn steering override stays disabled when a user owns a different 
 	const keybindings = new KeybindingsManager(KEYBINDINGS, { "app.message.followUp": "ctrl+j" });
 
 	assert.equal(usesSwappedTlhActiveTurnControls(keybindings), false);
-	assert.equal(shouldRouteAltEnterToSubmit(keybindings, "\x1b\r"), false);
+	assert.equal(shouldRouteAltEnterToSubmit(keybindings, false, "\x1b\r"), false);
 });

--- a/tests/the-last-harness-active-turn-controls.test.mjs
+++ b/tests/the-last-harness-active-turn-controls.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { CustomEditor } from "@earendil-works/pi-coding-agent";
 import { KeybindingsManager, getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
 import { KEYBINDINGS } from "../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js";
 import { createJiti } from "jiti";
@@ -9,6 +10,7 @@ const jiti = createJiti(import.meta.url);
 const { createTlhFooter } = await jiti.import("../extensions/the-last-harness/footer.ts");
 const {
 	TlhActiveTurnEditor,
+	createTlhActiveTurnEditorFactory,
 	shouldRouteAltEnterToSubmit,
 	usesSwappedTlhActiveTurnControls,
 } = await jiti.import("../extensions/the-last-harness/active-turn-controls.ts");
@@ -67,6 +69,51 @@ async function withKeybindings(config, fn) {
 
 function createEditor(keybindings, isIdle = () => false) {
 	return new TlhActiveTurnEditor({ requestRender() {} }, editorTheme, keybindings, isIdle);
+}
+
+class ExistingEditor extends CustomEditor {
+	handleInput(data) {
+		if (data === "!") {
+			this.insertTextAtCursor(" [custom]");
+			return;
+		}
+
+		super.handleInput(data);
+	}
+}
+
+class PlainEditorComponent {
+	constructor() {
+		this.text = "";
+		this.handledInputs = [];
+	}
+
+	render() {
+		return [];
+	}
+
+	invalidate() {}
+
+	getText() {
+		return this.text;
+	}
+
+	setText(text) {
+		this.text = text;
+		this.onChange?.(text);
+	}
+
+	handleInput(data) {
+		this.handledInputs.push(data);
+		if (data === "\r") {
+			this.setText(`${this.getText()} [enter]`);
+			return;
+		}
+
+		if (data === "\x1b\r") {
+			this.setText(`${this.getText()} [alt-enter]`);
+		}
+	}
 }
 
 function createSlashAutocompleteProvider() {
@@ -189,6 +236,66 @@ test("active-turn editor routes Alt+Enter through the normal submit path when TL
 
 		assert.equal(submitted, "/review --help");
 		assert.equal(editor.getText(), "");
+	});
+});
+
+test("existing editor factories are preserved while TLH active-turn routing is composed on top", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		const factory = createTlhActiveTurnEditorFactory(
+			(tui, theme, kb) => new ExistingEditor(tui, theme, kb),
+			() => false,
+		);
+		const editor = factory({ requestRender() {} }, editorTheme, keybindings);
+		let followUpCalls = 0;
+		let submitted;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.onAction("app.message.followUp", () => {
+			followUpCalls += 1;
+			const text = (editor.getExpandedText?.() ?? editor.getText()).trim();
+			if (!text) {
+				return;
+			}
+			editor.setText("");
+			editor.onSubmit?.(text);
+		});
+		editor.setText("Keep going");
+
+		assert.equal(editor instanceof ExistingEditor, true);
+
+		editor.handleInput("!");
+		assert.equal(editor.getText(), "Keep going [custom]");
+
+		editor.handleInput("\r");
+		assert.equal(followUpCalls, 1);
+		assert.equal(submitted, "Keep going [custom]");
+		assert.equal(editor.getText(), "");
+
+		editor.setText("/review --help");
+		editor.handleInput("\x1b\r");
+		assert.equal(submitted, "/review --help");
+		assert.equal(editor.getText(), "");
+	});
+});
+
+test("plain editor components keep their own handleInput behavior under TLH composition", async () => {
+	await withKeybindings({ "app.message.followUp": "enter" }, async (keybindings) => {
+		let idle = true;
+		const factory = createTlhActiveTurnEditorFactory(() => new PlainEditorComponent(), () => idle);
+		const editor = factory({ requestRender() {} }, editorTheme, keybindings);
+
+		assert.equal(editor instanceof PlainEditorComponent, true);
+
+		editor.setText("Keep going");
+		assert.doesNotThrow(() => editor.handleInput("\r"));
+		assert.deepEqual(editor.handledInputs, ["\r"]);
+		assert.equal(editor.getText(), "Keep going [enter]");
+
+		idle = false;
+		assert.doesNotThrow(() => editor.handleInput("\x1b\r"));
+		assert.deepEqual(editor.handledInputs, ["\r", "\x1b\r"]);
+		assert.equal(editor.getText(), "Keep going [enter] [alt-enter]");
 	});
 });
 

--- a/tests/the-last-harness-extension-startup-warning.test.mjs
+++ b/tests/the-last-harness-extension-startup-warning.test.mjs
@@ -92,6 +92,8 @@ function createCtx({ cwd, notifications, hasUI = true, onSetHeader, projectTrust
 		getContextUsage: () => undefined,
 		ui: {
 			addAutocompleteProvider() {},
+			setEditorComponent() {},
+			getEditorComponent: () => undefined,
 			setFooter() {},
 			setHeader(factory) {
 				onSetHeader?.(factory);

--- a/tests/the-last-harness-extension-usage-refresh.test.mjs
+++ b/tests/the-last-harness-extension-usage-refresh.test.mjs
@@ -67,6 +67,8 @@ function createCtx(options) {
 		getContextUsage: () => ({ tokens: 1000, contextWindow: 200000, percent: 12.3 }),
 		ui: {
 			addAutocompleteProvider() {},
+			setEditorComponent() {},
+			getEditorComponent: () => undefined,
 			setFooter(factory) {
 				factory({ requestRender: options.requestRender }, theme, footerData);
 			},


### PR DESCRIPTION
## Summary
- swap TLH active-turn defaults so Enter queues follow-ups during active turns while Alt/Option+Enter steers or interjects
- preserve normal idle Enter submit behavior via a custom editor path and update footer hints to match the active-turn controls
- update keybinding merge behavior, docs, changelog, and regression tests for the queue-first behavior
- keep idle Alt/Option+Enter on upstream newline behavior while active-turn Alt/Option+Enter still steers
- compose TLH active-turn routing with existing editor factories instead of clobbering prior custom editors

## Validation
- `npm run validate` — passed after the editor-composition review fix (673 tests)
- `node --test tests/the-last-harness-active-turn-controls.test.mjs tests/keybindings-merge.test.mjs` — passed
- `npx eslint extensions/the-last-harness/active-turn-controls.ts extensions/the-last-harness.ts tests/the-last-harness-active-turn-controls.test.mjs` — passed
- `git diff --check --cached` — passed before commit

Final review found no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new input behavior for active agent turns: pressing Enter now queues follow-ups by default while the agent is responding, Alt/Option+Enter allows steering or interjecting, and Enter returns to normal submit behavior once the agent becomes idle.

* **Chores**
  * Updated default keybinding configuration to support the new active-turn control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->