### PR TITLE
Make test validation quiet by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ Main repository validation:
 npm run validate
 ```
 
+That path inherits the default quiet `npm test` dot reporter. If you need the full Node test reporter while diagnosing a failure, rerun tests with:
+
+```sh
+npm run test:verbose
+```
+
 For installer-specific checks, use temporary paths, for example:
 
 ```sh

--- a/VALIDATING.md
+++ b/VALIDATING.md
@@ -10,7 +10,21 @@ Before considering changes ready, run:
 npm run validate
 ```
 
-This is the standard full validation flow for this repository.
+This is the standard full validation flow for this repository. Its test phase uses the quiet `npm test` dot reporter so passing runs stay concise.
+
+## Test output modes
+
+Use the default test command for normal local checks:
+
+```sh
+npm test
+```
+
+If you need the full Node test reporter while diagnosing a failure, rerun with:
+
+```sh
+npm run test:verbose
+```
 
 ## Useful targeted checks
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -10,7 +10,13 @@ Run the aggregate validation script, which covers the installer smoke checks, te
 npm run validate
 ```
 
-This default validation path stays deterministic and repo-local.
+This default validation path stays deterministic and repo-local. Its `npm test` step uses the quiet dot reporter for passing runs.
+
+When you need the full Node test reporter for diagnostics, rerun:
+
+```sh
+npm run test:verbose
+```
 
 ## Refresh the Understand Anything graph
 

--- a/docs/web-search-fork-release-cadence.md
+++ b/docs/web-search-fork-release-cadence.md
@@ -72,7 +72,9 @@ Follow these steps the next time a tag is rolled:
    - Bump `config/default-extensions.json` entry for `pi-web-access` (`source`) to the new tag.
    - Update `tests/default-extensions.test.mjs` to pin the new tag string.
 
-9. Run `npm run validate` in the TLH repo and fix any fallout.
+9. Run `npm run validate` in the TLH repo and fix any fallout. That TLH-repo validation flow uses
+   the quiet `npm test` dot reporter for passing runs; if you need the full Node test reporter while
+   diagnosing TLH-side failures, rerun `npm run test:verbose` in the TLH repo.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "lint": "eslint \"scripts/**/*.{js,mjs,ts}\" \"tests/**/*.{js,mjs,ts}\" \"extensions/**/*.{js,mjs,ts}\"",
-    "test": "node --test tests/*.test.mjs",
+    "test": "node --test --test-reporter=dot tests/*.test.mjs",
+    "test:verbose": "node --test tests/*.test.mjs",
     "validate": "bash scripts/check-installer-smoke.sh && npm test && npm run lint && node scripts/merge-settings.mjs --dry-run && npm pack --dry-run"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Make `npm test` use Node's dot reporter for concise passing output.
- Add `npm run test:verbose` for detailed diagnostics.
- Document the quiet default and verbose rerun path in validation/contributor docs.

## Validation
- `npm test`
- `npm run test:verbose`
- `npm run validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `npm run test:verbose` script for full test reporter output when diagnosing failures.

* **Documentation**
  * Updated contributor and development guides to document the concise dot reporter for `npm test` and when to use `npm run test:verbose` for detailed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->