### PR TITLE
Pin subagents default to tlh-v0.26.0-11

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -82,7 +82,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-10",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-11",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1006,7 +1006,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-10");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-11");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary
- subagents default pin updated to `tlh-v0.26.0-11`

## Validation
- `node --test tests/default-extensions.test.mjs` passed 35/35
- `npm run validate` is blocked by unrelated existing static test failure: `tests/the-last-harness-extension-static.test.mjs` / `editor.main.js content must be inlined`