### PR TITLE
Add estimated MCP/tool token footprint to /tokens report

### DIFF
--- a/extensions/the-last-harness/tokens-analyzer.ts
+++ b/extensions/the-last-harness/tokens-analyzer.ts
@@ -501,11 +501,11 @@ export function analyzeSessionEntries(
 			mcpProxyCalls,
 			mcpDirectCalls,
 			byTool: [...toolUsage.values()].sort(
-				(left, right) => right.callCount - left.callCount || right.resultCount - left.resultCount || left.toolName.localeCompare(right.toolName),
+				(left, right) => right.approxTokens - left.approxTokens || right.callCount - left.callCount || right.resultCount - left.resultCount || left.toolName.localeCompare(right.toolName),
 			),
 			mcpApproxTokens: [...toolUsage.values()].reduce((sum, tool) => (tool.mcp ? sum + tool.approxTokens : sum), 0),
-		totalToolApproxTokens: [...toolUsage.values()].reduce((sum, tool) => sum + tool.approxTokens, 0),
-		bySource: [...toolSourceUsage.values()]
+			totalToolApproxTokens: [...toolUsage.values()].reduce((sum, tool) => sum + tool.approxTokens, 0),
+			bySource: [...toolSourceUsage.values()]
 				.map((bucket) => ({
 					source: bucket.source,
 					callCount: bucket.callCount,

--- a/extensions/the-last-harness/tokens-analyzer.ts
+++ b/extensions/the-last-harness/tokens-analyzer.ts
@@ -1,6 +1,8 @@
 import type { ReadonlySessionManager, SessionEntry, ToolInfo } from "@earendil-works/pi-coding-agent";
 
 const BUILT_IN_TOOL_NAMES = new Set(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+/** Approximate characters per token used for tool-payload size estimates. */
+const CHARS_PER_TOKEN = 4;
 const SKIP_DISCOVERY_KEYS = new Set([
 	"content",
 	"messages",
@@ -71,6 +73,8 @@ export type TlhToolUsage = {
 	callCount: number;
 	resultCount: number;
 	errorCount: number;
+	/** Estimated tokens consumed by this tool's call arguments plus result content. */
+	approxTokens: number;
 	mcp: boolean;
 	source: TlhToolSourceEstimate;
 };
@@ -78,6 +82,8 @@ export type TlhToolUsage = {
 export type TlhToolSourceUsage = {
 	source: TlhToolSourceEstimate;
 	callCount: number;
+	/** Estimated tokens consumed by all tools in this source group. */
+	approxTokens: number;
 	tools: string[];
 };
 
@@ -169,6 +175,10 @@ export type TlhSessionUsageAnalysis = {
 		mcpCalls: number;
 		mcpProxyCalls: number;
 		mcpDirectCalls: number;
+		/** Estimated tokens across all MCP tool calls and results combined. */
+		mcpApproxTokens: number;
+		/** Estimated tokens across all tool calls and results combined. */
+		totalToolApproxTokens: number;
 		byTool: TlhToolUsage[];
 		bySource: TlhToolSourceUsage[];
 	};
@@ -244,7 +254,7 @@ export function analyzeSessionEntries(
 	const subagentTotals = createUsageTotals();
 	const modelUsage = new Map<string, TlhModelUsage>();
 	const toolUsage = new Map<string, TlhToolUsage>();
-	const toolSourceUsage = new Map<string, { source: TlhToolSourceEstimate; callCount: number; tools: Set<string> }>();
+	const toolSourceUsage = new Map<string, { source: TlhToolSourceEstimate; callCount: number; approxTokens: number; tools: Set<string> }>();
 	const subagentRuns = new Map<string, TlhDiscoveredSubagentRun>();
 	const sessionRefs = new Map<string, TlhSanitizedReference>();
 	const artifactRefs = new Map<string, TlhSanitizedReference>();
@@ -337,18 +347,23 @@ export function analyzeSessionEntries(
 						callCount: 0,
 						resultCount: 0,
 						errorCount: 0,
+						approxTokens: 0,
 						mcp: source.kind === "mcp-proxy" || source.kind === "mcp-direct",
 						source,
 					};
 					existing.callCount += 1;
+					const argApproxTokens = Math.ceil(safeArgChars(block.arguments) / CHARS_PER_TOKEN);
+					existing.approxTokens += argApproxTokens;
 					toolUsage.set(block.name, existing);
 
 					const sourceBucket = toolSourceUsage.get(source.key) ?? {
 						source,
 						callCount: 0,
+						approxTokens: 0,
 						tools: new Set<string>(),
 					};
 					sourceBucket.callCount += 1;
+					sourceBucket.approxTokens += argApproxTokens;
 					sourceBucket.tools.add(block.name);
 					toolSourceUsage.set(source.key, sourceBucket);
 
@@ -389,6 +404,7 @@ export function analyzeSessionEntries(
 				callCount: 0,
 				resultCount: 0,
 				errorCount: 0,
+				approxTokens: 0,
 				mcp: source.kind === "mcp-proxy" || source.kind === "mcp-direct",
 				source,
 			};
@@ -396,7 +412,13 @@ export function analyzeSessionEntries(
 			if (message.isError) {
 				existing.errorCount += 1;
 			}
+			const resultApproxTokens = Math.ceil(resultContentChars(message.content) / CHARS_PER_TOKEN);
+			existing.approxTokens += resultApproxTokens;
 			toolUsage.set(message.toolName, existing);
+			const resultSourceBucket = toolSourceUsage.get(source.key);
+			if (resultSourceBucket) {
+				resultSourceBucket.approxTokens += resultApproxTokens;
+			}
 		}
 
 		const discoveries = collectStructuredDiscoveries(message, {
@@ -481,10 +503,13 @@ export function analyzeSessionEntries(
 			byTool: [...toolUsage.values()].sort(
 				(left, right) => right.callCount - left.callCount || right.resultCount - left.resultCount || left.toolName.localeCompare(right.toolName),
 			),
-			bySource: [...toolSourceUsage.values()]
+			mcpApproxTokens: [...toolUsage.values()].reduce((sum, tool) => (tool.mcp ? sum + tool.approxTokens : sum), 0),
+		totalToolApproxTokens: [...toolUsage.values()].reduce((sum, tool) => sum + tool.approxTokens, 0),
+		bySource: [...toolSourceUsage.values()]
 				.map((bucket) => ({
 					source: bucket.source,
 					callCount: bucket.callCount,
+					approxTokens: bucket.approxTokens,
 					tools: [...bucket.tools].sort((left, right) => left.localeCompare(right)),
 				}))
 				.sort((left, right) => right.callCount - left.callCount || left.source.label.localeCompare(right.source.label)),
@@ -509,6 +534,7 @@ export function analyzeSessionEntries(
 		caveats: [
 			"Primary assistant token and cost totals use provider-reported assistant usage exactly where the session recorded it.",
 			"Tool, MCP, and source attribution are estimates derived from tool names and the current tool catalog.",
+			"Tool I/O token counts are estimated from payload size (~4 chars/token), are not provider-reported, and reflect model-visible tool arguments and result content rather than turn-level token attribution.",
 			"Subagent usage appears only when structured session data exposed it; missing discoveries do not prove zero subagent spend.",
 			"Artifact and session references are sanitized and do not expose absolute local paths.",
 		],
@@ -1121,4 +1147,37 @@ function splitProviderModel(value: string): { provider?: string; modelId: string
 		provider: value.slice(0, slashIndex),
 		modelId: value.slice(slashIndex + 1),
 	};
+}
+
+/**
+ * Serialize tool-call arguments to JSON and return the character length.
+ * Returns 0 if arguments are absent or not serializable.
+ * Only the character count is used — raw payload text is never stored.
+ */
+function safeArgChars(args: unknown): number {
+	if (args == null) {
+		return 0;
+	}
+	try {
+		return JSON.stringify(args).length;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Sum the character length of all text items in a tool-result content array.
+ * Image and other non-text items are excluded — only derived counts are used.
+ */
+function resultContentChars(content: unknown): number {
+	if (!Array.isArray(content)) {
+		return 0;
+	}
+	let total = 0;
+	for (const item of content) {
+		if (isRecord(item) && item.type === "text" && typeof item.text === "string") {
+			total += item.text.length;
+		}
+	}
+	return total;
 }

--- a/extensions/the-last-harness/tokens.ts
+++ b/extensions/the-last-harness/tokens.ts
@@ -166,6 +166,7 @@ export function buildTokensReportHtml(analysis: TlhSessionUsageAnalysis, options
 				renderMetricCard("Tool errors", formatInteger(analysis.tools.totalErrors), `${formatErrorRate(analysis.tools.totalErrors, analysis.tools.totalResults)} result error rate`),
 				renderMetricCard("MCP calls", formatInteger(analysis.tools.mcpCalls), `${formatInteger(analysis.tools.mcpProxyCalls)} proxy • ${formatInteger(analysis.tools.mcpDirectCalls)} direct`),
 				renderMetricCard("Source precision", analysis.tools.precision, "Estimated from tool names and current catalog"),
+				renderMetricCard("MCP est. tokens", formatInteger(analysis.tools.mcpApproxTokens), `${formatInteger(analysis.tools.totalToolApproxTokens)} all-tools est.`),
 				"</div>",
 				renderToolSourceTable(analysis.tools.bySource),
 				renderToolTable(analysis.tools.byTool),
@@ -300,11 +301,12 @@ function renderToolSourceTable(sources: TlhToolSourceUsage[]): string {
 	return [
 		"<h3>Tool sources</h3>",
 		renderTable(
-			["Source", "Kind", "Calls", "Tools", "Scope", "Origin"],
+			["Source", "Kind", "Calls", "Est. tokens", "Tools", "Scope", "Origin"],
 			sources.map((bucket) => [
 				bucket.source.label,
 				bucket.source.kind,
 				formatInteger(bucket.callCount),
+				formatInteger(bucket.approxTokens),
 				bucket.tools.join(", "),
 				bucket.source.scope ?? "—",
 				bucket.source.origin ?? "—",
@@ -318,7 +320,7 @@ function renderToolTable(tools: TlhToolUsage[]): string {
 	return [
 		"<h3>Tools</h3>",
 		renderTable(
-			["Tool", "Source", "Calls", "Results", "Errors", "MCP"],
+			["Tool", "Source", "Calls", "Results", "Errors", "MCP", "Est. tokens"],
 			tools.map((tool) => [
 				tool.toolName,
 				tool.source.label,
@@ -326,6 +328,7 @@ function renderToolTable(tools: TlhToolUsage[]): string {
 				formatInteger(tool.resultCount),
 				formatInteger(tool.errorCount),
 				tool.mcp ? "yes" : "no",
+				formatInteger(tool.approxTokens),
 			]),
 			"No tool calls recorded.",
 		),

--- a/tests/the-last-harness-tokens-command.test.mjs
+++ b/tests/the-last-harness-tokens-command.test.mjs
@@ -398,3 +398,92 @@ test("buildTokensReportHtml renders MCP est. tokens card and Est. tokens columns
 	assert.match(html, /~4 chars\/token/);
 	assert.match(html, /not provider-reported/);
 });
+
+test("analyzeSessionEntries counts result-content characters toward a tool's approxTokens even when tool arguments are empty", () => {
+	// Verify result-content text alone drives approxTokens (i.e. the assertion
+	// approxTokens > 0 cannot pass only because of argument bytes).
+	const RESULT_TEXT = "Result text that is longer than a few characters."; // 49 chars → ≥1 token
+	const entries = [
+		userEntry("u1", null, "2026-06-17T11:00:00Z", "user message"),
+		assistantEntry("a1", "u1", "2026-06-17T11:00:05Z", {
+			stopReason: "tool_use",
+			content: [
+				// null arguments → safeArgChars returns 0, so arg tokens = 0
+				{ type: "toolCall", id: "call-read-1", name: "read-file", arguments: null },
+			],
+			usage: usage({ input: 50, output: 5, cost: 0.1 }),
+		}),
+		toolResultEntry("tr1", "a1", "2026-06-17T11:00:06Z", "read-file", {}, false, RESULT_TEXT),
+		assistantEntry("a2", "tr1", "2026-06-17T11:00:10Z", {
+			text: "Done.",
+			usage: usage({ input: 30, output: 3, cost: 0.05 }),
+		}),
+	];
+	const toolCatalog = [
+		{ name: "read-file", sourceInfo: { source: "built-in", path: "core/read.ts", scope: "user", origin: "top-level" } },
+	];
+	const analysis = analyzeSessionEntries(entries, { toolCatalog });
+
+	const readTool = analysis.tools.byTool.find((t) => t.toolName === "read-file");
+	assert.ok(readTool, "read-file tool present in byTool");
+	// callCount is 1 but arguments were null, so arg tokens = 0; only result chars drive approxTokens
+	assert.equal(readTool.callCount, 1, "callCount is 1");
+	assert.equal(readTool.resultCount, 1, "resultCount is 1");
+	// RESULT_TEXT is 49 chars → Math.ceil(49/4) = 13 tokens; arg contribution = 0
+	const expectedApproxTokens = Math.ceil(RESULT_TEXT.length / 4);
+	assert.equal(readTool.approxTokens, expectedApproxTokens, `approxTokens (${readTool.approxTokens}) equals result-content estimate (${expectedApproxTokens})`);
+	assert.ok(readTool.approxTokens > 0, "result-content text alone contributes non-zero approxTokens");
+});
+
+test("analyzeSessionEntries byTool sorts by approxTokens descending, with callCount as tiebreaker", () => {
+	// expensive-tool: 1 call, 400-char result → 100 approxTokens
+	// cheap-tool: 3 calls, 4-char result each → 3 approxTokens total
+	// Expected byTool order: expensive-tool first (higher approxTokens), cheap-tool second
+	const EXPENSIVE_RESULT = "E".repeat(400); // 400 chars → Math.ceil(400/4) = 100 tokens
+	const CHEAP_RESULT = "c".repeat(4); // 4 chars → Math.ceil(4/4) = 1 token each
+	const entries = [
+		userEntry("u1", null, "2026-06-17T12:00:00Z", "user message"),
+		assistantEntry("a1", "u1", "2026-06-17T12:00:05Z", {
+			stopReason: "tool_use",
+			content: [
+				{ type: "toolCall", id: "call-exp-1", name: "expensive-tool", arguments: null },
+				{ type: "toolCall", id: "call-cheap-1", name: "cheap-tool", arguments: null },
+				{ type: "toolCall", id: "call-cheap-2", name: "cheap-tool", arguments: null },
+				{ type: "toolCall", id: "call-cheap-3", name: "cheap-tool", arguments: null },
+			],
+			usage: usage({ input: 100, output: 10, cost: 0.2 }),
+		}),
+		toolResultEntry("tr1", "a1", "2026-06-17T12:00:06Z", "expensive-tool", {}, false, EXPENSIVE_RESULT),
+		toolResultEntry("tr2", "a1", "2026-06-17T12:00:07Z", "cheap-tool", {}, false, CHEAP_RESULT),
+		toolResultEntry("tr3", "a1", "2026-06-17T12:00:08Z", "cheap-tool", {}, false, CHEAP_RESULT),
+		toolResultEntry("tr4", "a1", "2026-06-17T12:00:09Z", "cheap-tool", {}, false, CHEAP_RESULT),
+		assistantEntry("a2", "tr4", "2026-06-17T12:00:15Z", {
+			text: "Done.",
+			usage: usage({ input: 50, output: 5, cost: 0.1 }),
+		}),
+	];
+	const toolCatalog = [
+		{ name: "expensive-tool", sourceInfo: { source: "built-in", path: "core/expensive.ts", scope: "user", origin: "top-level" } },
+		{ name: "cheap-tool", sourceInfo: { source: "built-in", path: "core/cheap.ts", scope: "user", origin: "top-level" } },
+	];
+	const analysis = analyzeSessionEntries(entries, { toolCatalog });
+
+	const expensiveTool = analysis.tools.byTool.find((t) => t.toolName === "expensive-tool");
+	const cheapTool = analysis.tools.byTool.find((t) => t.toolName === "cheap-tool");
+	assert.ok(expensiveTool, "expensive-tool present in byTool");
+	assert.ok(cheapTool, "cheap-tool present in byTool");
+
+	// Verify the token counts are as expected
+	const expectedExpensive = Math.ceil(EXPENSIVE_RESULT.length / 4); // 100
+	const expectedCheap = 3 * Math.ceil(CHEAP_RESULT.length / 4); // 3
+	assert.equal(expensiveTool.approxTokens, expectedExpensive, `expensive-tool approxTokens is ${expectedExpensive}`);
+	assert.equal(cheapTool.approxTokens, expectedCheap, `cheap-tool approxTokens is ${expectedCheap}`);
+	assert.equal(cheapTool.callCount, 3, "cheap-tool has 3 calls");
+	assert.equal(expensiveTool.callCount, 1, "expensive-tool has 1 call");
+
+	// byTool should rank by approxTokens desc: expensive-tool first despite fewer calls
+	assert.ok(expensiveTool.approxTokens > cheapTool.approxTokens, "expensive-tool has more approxTokens");
+	assert.ok(cheapTool.callCount > expensiveTool.callCount, "cheap-tool has more calls");
+	assert.equal(analysis.tools.byTool[0].toolName, "expensive-tool", "byTool[0] is expensive-tool (highest approxTokens)");
+	assert.equal(analysis.tools.byTool[1].toolName, "cheap-tool", "byTool[1] is cheap-tool (lower approxTokens despite more calls)");
+});

--- a/tests/the-last-harness-tokens-command.test.mjs
+++ b/tests/the-last-harness-tokens-command.test.mjs
@@ -8,6 +8,7 @@ import { makeTempDir } from "./test-fixture-helpers.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { buildTokensReportHtml, registerTokensCommand } = await jiti.import("../extensions/the-last-harness/tokens.ts");
+const { analyzeSessionEntries } = await jiti.import("../extensions/the-last-harness/tokens-analyzer.ts");
 
 function usage({ input, output, cacheRead = 0, cacheWrite = 0, cost, turns = 0, assistantMessages = 0 }) {
 	return {
@@ -275,8 +276,10 @@ test("buildTokensReportHtml escapes dynamic content while preserving required re
 				mcpCalls: 0,
 				mcpProxyCalls: 0,
 				mcpDirectCalls: 0,
-				byTool: [{ toolName: "tool<script>", callCount: 1, resultCount: 1, errorCount: 0, mcp: false, source: { key: "source", label: "Extension <unsafe>", kind: "extension", source: "pkg<unsafe>", estimated: true } }],
-				bySource: [{ source: { key: "source", label: "Extension <unsafe>", kind: "extension", source: "pkg<unsafe>", estimated: true }, callCount: 1, tools: ["tool<script>"] }],
+				mcpApproxTokens: 0,
+				totalToolApproxTokens: 100,
+				byTool: [{ toolName: "tool<script>", callCount: 1, resultCount: 1, errorCount: 0, approxTokens: 100, mcp: false, source: { key: "source", label: "Extension <unsafe>", kind: "extension", source: "pkg<unsafe>", estimated: true } }],
+				bySource: [{ source: { key: "source", label: "Extension <unsafe>", kind: "extension", source: "pkg<unsafe>", estimated: true }, callCount: 1, approxTokens: 100, tools: ["tool<script>"] }],
 			},
 			subagents: {
 				precision: "discoverable-only",
@@ -308,4 +311,90 @@ test("buildTokensReportHtml escapes dynamic content while preserving required re
 	assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
 	assert.doesNotMatch(html, /developer<img>/);
 	assert.doesNotMatch(html, /run-1\/output<script>\.md/);
+});
+
+test("analyzeSessionEntries computes non-zero approxTokens for tool calls and results", () => {
+	const entries = [
+		userEntry("u1", null, "2026-06-17T10:00:00Z", "user message"),
+		assistantEntry("a1", "u1", "2026-06-17T10:00:05Z", {
+			stopReason: "tool_use",
+			content: [
+				{ type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "echo hello world" } },
+				{ type: "toolCall", id: "call-mcp-1", name: "mcp", arguments: { server: "search", query: "example query text" } },
+			],
+			usage: usage({ input: 100, output: 10, cost: 0.2 }),
+		}),
+		toolResultEntry("tr1", "a1", "2026-06-17T10:00:06Z", "bash", {}, false, "hello world"),
+		toolResultEntry("tr2", "a1", "2026-06-17T10:00:07Z", "mcp", {}, false, "search result content here"),
+		assistantEntry("a2", "tr2", "2026-06-17T10:00:10Z", {
+			text: "Done.",
+			usage: usage({ input: 50, output: 5, cost: 0.1 }),
+		}),
+	];
+	const toolCatalog = [
+		{ name: "bash", sourceInfo: { source: "built-in", path: "core/bash.ts", scope: "user", origin: "top-level" } },
+		{ name: "mcp", sourceInfo: { source: "npm:pi-mcp-adapter", path: "extensions/mcp.mjs", scope: "user", origin: "package" } },
+	];
+	const analysis = analyzeSessionEntries(entries, { toolCatalog });
+
+	// Per-tool approxTokens should be non-zero when there are calls and results
+	const bashTool = analysis.tools.byTool.find((t) => t.toolName === "bash");
+	assert.ok(bashTool, "bash tool present in byTool");
+	assert.ok(bashTool.approxTokens > 0, "bash tool has non-zero approxTokens");
+
+	const mcpTool = analysis.tools.byTool.find((t) => t.toolName === "mcp");
+	assert.ok(mcpTool, "mcp tool present in byTool");
+	assert.ok(mcpTool.approxTokens > 0, "mcp tool has non-zero approxTokens");
+
+	// Per-source approxTokens should be non-zero
+	const mcpSource = analysis.tools.bySource.find((s) => s.source.kind === "mcp-proxy");
+	assert.ok(mcpSource, "mcp-proxy source present in bySource");
+	assert.ok(mcpSource.approxTokens > 0, "mcp-proxy source has non-zero approxTokens");
+
+	// Aggregate totals should be non-zero
+	assert.ok(analysis.tools.mcpApproxTokens > 0, "mcpApproxTokens is non-zero");
+	assert.ok(analysis.tools.totalToolApproxTokens > 0, "totalToolApproxTokens is non-zero");
+
+	// MCP total should equal the mcp tool's approxTokens only
+	assert.equal(analysis.tools.mcpApproxTokens, mcpTool.approxTokens, "mcpApproxTokens matches mcp tool approxTokens");
+
+	// Total should be sum of all tools
+	const expectedTotal = analysis.tools.byTool.reduce((sum, t) => sum + t.approxTokens, 0);
+	assert.equal(analysis.tools.totalToolApproxTokens, expectedTotal, "totalToolApproxTokens is sum of all per-tool approxTokens");
+});
+
+test("buildTokensReportHtml renders MCP est. tokens card and Est. tokens columns in Tools/MCP section", () => {
+	const entries = [
+		userEntry("u1", null, "2026-06-17T10:00:00Z", "user message"),
+		assistantEntry("a1", "u1", "2026-06-17T10:00:05Z", {
+			stopReason: "tool_use",
+			content: [
+				{ type: "toolCall", id: "call-mcp-1", name: "mcp", arguments: { server: "search", query: "example" } },
+			],
+			usage: usage({ input: 80, output: 10, cost: 0.18 }),
+		}),
+		toolResultEntry("tr1", "a1", "2026-06-17T10:00:06Z", "mcp", {}, false, "result content"),
+		assistantEntry("a2", "tr1", "2026-06-17T10:00:10Z", {
+			text: "Done.",
+			usage: usage({ input: 40, output: 5, cost: 0.08 }),
+		}),
+	];
+	const toolCatalog = [
+		{ name: "mcp", sourceInfo: { source: "npm:pi-mcp-adapter", path: "extensions/mcp.mjs", scope: "user", origin: "package" } },
+	];
+	const analysis = analyzeSessionEntries(entries, { toolCatalog });
+	const html = buildTokensReportHtml(analysis, { generatedAt: "2026-06-17T10:01:00Z" });
+
+	// MCP est. tokens metric card should appear
+	assert.match(html, /MCP est\. tokens/);
+	// Detail line with all-tools estimate
+	assert.match(html, /all-tools est\./);
+
+	// Est. tokens column header should appear in both tables (Tools and Tool sources)
+	const estTokensMatches = [...html.matchAll(/Est\. tokens/g)];
+	assert.ok(estTokensMatches.length >= 2, `Expected at least 2 "Est. tokens" column headers, found ${estTokensMatches.length}`);
+
+	// The tool estimates caveat should appear
+	assert.match(html, /~4 chars\/token/);
+	assert.match(html, /not provider-reported/);
 });


### PR DESCRIPTION
## What

The `/tokens` report's **Tools/MCP** section previously showed only call counts, with no token signal for MCP usage. This adds an estimated token footprint per tool (and an MCP aggregate).

## Why it's an estimate

Provider token usage is reported **per assistant turn only**, and `toolResult` session entries carry **no usage field** — so precise per-tool/MCP token cost is genuinely unavailable. We estimate the model-visible footprint from payload size (tool-call arguments + tool-result content) via a `~4 chars/token` heuristic.

## Changes

- **analyzer** (`tokens-analyzer.ts`): per-tool `approxTokens`, per-source `approxTokens`, and `tools.mcpApproxTokens` / `tools.totalToolApproxTokens` aggregates, behind a single tunable `CHARS_PER_TOKEN = 4` constant. Only derived integer counts are stored — never raw payload text (preserves the report's privacy design).
- **report** (`tokens.ts`): new "MCP est. tokens" card, an "Est. tokens" column in the Tools and Tool sources tables, and a caveat clarifying the value is estimated and not provider-reported.
- **tests**: cover the analyzer estimate and the rendered output.

## Validation

- `npm test` (tokens suite) and `npm run lint` pass.
- Verified end-to-end against a real session with live MCP (Atlassian/Jira) calls: the `mcp` tool reported ~19.7k estimated tokens, the largest single tool — matching the large JSON payloads.
- Note: `npm run validate` has one **pre-existing, unrelated** failure (`annotate-git-diff ... inlines Monaco assets`, a missing local Monaco build asset), confirmed failing identically with these changes stashed.

## Notes / tradeoffs

- It's a size heuristic, not real tokenization — directionally useful, not exact. `CHARS_PER_TOKEN` makes it easy to retune.
- Minor cosmetic: the metric-card grid CSS class is still named `four` while now holding 5 cards; it uses `auto-fit` so layout reflows fine.

Co-authored-by: The Last Harness <hi@thelastharness.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated token usage metrics for tool calls and MCP interactions in session analysis.
  * Reports now display estimated token counts per tool, per source, and overall MCP usage.

* **Tests**
  * Added comprehensive test coverage for token estimation calculation and HTML report rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->