### PR TITLE
Add PR-template rule to architect and rush primaries

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -24,7 +24,6 @@ Your job is to clarify the requested outcome, design the smallest correct approa
 - Prefer simple, correct, reviewable changes. Avoid speculative abstractions and YAGNI violations.
 - Treat only the exact word `approved` as approval when you ask for signoff.
 - Keep user-facing communication concise and decision-relevant.
-- When opening PRs, if a PR template is present for the repository, always follow it.
 
 ## Tools and delegation
 
@@ -130,3 +129,4 @@ When the incoming user turn's first line is exactly `[/review]`, skip the normal
 1. During cleanup after final review and before the final handoff, delete any `tk` tickets created for the current workflow or session once they are closed.
 2. Verify no session-created `.tickets/` files remain tracked, staged, in the worktree, or in the final commit.
 3. If this workflow closed or modified a ticket that already existed in the repository, ask the user whether they want to keep the change, revert it, or delete the ticket.
+4. When opening PRs, if a PR template is present for the repository, always follow it.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -24,6 +24,7 @@ Your job is to clarify the requested outcome, design the smallest correct approa
 - Prefer simple, correct, reviewable changes. Avoid speculative abstractions and YAGNI violations.
 - Treat only the exact word `approved` as approval when you ask for signoff.
 - Keep user-facing communication concise and decision-relevant.
+- When opening PRs, if a PR template is present for the repository, always follow it.
 
 ## Tools and delegation
 

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -25,7 +25,6 @@ Your job is to inspect the codebase, implement the smallest correct change yours
 - Keep work small, local, and reviewable. If the request becomes broad, ambiguous, or multi-step, recommend switching to `architect`.
 - Prefer simple fixes, focused tests, and minimal scope.
 - Keep user-facing communication concise and execution-oriented.
-- When opening PRs, if a PR template is present for the repository, always follow it.
 
 ## Workflow
 
@@ -49,3 +48,7 @@ Use minor subagents only when they materially help:
 Rush is for small bounded implementation work, focused bug fixes, targeted tests, and local refactors.
 
 If the task expands into product decisions, multi-ticket planning, or broader orchestration, recommend switching to `architect` or `product`.
+
+## Cleanup
+
+- When opening PRs, if a PR template is present for the repository, always follow it.

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -25,6 +25,7 @@ Your job is to inspect the codebase, implement the smallest correct change yours
 - Keep work small, local, and reviewable. If the request becomes broad, ambiguous, or multi-step, recommend switching to `architect`.
 - Prefer simple fixes, focused tests, and minimal scope.
 - Keep user-facing communication concise and execution-oriented.
+- When opening PRs, if a PR template is present for the repository, always follow it.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Adds a `## Core rules` bullet to the two PR-opening primary agents instructing them to follow a repository's PR template when one is present:

> When opening PRs, if a PR template is present for the repository, always follow it.

## Files changed

- `agents/primary/architect.md` — new final Core rules bullet
- `agents/primary/rush.md` — new final Core rules bullet

## Scope decision

Only `architect` and `rush` are updated — they are the primaries that actually open PRs. `bug-hunter` (read-only) and `product` (non-implementing) are intentionally left unchanged.

## Validation

`npm run validate` passes (installer smoke checks, 35 test suites, ESLint, merge-settings dry-run, `npm pack --dry-run`).

---

Install this branch:

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/add-pr-template-rule/install.sh | bash -s -- --ref add-pr-template-rule --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal developer documentation and guidelines for pull request submission processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->