### PR TITLE
Exempt ephemeral fixture git commits from TLH attribution guard

### DIFF
--- a/docs/git-attribution.md
+++ b/docs/git-attribution.md
@@ -31,6 +31,52 @@ You can manage the same setting yourself in `~/.the-last-harness/agent/settings.
 - Set `tlh.attribution.commit` to `true` to re-enable it explicitly.
 - Delete `tlh.attribution.commit` to return to TLH's built-in default footer.
 
+## Ephemeral fixture exemption
+
+The attribution guard uses a **CWD-aware, per-commit** check as it walks through the segments of a command chain. A `git commit` is exempt only when it is *proven* to target an ephemeral temp fixture at the commit's position in the chain.
+
+### How the walk works
+
+TLH processes segments in order, maintaining:
+
+- **`inTempContext`** — set `true` after a `cd` to a recognised temp root (literal path, `$TMPDIR`/`$TMP` reference, or a variable assigned from `mktemp`); set `false` after a `cd` to any other path or an unresolvable target (fail-safe).
+- **`sawGitInitInTemp`** — set `true` when `git init` runs while `inTempContext`, or when `git -C <temp-path> init` explicitly targets a temp path.
+- **`tempInitPaths`** — the set of explicit temp paths that were `git init`-ed via `git -C <path> init`.
+
+A `git commit` segment is exempt (not blocked) **only if** one of these conditions holds at its position in the walk:
+
+1. `inTempContext && sawGitInitInTemp` — the CWD was moved into a temp dir that had `git init` run inside it.
+2. The commit itself uses `git -C <path>` where `<path>` is in `tempInitPaths` — the commit explicitly targets a temp path that was previously `git init`-ed.
+
+Wrapped shells (e.g. `bash -lc '...'`, `sh -c '...'`) get **fresh, independent state** so that their inner command chains are evaluated on their own.
+
+### Example chains that are exempt
+
+```bash
+tmp=$(mktemp -d) && cd "$tmp" && git init -q && git commit -m init
+# ^ inTempContext=true, sawGitInitInTemp=true at commit time → exempt
+
+git -C /tmp/fixture init && git -C /tmp/fixture commit -m init
+# ^ tempInitPaths={'/tmp/fixture'}, commit uses same -C path → exempt
+
+bash -lc 'tmp=$(mktemp -d) && cd "$tmp" && git init -q && git commit -m init'
+# ^ inner shell evaluated with fresh state; same logic applies → exempt
+```
+
+### Examples that remain blocked (attribution still required)
+
+```bash
+git commit -m "ship it"                          # neither signal
+git init && git commit -m "ship it"              # no temp-dir context
+cd /tmp/mydir && git commit -m "ship it"         # no git init
+
+git -C /tmp/fixture init && git commit -m "real"
+# ^ commit has no -C; inTempContext is false → still blocked
+
+tmp=$(mktemp -d) && cd "$tmp" && git init && cd /real/repo && git commit -m "real"
+# ^ cd /real/repo clears inTempContext before the commit → still blocked
+```
+
 ## What does not change
 
 TLH does not change `git push`. Attribution only affects the commit message before you push.

--- a/extensions/the-last-harness/attribution.ts
+++ b/extensions/the-last-harness/attribution.ts
@@ -1224,6 +1224,7 @@ function getWrappedShellGitCommitAttributionBlockReason(
 	depth = 0,
 	failClosedOnCommitLike = false,
 	sourceSegment?: string,
+	fixtureState: EphemeralFixtureState = createEphemeralFixtureState(),
 ): string | undefined {
 	if (depth > MAX_WRAPPED_SHELL_GIT_COMMIT_RECURSION_DEPTH) {
 		return buildTlhGitCommitAttributionBlockReason(footer);
@@ -1234,10 +1235,18 @@ function getWrappedShellGitCommitAttributionBlockReason(
 		if (!trimmedSegment) {
 			continue;
 		}
+
+		// Update CWD-aware fixture state before evaluating this segment.
+		updateEphemeralFixtureState(trimmedSegment, fixtureState);
+
 		const effectiveSourceSegment = sourceSegment ?? trimmedSegment;
 		const commitArguments = getGitCommitArguments(trimmedSegment);
 		const isObviousInlineGitCommit = commitArguments !== undefined && hasInlineLikeGitCommitMessageOrFileArgument(commitArguments);
 		if (isObviousInlineGitCommit) {
+			// Exempt commits that provably target an ephemeral temp fixture.
+			if (isCommitSegmentEphemeralExempt(trimmedSegment, fixtureState)) {
+				continue;
+			}
 			if (
 				areInlineGitCommitArgumentsAttributed(commitArguments, footer, trimmedSegment)
 				|| areInlineGitCommitArgumentsAttributed(commitArguments, footer, effectiveSourceSegment)
@@ -1259,18 +1268,231 @@ function getWrappedShellGitCommitAttributionBlockReason(
 		if (!wrappedCommand) {
 			continue;
 		}
+		// Recurse with FRESH state: each wrapped-shell level gets independent context.
 		const blockReason = getWrappedShellGitCommitAttributionBlockReason(
 			wrappedCommand,
 			footer,
 			depth + 1,
 			failClosedOnCommitLike,
 			effectiveSourceSegment,
+			createEphemeralFixtureState(),
 		);
 		if (blockReason) {
 			return blockReason;
 		}
 	}
 	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Ephemeral-fixture exemption helpers (CWD-aware, per-commit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognised temp-dir root prefixes (literal paths and env-var references).
+ * A path "under" one of these roots satisfies the temp-dir signal.
+ */
+const TEMP_DIR_LITERAL_PREFIXES = [
+	"/tmp/",
+	"/private/tmp/",
+	"/var/folders/",
+	"/private/var/folders/",
+];
+const TEMP_DIR_EXACT_ROOTS = new Set(["/tmp", "/private/tmp"]);
+/** Shell variable references that expand to a temp root (as produced by the tokenizer). */
+const TEMP_ENV_VAR_REFS = new Set(["$TMPDIR", "${TMPDIR}", "$TMP", "${TMP}"]);
+
+/** Returns true when `path` is, or is under, a recognised temp root. */
+function pathIsUnderTempRoot(path: string): boolean {
+	if (TEMP_DIR_EXACT_ROOTS.has(path)) {
+		return true;
+	}
+	if (TEMP_DIR_LITERAL_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+		return true;
+	}
+	for (const ref of TEMP_ENV_VAR_REFS) {
+		if (path === ref || path.startsWith(`${ref}/`)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * If `token` is a bare shell variable reference (`$var` or `${var}`),
+ * returns the variable name; otherwise returns undefined.
+ */
+function extractShellVarName(token: string): string | undefined {
+	const match = /^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/.exec(token);
+	return match?.[1];
+}
+
+/**
+ * Returns true when `segment` contains a `git init` invocation
+ * (after stripping leading env/shell prefixes).
+ */
+function segmentHasGitInit(segment: string): boolean {
+	const tokens = normalizeShellCommandTokens(segment);
+	if (commandBasename(tokens[0] ?? "") !== "git") {
+		return false;
+	}
+	for (let index = 1; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token.toLowerCase() === "init") {
+			return true;
+		}
+		if (!token.startsWith("-")) {
+			return false;
+		}
+		if (GIT_GLOBAL_OPTIONS_WITH_VALUES.has(token)) {
+			index += 1;
+			continue;
+		}
+		if (token.startsWith("-C") || token.startsWith("-c")) {
+			continue;
+		}
+		if (
+			["--config-env", "--git-dir", "--namespace", "--super-prefix", "--work-tree"].some((option) =>
+				token.startsWith(`${option}=`),
+			)
+		) {
+			continue;
+		}
+	}
+	return false;
+}
+
+/**
+ * Extracts the `-C <path>` working-directory override from a git command's
+ * token list.  Returns the path value if present; undefined otherwise.
+ */
+function getGitDashCPath(tokens: string[]): string | undefined {
+	if (commandBasename(tokens[0] ?? "") !== "git") {
+		return undefined;
+	}
+	for (let index = 1; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token === "-C") {
+			return tokens[index + 1];
+		}
+		if (token.startsWith("-C") && token.length > 2) {
+			return token.slice(2);
+		}
+		if (!token.startsWith("-")) {
+			break; // reached the git subcommand — -C must precede it
+		}
+		// Skip the value of other global options so we don't mistake it for -C's value.
+		if (GIT_GLOBAL_OPTIONS_WITH_VALUES.has(token) && token !== "-C") {
+			index += 1;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * CWD-aware state maintained while walking the segments of a command chain.
+ * A fresh instance must be created at each wrapped-command boundary so that
+ * inner shells (e.g. `bash -c '...'`) are evaluated independently.
+ */
+interface EphemeralFixtureState {
+	/** Variables assigned from `mktemp` output in earlier segments. */
+	mktempVars: Set<string>;
+	/** True when a preceding `cd` moved into a recognised temp root. */
+	inTempContext: boolean;
+	/**
+	 * True after a `git init` that ran while `inTempContext`, OR after a
+	 * `git -C <temp-path> init` that explicitly targeted a temp path.
+	 */
+	sawGitInitInTemp: boolean;
+	/**
+	 * Explicit temp paths (from `git -C <path> init`) that have been
+	 * initialised as git repos in this chain.
+	 */
+	tempInitPaths: Set<string>;
+}
+
+function createEphemeralFixtureState(): EphemeralFixtureState {
+	return {
+		mktempVars: new Set(),
+		inTempContext: false,
+		sawGitInitInTemp: false,
+		tempInitPaths: new Set(),
+	};
+}
+
+/**
+ * Updates `state` based on what `segment` does (cd, git init, mktemp
+ * assignments).  Must be called for every segment in order so that each
+ * subsequent segment sees the correct accumulated context.
+ */
+function updateEphemeralFixtureState(segment: string, state: EphemeralFixtureState): void {
+	// 1. Collect `var=$(mktemp ...)` assignments visible as tokens in this segment.
+	for (const token of tokenizeShellWords(segment)) {
+		if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+			continue;
+		}
+		const eqIndex = token.indexOf("=");
+		const value = token.slice(eqIndex + 1);
+		if (/\$\(mktemp\b/.test(value) || /`mktemp\b/.test(value)) {
+			state.mktempVars.add(token.slice(0, eqIndex));
+		}
+	}
+
+	const tokens = normalizeShellCommandTokens(segment);
+	const cmd = commandBasename(tokens[0] ?? "");
+
+	// 2. Handle `cd` — update inTempContext.
+	//    Fail-safe: an unknown or non-temp target clears the flag.
+	if (cmd === "cd" && tokens.length >= 2) {
+		const target = tokens[1];
+		if (
+			pathIsUnderTempRoot(target)
+			|| /\$\(mktemp\b/.test(target)
+			|| /`mktemp\b/.test(target)
+		) {
+			state.inTempContext = true;
+		} else {
+			const varName = extractShellVarName(target);
+			state.inTempContext = varName !== undefined && state.mktempVars.has(varName);
+		}
+		return;
+	}
+
+	// 3. Handle `git init` — update sawGitInitInTemp / tempInitPaths.
+	if (cmd === "git" && segmentHasGitInit(segment)) {
+		const dashCPath = getGitDashCPath(tokens);
+		if (dashCPath !== undefined) {
+			const varName = extractShellVarName(dashCPath);
+			const isTemp =
+				pathIsUnderTempRoot(dashCPath)
+				|| (varName !== undefined && state.mktempVars.has(varName));
+			if (isTemp) {
+				state.sawGitInitInTemp = true;
+				state.tempInitPaths.add(dashCPath);
+			}
+		} else if (state.inTempContext) {
+			// `git init` with no explicit path — runs in the current (temp) CWD.
+			state.sawGitInitInTemp = true;
+		}
+	}
+}
+
+/**
+ * Returns true when `segment` is a `git commit` that is proven to target an
+ * ephemeral temp fixture at its position in the segment walk.
+ *
+ * Condition 1: the CWD-walk shows we are currently inside a temp directory
+ *   that had `git init` run in it.
+ * Condition 2: the commit itself uses `git -C <path>` where `<path>` was
+ *   explicitly git-initialised as a temp fixture earlier in the same chain.
+ */
+function isCommitSegmentEphemeralExempt(segment: string, state: EphemeralFixtureState): boolean {
+	if (state.inTempContext && state.sawGitInitInTemp) {
+		return true;
+	}
+	const tokens = normalizeShellCommandTokens(segment);
+	const dashCPath = getGitDashCPath(tokens);
+	return dashCPath !== undefined && state.tempInitPaths.has(dashCPath);
 }
 
 export function buildTlhCommitAttributionPrompt(state: TlhCommitAttributionState): string | undefined {
@@ -1288,6 +1510,7 @@ export function getTlhGitCommitAttributionBlockReason(command: string, state: Tl
 	if (!state.enabled || !state.footer) {
 		return undefined;
 	}
+	// Per-commit CWD-aware exemption is applied inside getWrappedShellGitCommitAttributionBlockReason.
 	return getWrappedShellGitCommitAttributionBlockReason(command, state.footer);
 }
 

--- a/tests/the-last-harness-attribution.test.mjs
+++ b/tests/the-last-harness-attribution.test.mjs
@@ -723,6 +723,154 @@ test("toggle attribution command rewrites attribution settings to boolean-only c
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Ephemeral-fixture exemption — four acceptance criteria (tlhmf-7hco)
+// ---------------------------------------------------------------------------
+
+test("ephemeral-fixture exemption: git commit inside mktemp+git-init chain is NOT blocked (AC1)", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// Primary use-case: variable assigned from mktemp, then cd + git init + git commit.
+	const primaryChain = `tmp=$(mktemp -d) && cd "$tmp" && git init -q && git add . && git commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(primaryChain, enabled), undefined);
+
+	// Multiline variant (newline-separated segments).
+	const multiline = `tmp=$(mktemp -d)\ncd "$tmp"\ngit init -q\ngit commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(multiline, enabled), undefined);
+
+	// mktemp as a standalone command (not assigned).
+	const standaloneMktemp = `mktemp -d && cd /tmp/fixture && git init && git commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(standaloneMktemp, enabled), undefined);
+
+	// git -C pointing to a temp root alongside git init.
+	const gitCInit = `git -C /tmp/fixture init && git -C /tmp/fixture commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(gitCInit, enabled), undefined);
+
+	// mktemp as a command substitution in cd.
+	const cdSubstitution = `cd $(mktemp -d) && git init -q && git commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(cdSubstitution, enabled), undefined);
+
+	// $TMPDIR-based cd alongside git init.
+	const tmpdirChain = `cd "$TMPDIR/fixture" && git init -q && git commit -m init`;
+	assert.equal(getTlhGitCommitAttributionBlockReason(tmpdirChain, enabled), undefined);
+});
+
+test("ephemeral-fixture exemption: normal real-repo commit missing footer is STILL blocked (AC2)", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// Plain commit with no footer, no git init, no temp context.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('git commit -m "ship it"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+
+	// Footer present → not blocked (ensure exemption doesn't break the happy path).
+	assert.equal(
+		getTlhGitCommitAttributionBlockReason(`git commit -m "ship it\n\n${TLH_DEFAULT_COMMIT_ATTRIBUTION}"`, enabled),
+		undefined,
+	);
+});
+
+test("ephemeral-fixture exemption: git init + commit in NON-temp path is STILL blocked (AC3)", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// git init in the current dir (no temp root) must not bypass the guard.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('git init && git commit -m "initial commit"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+
+	// git init in a named but non-temp path.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('cd /home/user/project && git init && git commit -m "init"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+
+	// git init in a relative path that isn't a temp root.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('cd ./testfixture && git init && git commit -m "init"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+});
+
+test("ephemeral-fixture exemption: cd into temp path WITHOUT git init is STILL blocked (AC4)", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// Has a temp-dir context but no git init → still blocked.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('cd /tmp/mydir && git commit -m "ship it"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+
+	// mktemp invocation without git init → still blocked.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('tmp=$(mktemp -d) && cd "$tmp" && git commit -m "ship it"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+
+	// $TMPDIR cd without git init → still blocked.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason('cd "$TMPDIR/fixture" && git commit -m "ship it"', enabled) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests: CWD-aware exemption correctness (tlhmf-7hco review)
+// ---------------------------------------------------------------------------
+
+test("CWD-aware exemption: git -C /tmp init then bare git commit is STILL blocked", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// The commit does not use -C and inTempContext is false → must be blocked.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason(
+			'git -C /tmp/fixture init && git commit -m "real"',
+			enabled,
+		) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+});
+
+test("CWD-aware exemption: cd back to real repo before commit is STILL blocked", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// After cd /real/repo, inTempContext becomes false → commit must be blocked.
+	assert.match(
+		getTlhGitCommitAttributionBlockReason(
+			'tmp=$(mktemp -d) && cd "$tmp" && git init && cd /real/repo && git commit -m "real"',
+			enabled,
+		) ?? "",
+		/missing the required TLH attribution footer/,
+	);
+});
+
+test("CWD-aware exemption: git -C /tmp init and git -C /tmp commit is exempt", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// Commit explicitly targets the same temp path that was git-initialized → exempt.
+	assert.equal(
+		getTlhGitCommitAttributionBlockReason(
+			"git -C /tmp/fixture init && git -C /tmp/fixture commit -m init",
+			enabled,
+		),
+		undefined,
+	);
+});
+
+test("CWD-aware exemption: fixture inside bash -lc wrapper is exempt (Issue 2)", () => {
+	const enabled = resolveTlhCommitAttribution(undefined);
+
+	// The wrapped shell gets its own fresh context; inner fixture chain must be exempt.
+	assert.equal(
+		getTlhGitCommitAttributionBlockReason(
+			"bash -lc 'tmp=$(mktemp -d) && cd \"$tmp\" && git init -q && git commit -m init'",
+			enabled,
+		),
+		undefined,
+	);
+});
+
 test("toggle attribution command rejects non-boolean persisted values", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-attribution-test-", { test: t });
 	const settingsPath = join(fixture.agent, "settings.json");


### PR DESCRIPTION
## Summary

The TLH commit-attribution guard was forcing the TLH footer onto commits made inside **throwaway fixture repos** (e.g. `tmp=$(mktemp -d); cd "$tmp" && git init && git commit -m init`). A week-of-sessions audit found these were the only true footer-block *loops* — false positives that also polluted unit-test fixtures with the footer.

This narrows the guard so a `git commit` is exempt **only** when it provably targets an ephemeral temp fixture.

## Behavior

A commit is exempt only when, at its position in the command chain, **both** signals hold:
1. the working context is a temp directory (`mktemp`, `cd` into `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR`/`$TMP`, or a var assigned from `mktemp`), **and**
2. a `git init` ran in that temp context (or `git -C <temp> init` with a matching `git -C <temp> commit`).

The exemption is **CWD-aware and per-commit** (not command-wide): real-repo commits missing the footer stay blocked, including mixed chains like `git -C /tmp/fixture init && git commit -m "real"` and `…cd "$tmp" && git init && cd /real/repo && git commit`. It also applies inside wrapped shells (`bash -lc '…'`).

## Tests

`tests/the-last-harness-attribution.test.mjs` adds AC1–AC4 plus 4 regression cases (mixed real-repo chains stay blocked; `git -C /tmp` fixture exempt; wrapped-shell fixture exempt).

## Validation

`npm run validate` → exit 0 (716 tests + lint + dry-runs).

## Notes

- No prompt/system-text changes.
- Conservative tradeoffs: only the first `-C` path is tracked and `--git-dir`/`--work-tree` are not tracked for the exemption — both err toward *blocking*, so there is no attribution-bypass risk.

Co-authored-by: The Last Harness <hi@thelastharness.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribution guard now exempts git commits executed within ephemeral temporary fixtures from requiring the TLH footer during command-chain execution.

* **Documentation**
  * Added "Ephemeral fixture exemption" guide detailing when commits are exempt and providing command examples.

* **Tests**
  * Added comprehensive coverage for ephemeral fixture exemption scenarios, including CWD-aware and wrapped-shell behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->