### PR TITLE
Add macOS CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ permissions:
 
 jobs:
   validation:
-    name: Repository validation
-    runs-on: ubuntu-latest
+    name: Repository validation (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
 
     steps:
       - name: Check out repository
@@ -27,4 +33,8 @@ jobs:
         run: npm install --no-package-lock --legacy-peer-deps
 
       - name: Run validation checks
-        run: npm run validate
+        env:
+          HOME: ${{ runner.temp }}/tlh-home
+        run: |
+          mkdir -p "${HOME}"
+          npm run validate


### PR DESCRIPTION
## Summary
- run repository validation on both Ubuntu and macOS in CI
- keep Node pinned to 22.19.0
- run validation with a temporary HOME so CI does not depend on a real home-directory install

## Install/Update Impact
- No runtime install/update behavior changes.
- CI-only workflow change.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `HOME="$(mktemp -d)" npm run validate` (run by developer subagent)
- code-reviewer pass for `tlht-mq50`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration validation workflow to run on multiple operating systems (Ubuntu and macOS) instead of a single platform, ensuring broader compatibility verification during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->