### PR TITLE
Pin TLH dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,4 @@ git diff --cached
 - After finishing a task, run `gn help review`.
 - This project uses a CLI ticket system for task management. Run `tk help` when you need to use it.
 - If the human links you a PR comments, or pastes you one, do not take it at face value — instead, investigate if valid and report back first. Do not start fixing it immediately.
+- If the human asks you to open a PR, after creating it check CI/status checks and investigate PR comments/review comments. Address valid findings; resolve or dismiss invalid or non-actionable comments with rationale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
+- Bundled installer-managed runtime dependencies outside `package.json` are now explicitly pinned too: bundled npm default extensions in `config/default-extensions.json` use concrete versions, existing TLH git-fork defaults stay tag-pinned, and managed Gnosis now defaults to the pinned `v0.5.3` release instead of resolving `latest` unless you override it.
 - TLH now suppresses the upstream Pi “Update Available — Run `pi update`” launch banner. Because TLH pins Pi to a supported version window, the upstream update prompt is misleading noise — `tlh update` is the correct update path. TLH’s own update notifications are unaffected.
 
 ## [0.22.2] - 2026-06-19

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -1,22 +1,22 @@
 [
   {
     "id": "oracle",
-    "source": "npm:@diegopetrucci/pi-oracle",
+    "source": "npm:@diegopetrucci/pi-oracle@0.1.12",
     "description": "Consult a separate read-only reasoning process for second opinions."
   },
   {
     "id": "openai-fast",
-    "source": "npm:@diegopetrucci/pi-openai-fast",
+    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.4",
     "description": "Enable optional OpenAI Codex Fast mode commands for eligible ChatGPT-auth GPT-5.4/GPT-5.5 sessions."
   },
   {
     "id": "anthropic-auth",
-    "source": "npm:@gotgenes/pi-anthropic-auth",
+    "source": "npm:@gotgenes/pi-anthropic-auth@0.6.2",
     "description": "Improve compatibility with Anthropic Claude Pro/Max OAuth while preserving normal API-key behavior."
   },
   {
     "id": "librarian",
-    "source": "npm:@diegopetrucci/pi-librarian",
+    "source": "npm:@diegopetrucci/pi-librarian@0.1.5",
     "description": "Research GitHub repositories and optionally cache local checkouts."
   },
   {
@@ -35,22 +35,22 @@
   },
   {
     "id": "fff",
-    "source": "npm:@ff-labs/pi-fff",
+    "source": "npm:@ff-labs/pi-fff@0.9.5",
     "description": "FFF-powered fuzzy file and content search."
   },
   {
     "id": "inline-bash",
-    "source": "npm:@diegopetrucci/pi-inline-bash",
+    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.2",
     "description": "Expand inline bash commands in user prompts."
   },
   {
     "id": "notify",
-    "source": "npm:@diegopetrucci/pi-notify",
+    "source": "npm:@diegopetrucci/pi-notify@0.1.5",
     "description": "Send a notification when an agent turn finishes."
   },
   {
     "id": "context-inspector",
-    "source": "npm:@diegopetrucci/pi-context-inspector",
+    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.2",
     "description": "Open a local HTML dashboard explaining where the current session context is going."
   },
   {
@@ -65,17 +65,17 @@
     "id": "quiet-tools",
     "aliases": ["compact-bash"],
     "replaces": ["npm:@diegopetrucci/pi-compact-bash"],
-    "source": "npm:@diegopetrucci/pi-quiet-tools",
+    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.3",
     "description": "Compact collapsed built-in tool output in the TUI without changing model-visible results."
   },
   {
     "id": "dirty-repo-guard",
-    "source": "npm:@diegopetrucci/pi-dirty-repo-guard",
+    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.2",
     "description": "Prompt before session changes when the current git repo has uncommitted changes."
   },
   {
     "id": "triage-comments",
-    "source": "npm:@diegopetrucci/pi-triage-comments",
+    "source": "npm:@diegopetrucci/pi-triage-comments@0.1.3",
     "description": "Add /triage-comments and a read-only triage_comments subagent tool for review-comment triage."
   },
   {

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ Run the one-liner:
 curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/latest/download/install.sh | bash -s --
 ```
 
-On supported platforms (linux/darwin × x64/arm64), it installs [Gnosis](https://github.com/skorokithakis/gnosis) automatically. Installs on unsupported platforms hard-fail. TLH also requires `tk` ticket integration; if no valid configured/existing `tk` is found, TLH installs a managed copy at `~/.the-last-harness/agent/bin/tk`. If TLH cannot validate or install `tk`, install fails with an actionable error instead of creating an incomplete workflow. Once the installation is finished, start `tlh` by running… you guessed it, `tlh`.
+On supported platforms (linux/darwin × x64/arm64), it installs [Gnosis](https://github.com/skorokithakis/gnosis) automatically. TLH currently pins the managed default to Gnosis `v0.5.3`; installer-owned `TLH_GNOSIS_VERSION` or helper `--gnosis-version` overrides can still point at another release (including `latest`) when needed. Installs on unsupported platforms hard-fail. TLH also requires `tk` ticket integration; if no valid configured/existing `tk` is found, TLH installs a managed copy at `~/.the-last-harness/agent/bin/tk`. If TLH cannot validate or install `tk`, install fails with an actionable error instead of creating an incomplete workflow. Once the installation is finished, start `tlh` by running… you guessed it, `tlh`.
 
 Note: if you already have `pi` installed, `tlh` does not replace it — you can keep both, as it uses its own isolated config in `~/.the-last-harness/` and never mutates normal `~/.pi/agent` settings.
 
@@ -89,7 +89,7 @@ Release builds with TelemetryDeck identifiers configured also send at most one p
 
 To opt out persistently, set `"tlh": { "telemetry": { "enabled": false } }` in `~/.the-last-harness/agent/settings.json`. This opt-out is user-owned and survives `tlh update` and installer reruns. Per-run opt-outs are `PI_OFFLINE=1`, `TLH_SKIP_TELEMETRY=1`, `TLH_TELEMETRY_DISABLED=1`, or `PI_TELEMETRY=0`. To reset only the pseudonymous install ID, remove `~/.the-last-harness/agent/tlh/telemetry-state.json`.
 
-Plain `tlh update` also refreshes bundled default extension packages; it refreshes pinned critical defaults safely before updating other enabled defaults.
+Plain `tlh update` also refreshes bundled default extension packages. Bundled npm defaults are installer-pinned to explicit versions from `config/default-extensions.json`, while TLH git-fork defaults stay pinned to their tagged refs; TLH only changes those managed versions when a TLH release updates the bundle. Updates still refresh pinned critical defaults safely before updating other enabled defaults.
 
 ## Uninstall
 
@@ -158,4 +158,4 @@ TLH installs Pi per-user under `~/.local` (the binary lives at `~/.local/bin/pi`
 
 ## Security note
 
-The one-line installer and `tlh update` run shell commands on your machine, may install the upstream Pi npm package per-user under `~/.local` and bundled default extensions, install managed Gnosis and `tk` binaries into the isolated TLH profile when needed, create an isolated Pi profile, and write a wrapper command. Managed `tk` is copied from the pinned `wedow/ticket` source tarball (`v0.3.2`) only after SHA-256 verification; TLH does not install `tk` globally or through Homebrew. Review `install.sh` and the stage-1 helper it fetches (`scripts/tlh-install.mjs`) before piping to `bash` if you prefer. At launch, TLH may contact GitHub Releases to check for new TLH versions unless disabled with the update-check opt-outs above. This repo does not create, read, or modify API keys or auth files.
+The one-line installer and `tlh update` run shell commands on your machine, may install the upstream Pi npm package per-user under `~/.local` and bundled default extensions, install managed Gnosis and `tk` binaries into the isolated TLH profile when needed, create an isolated Pi profile, and write a wrapper command. Managed bundled npm extension sources are pinned to explicit versions in `config/default-extensions.json`; managed Gnosis defaults to the pinned `v0.5.3` release unless you override it. Managed `tk` is copied from the pinned `wedow/ticket` source tarball (`v0.3.2`) only after SHA-256 verification; TLH does not install `tk` globally or through Homebrew. Review `install.sh` and the stage-1 helper it fetches (`scripts/tlh-install.mjs`) before piping to `bash` if you prefer. At launch, TLH may contact GitHub Releases to check for new TLH versions unless disabled with the update-check opt-outs above. This repo does not create, read, or modify API keys or auth files.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,7 +4,7 @@ TLH includes managed integrations for project memory and ticketed workflows. Gno
 
 ## Gnosis integration
 
-[Gnosis](https://github.com/skorokithakis/gnosis) is a small `gn` CLI for recording project decisions, constraints, rejected alternatives, and lessons that are not obvious from code alone. On supported platforms (linux/darwin × x64/arm64), TLH installs it automatically because `tlh` works better when agents can consult and update repo-local project memory. Installs and updates on unsupported platforms hard-fail.
+[Gnosis](https://github.com/skorokithakis/gnosis) is a small `gn` CLI for recording project decisions, constraints, rejected alternatives, and lessons that are not obvious from code alone. On supported platforms (linux/darwin × x64/arm64), TLH installs it automatically because `tlh` works better when agents can consult and update repo-local project memory. TLH currently pins the managed default to Gnosis `v0.5.3`, while installer-owned `TLH_GNOSIS_VERSION` and helper `--gnosis-version` overrides still let maintainers point at a different release or `latest` when needed. Installs and updates on unsupported platforms hard-fail.
 
 When a valid Gnosis `gn` binary is present, TLH appends these instructions to the system prompt:
 

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ Environment overrides:
   TLH_UPDATE_TRACK     Update track for future tlh update
   TLH_PACKAGE_SOURCE   Package source passed to `pi install`
   TLH_RAW_BASE         Base URL for installer support files
-  TLH_GNOSIS_VERSION   Gnosis version to install (default: latest)
+  TLH_GNOSIS_VERSION   Gnosis version to install (default: 0.5.3)
   TLH_GNOSIS_REPO      Gnosis GitHub repo, owner/name (default: skorokithakis/gnosis)
 
 Examples:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/browser": "^4.3.0",
-        "glimpseui": "^0.8.1",
+        "@tailwindcss/browser": "4.3.0",
+        "glimpseui": "0.8.1",
         "monaco-editor": "0.52.2"
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.79.7",
         "@earendil-works/pi-tui": "0.79.7",
-        "@eslint/js": "^9.39.4",
-        "eslint": "^9.39.4",
-        "globals": "^14.0.0",
-        "jiti": "^2.7.0",
-        "typescript": "~6.0.3",
-        "typescript-eslint": "^8.59.4"
+        "@eslint/js": "9.39.4",
+        "eslint": "9.39.4",
+        "globals": "14.0.0",
+        "jiti": "2.7.0",
+        "typescript": "6.0.3",
+        "typescript-eslint": "8.60.1"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -61,18 +61,18 @@
     "@earendil-works/pi-tui": ">=0.79.1 <=0.79.7"
   },
   "dependencies": {
-    "@tailwindcss/browser": "^4.3.0",
-    "glimpseui": "^0.8.1",
+    "@tailwindcss/browser": "4.3.0",
+    "glimpseui": "0.8.1",
     "monaco-editor": "0.52.2"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.79.7",
     "@earendil-works/pi-tui": "0.79.7",
-    "@eslint/js": "^9.39.4",
-    "eslint": "^9.39.4",
-    "globals": "^14.0.0",
-    "jiti": "^2.7.0",
-    "typescript": "~6.0.3",
-    "typescript-eslint": "^8.59.4"
+    "@eslint/js": "9.39.4",
+    "eslint": "9.39.4",
+    "globals": "14.0.0",
+    "jiti": "2.7.0",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.60.1"
   }
 }

--- a/scripts/check-package-versions.mjs
+++ b/scripts/check-package-versions.mjs
@@ -8,7 +8,9 @@ import { requiredValue } from "./lib/tlh-install-utils.mjs";
 
 const EXACT_VERSION_RE = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const VERSION_TOKEN_RE = /(?:^|[^0-9A-Za-z])((?:v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))(?=$|[^0-9A-Za-z])/;
-const FLOATING_GIT_REF_RE = /^(?:head|latest|main|master|trunk)$/i;
+const COMMIT_SHA_GIT_REF_RE = /^[0-9a-f]{7,40}$/i;
+const FLOATING_GIT_REF_RE = /^(?:head|latest|main|master|trunk|develop)$/i;
+const BRANCH_LIKE_GIT_REF_RE = /^(?:feature|features|release|releases|hotfix|bugfix|fix|feat|chore|develop|dev)(?:$|[/-])/i;
 const DEFAULT_GNOSIS_SCRIPT_PATHS = Object.freeze([
 	"scripts/tlh-gnosis.mjs",
 	"scripts/tlh-install.mjs",
@@ -212,14 +214,19 @@ function stripArchiveExtension(value) {
 }
 
 function isPinnedGitRef(ref) {
-	const trimmed = String(ref ?? "").trim().replace(/^refs\/tags\//i, "");
+	const trimmed = String(ref ?? "").trim();
 	if (!trimmed) return false;
 	if (/^semver:/i.test(trimmed)) {
 		return isPinnedExactVersion(trimmed.slice("semver:".length).trim());
 	}
+	if (/^refs\/tags\//i.test(trimmed)) {
+		return isPinnedGitRef(trimmed.slice("refs/tags/".length));
+	}
 	if (/^refs\/heads\//i.test(trimmed) || /^heads\//i.test(trimmed)) return false;
-	if (FLOATING_GIT_REF_RE.test(trimmed)) return false;
-	return true;
+	if (COMMIT_SHA_GIT_REF_RE.test(trimmed)) return true;
+	if (trimmed.includes("/")) return false;
+	if (FLOATING_GIT_REF_RE.test(trimmed) || BRANCH_LIKE_GIT_REF_RE.test(trimmed)) return false;
+	return Boolean(extractExactVersionToken(trimmed));
 }
 
 function isPinnedGitLikeDependencySpec(spec) {
@@ -326,8 +333,13 @@ function validateDefaultExtensionPins(defaultExtensionsPath, problems) {
 		}
 
 		const gitSource = parseGitSource(extension.source);
-		if (gitSource && !gitSource.ref) {
+		if (!gitSource) continue;
+		if (!gitSource.ref) {
 			problems.push(`${label} must pin git defaults to an explicit ref, found ${JSON.stringify(extension.source)}`);
+			continue;
+		}
+		if (!isPinnedGitRef(gitSource.ref)) {
+			problems.push(`${label} must pin git defaults to a tag- or commit-like ref, found ${JSON.stringify(extension.source)}`);
 		}
 	}
 }

--- a/scripts/check-package-versions.mjs
+++ b/scripts/check-package-versions.mjs
@@ -2,17 +2,34 @@
 import { readFileSync } from "node:fs";
 import process from "node:process";
 
+import { readDefaultExtensions } from "./lib/default-extensions.mjs";
+import { parseGitSource } from "./lib/tlh-install-package-source.mjs";
 import { requiredValue } from "./lib/tlh-install-utils.mjs";
+
+const EXACT_VERSION_RE = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const VERSION_TOKEN_RE = /(?:^|[^0-9A-Za-z])((?:v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))(?=$|[^0-9A-Za-z])/;
+const FLOATING_GIT_REF_RE = /^(?:head|latest|main|master|trunk)$/i;
+const DEFAULT_GNOSIS_SCRIPT_PATHS = Object.freeze([
+	"scripts/tlh-gnosis.mjs",
+	"scripts/tlh-install.mjs",
+]);
+const ALLOWED_LOCAL_DEPENDENCY_PREFIXES = Object.freeze([
+	"file:",
+	"link:",
+	"workspace:",
+]);
 
 function usage() {
 	return `Usage: node scripts/check-package-versions.mjs [options]
 
-Validate that tracked package metadata versions stay in sync.
+Validate tracked version metadata and TLH-managed dependency pins.
 
 Options:
-  --package <path>   package.json path (default: package.json)
-  --lockfile <path>  package-lock.json path (default: package-lock.json)
-  -h, --help         Show this help
+  --package <path>             package.json path (default: package.json)
+  --lockfile <path>            package-lock.json path (default: package-lock.json)
+  --default-extensions <path>  Bundled default-extension manifest (default: config/default-extensions.json)
+  --gnosis-script <path>       Managed Gnosis script to validate (repeatable; defaults: scripts/tlh-gnosis.mjs, scripts/tlh-install.mjs)
+  -h, --help                   Show this help
 `;
 }
 
@@ -20,8 +37,11 @@ function parseArgs(argv) {
 	const args = {
 		packagePath: "package.json",
 		lockfilePath: "package-lock.json",
+		defaultExtensionsPath: "config/default-extensions.json",
+		gnosisScriptPaths: [...DEFAULT_GNOSIS_SCRIPT_PATHS],
 		help: false,
 	};
+	let customGnosisScripts = false;
 
 	for (let index = 0; index < argv.length; index += 1) {
 		const arg = argv[index];
@@ -39,6 +59,20 @@ function parseArgs(argv) {
 			index += 1;
 			continue;
 		}
+		if (arg === "--default-extensions") {
+			args.defaultExtensionsPath = requiredValue(argv, index + 1, arg);
+			index += 1;
+			continue;
+		}
+		if (arg === "--gnosis-script") {
+			if (!customGnosisScripts) {
+				args.gnosisScriptPaths = [];
+				customGnosisScripts = true;
+			}
+			args.gnosisScriptPaths.push(requiredValue(argv, index + 1, arg));
+			index += 1;
+			continue;
+		}
 		if (arg.startsWith("--package=")) {
 			args.packagePath = arg.slice("--package=".length);
 			if (!args.packagePath) throw new Error("--package requires a value");
@@ -49,19 +83,41 @@ function parseArgs(argv) {
 			if (!args.lockfilePath) throw new Error("--lockfile requires a value");
 			continue;
 		}
+		if (arg.startsWith("--default-extensions=")) {
+			args.defaultExtensionsPath = arg.slice("--default-extensions=".length);
+			if (!args.defaultExtensionsPath) throw new Error("--default-extensions requires a value");
+			continue;
+		}
+		if (arg.startsWith("--gnosis-script=")) {
+			const value = arg.slice("--gnosis-script=".length);
+			if (!value) throw new Error("--gnosis-script requires a value");
+			if (!customGnosisScripts) {
+				args.gnosisScriptPaths = [];
+				customGnosisScripts = true;
+			}
+			args.gnosisScriptPaths.push(value);
+			continue;
+		}
 		throw new Error(`Unknown argument: ${arg}`);
 	}
 
 	return args;
 }
 
-function readJsonFile(path) {
-	let raw;
+function isPlainObject(value) {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readTextFile(path) {
 	try {
-		raw = readFileSync(path, "utf8").replace(/^\uFEFF/, "");
+		return readFileSync(path, "utf8").replace(/^\uFEFF/, "");
 	} catch (error) {
 		throw new Error(`Unable to read ${path}: ${error.message}`);
 	}
+}
+
+function readJsonFile(path) {
+	const raw = readTextFile(path);
 
 	try {
 		return JSON.parse(raw);
@@ -77,10 +133,7 @@ function readRequiredVersion(value, label) {
 	return value;
 }
 
-function versionEntries({ packagePath, lockfilePath }) {
-	const packageJson = readJsonFile(packagePath);
-	const packageLock = readJsonFile(lockfilePath);
-
+function versionEntries({ packagePath, lockfilePath }, packageJson, packageLock) {
 	return [
 		{
 			label: `${packagePath}#version`,
@@ -107,6 +160,237 @@ function assertMatchingVersions(entries) {
 	throw new Error(`Version metadata mismatch:\n${details}`);
 }
 
+function isPinnedExactVersion(value) {
+	return EXACT_VERSION_RE.test(String(value ?? "").trim());
+}
+
+function splitNpmPackageSpec(spec) {
+	const text = String(spec ?? "").trim().replace(/^npm:/, "").trim();
+	if (!text) return { name: "", version: "" };
+	if (text.startsWith("@")) {
+		const secondAt = text.indexOf("@", 1);
+		if (secondAt === -1) return { name: text, version: "" };
+		return {
+			name: text.slice(0, secondAt),
+			version: text.slice(secondAt + 1),
+		};
+	}
+	const separator = text.lastIndexOf("@");
+	if (separator === -1) return { name: text, version: "" };
+	return {
+		name: text.slice(0, separator),
+		version: text.slice(separator + 1),
+	};
+}
+
+function extractExactVersionToken(value) {
+	const match = String(value ?? "").match(VERSION_TOKEN_RE);
+	return match?.[1] || "";
+}
+
+function hasAllowedLocalDependencyPrefix(spec) {
+	const trimmed = String(spec ?? "").trim();
+	return ALLOWED_LOCAL_DEPENDENCY_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+function parseGithubDependencySpec(spec) {
+	const trimmed = String(spec ?? "").trim();
+	if (!trimmed.startsWith("github:")) return undefined;
+
+	const source = trimmed.slice("github:".length).trim();
+	if (!source) return undefined;
+	const hashIndex = source.lastIndexOf("#");
+	if (hashIndex < 0) return { repo: source, ref: "" };
+	return {
+		repo: source.slice(0, hashIndex).trim(),
+		ref: source.slice(hashIndex + 1).trim(),
+	};
+}
+
+function stripArchiveExtension(value) {
+	return String(value ?? "").replace(/\.(?:tar\.gz|tgz|zip)$/i, "");
+}
+
+function isPinnedGitRef(ref) {
+	const trimmed = String(ref ?? "").trim().replace(/^refs\/tags\//i, "");
+	if (!trimmed) return false;
+	if (/^semver:/i.test(trimmed)) {
+		return isPinnedExactVersion(trimmed.slice("semver:".length).trim());
+	}
+	if (/^refs\/heads\//i.test(trimmed) || /^heads\//i.test(trimmed)) return false;
+	if (FLOATING_GIT_REF_RE.test(trimmed)) return false;
+	return true;
+}
+
+function isPinnedGitLikeDependencySpec(spec) {
+	const trimmed = String(spec ?? "").trim();
+	const githubSpec = parseGithubDependencySpec(trimmed);
+	if (githubSpec) {
+		return Boolean(githubSpec.repo) && isPinnedGitRef(githubSpec.ref);
+	}
+
+	const normalized = trimmed.startsWith("git+") ? trimmed.slice(4) : trimmed;
+	const gitSource = parseGitSource(normalized);
+	return Boolean(gitSource) && isPinnedGitRef(gitSource.ref);
+}
+
+function isPinnedUrlDependencySpec(spec) {
+	const trimmed = String(spec ?? "").trim();
+	let parsed;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return false;
+	}
+
+	const pathname = decodeURIComponent(parsed.pathname || "");
+	if (/\/releases\/latest(?:\/|$)/i.test(pathname)) return false;
+	const segments = pathname.split("/").filter(Boolean);
+
+	for (let index = 0; index < segments.length; index += 1) {
+		const segment = segments[index];
+		if (segment === "download" && segments[index - 1] === "releases") {
+			return isPinnedGitRef(stripArchiveExtension(segments[index + 1] || ""));
+		}
+		if (segment === "archive" || segment === "tarball" || segment === "zipball") {
+			if (segments[index + 1] === "refs") {
+				if (segments[index + 2] === "tags") {
+					return isPinnedGitRef(stripArchiveExtension(segments[index + 3] || ""));
+				}
+				if (segments[index + 2] === "heads") {
+					return false;
+				}
+				return false;
+			}
+			if (segments[index + 1]) {
+				return isPinnedGitRef(stripArchiveExtension(segments[index + 1] || ""));
+			}
+		}
+	}
+
+	return Boolean(extractExactVersionToken(pathname));
+}
+
+function isPinnedDependencySpec(spec) {
+	const trimmed = String(spec ?? "").trim();
+	if (!trimmed) return false;
+	if (isPinnedExactVersion(trimmed)) return true;
+	if (trimmed.startsWith("npm:")) {
+		const { name, version } = splitNpmPackageSpec(trimmed);
+		return Boolean(name) && isPinnedExactVersion(version);
+	}
+	if (hasAllowedLocalDependencyPrefix(trimmed)) return true;
+	if (trimmed.startsWith("http:") || trimmed.startsWith("https:")) {
+		return isPinnedUrlDependencySpec(trimmed);
+	}
+	return isPinnedGitLikeDependencySpec(trimmed);
+}
+
+function validatePinnedDependencies(packageJson, packagePath, problems) {
+	for (const field of ["dependencies", "devDependencies"]) {
+		const value = packageJson[field];
+		if (value === undefined) continue;
+		if (!isPlainObject(value)) {
+			problems.push(`${packagePath}#${field} must be an object`);
+			continue;
+		}
+		for (const [name, spec] of Object.entries(value)) {
+			if (typeof spec !== "string" || spec.trim().length === 0) {
+				problems.push(`Missing string dependency spec at ${packagePath}#${field}.${name}`);
+				continue;
+			}
+			if (!isPinnedDependencySpec(spec)) {
+				problems.push(`${packagePath}#${field}.${name} must use an exact version or pinned non-registry source, found ${JSON.stringify(spec)}`);
+			}
+		}
+	}
+}
+
+function validateDefaultExtensionPins(defaultExtensionsPath, problems) {
+	let defaultExtensions;
+	try {
+		defaultExtensions = readDefaultExtensions(defaultExtensionsPath);
+	} catch (error) {
+		problems.push(error.message);
+		return;
+	}
+
+	for (const extension of defaultExtensions) {
+		const label = `${defaultExtensionsPath}#${extension.id}.source`;
+		if (extension.source.startsWith("npm:")) {
+			const { name, version } = splitNpmPackageSpec(extension.source);
+			if (!name || !isPinnedExactVersion(version)) {
+				problems.push(`${label} must pin npm defaults to an exact version, found ${JSON.stringify(extension.source)}`);
+			}
+			continue;
+		}
+
+		const gitSource = parseGitSource(extension.source);
+		if (gitSource && !gitSource.ref) {
+			problems.push(`${label} must pin git defaults to an explicit ref, found ${JSON.stringify(extension.source)}`);
+		}
+	}
+}
+
+function escapeRegex(value) {
+	return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readDeclaredStringConstant(path, name) {
+	const source = readTextFile(path);
+	const pattern = new RegExp(`(?:^|\\n)const\\s+${escapeRegex(name)}\\s*=\\s*["']([^"'\\n]+)["'];`);
+	const match = source.match(pattern);
+	if (!match) {
+		throw new Error(`Missing ${name} constant in ${path}`);
+	}
+	return match[1];
+}
+
+function validateManagedGnosisDefaults(gnosisScriptPaths, problems) {
+	const versions = [];
+	for (const path of gnosisScriptPaths) {
+		let version;
+		try {
+			version = readDeclaredStringConstant(path, "DEFAULT_GNOSIS_VERSION");
+		} catch (error) {
+			problems.push(error.message);
+			continue;
+		}
+		versions.push({ path, version });
+		if (!isPinnedExactVersion(version)) {
+			problems.push(`${path}#DEFAULT_GNOSIS_VERSION must use an exact version, found ${JSON.stringify(version)}`);
+		}
+	}
+
+	const distinctVersions = new Set(versions.map(({ version }) => version));
+	if (versions.length > 1 && distinctVersions.size > 1) {
+		const details = versions
+			.map(({ path, version }) => `  - ${path}: ${JSON.stringify(version)}`)
+			.join("\n");
+		problems.push(`Managed Gnosis defaults must stay in sync:\n${details}`);
+	}
+}
+
+function collectProblems(args) {
+	const packageJson = readJsonFile(args.packagePath);
+	const packageLock = readJsonFile(args.lockfilePath);
+	const problems = [];
+	const entries = versionEntries(args, packageJson, packageLock);
+	let version = entries[0]?.value;
+
+	try {
+		version = assertMatchingVersions(entries);
+	} catch (error) {
+		problems.push(error.message);
+	}
+
+	validatePinnedDependencies(packageJson, args.packagePath, problems);
+	validateDefaultExtensionPins(args.defaultExtensionsPath, problems);
+	validateManagedGnosisDefaults(args.gnosisScriptPaths, problems);
+
+	return { version, problems };
+}
+
 function main() {
 	const args = parseArgs(process.argv.slice(2));
 	if (args.help) {
@@ -114,8 +398,12 @@ function main() {
 		return;
 	}
 
-	const version = assertMatchingVersions(versionEntries(args));
-	process.stdout.write(`check-package-versions: all tracked version fields match (${version}).\n`);
+	const { version, problems } = collectProblems(args);
+	if (problems.length > 0) {
+		throw new Error(problems.join("\n\n"));
+	}
+
+	process.stdout.write(`check-package-versions: all tracked version fields match (${version}), and managed dependency pins are valid.\n`);
 }
 
 try {

--- a/scripts/check-package-versions.mjs
+++ b/scripts/check-package-versions.mjs
@@ -333,7 +333,10 @@ function validateDefaultExtensionPins(defaultExtensionsPath, problems) {
 		}
 
 		const gitSource = parseGitSource(extension.source);
-		if (!gitSource) continue;
+		if (!gitSource) {
+			problems.push(`${label} must use a pinned npm or git source, found ${JSON.stringify(extension.source)}`);
+			continue;
+		}
 		if (!gitSource.ref) {
 			problems.push(`${label} must pin git defaults to an explicit ref, found ${JSON.stringify(extension.source)}`);
 			continue;

--- a/scripts/lib/default-extensions.mjs
+++ b/scripts/lib/default-extensions.mjs
@@ -235,7 +235,7 @@ export function managedDefaultExtensionPackageIdentities(settings, defaultExtens
 		if (disabledIds.has(extension.id)) continue;
 		const identity = packageIdentity(extension.source);
 		if (!identity) continue;
-		if (settings.packages.some((entry) => packageIdentity(entry) === identity)) {
+		if (settings.packages.some((entry) => packageSourceOf(entry) === extension.source)) {
 			managedIdentities.add(identity);
 		}
 	}

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -137,11 +137,13 @@ function isUnpinnedNpmSource(source) {
 	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) === source.trim();
 }
 
-function shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force }) {
+function shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities = new Set() }) {
 	if (force || extension.critical === true) return true;
-	return isPinnedNpmSource(extension.source)
-		&& isUnpinnedNpmSource(currentSource)
-		&& packageIdentity(currentSource) === packageIdentity(extension.source);
+	const identity = packageIdentity(extension.source);
+	if (!identity || packageIdentity(currentSource) !== identity) return false;
+	if (!isPinnedNpmSource(extension.source)) return false;
+	if (isUnpinnedNpmSource(currentSource)) return true;
+	return managedPackageIdentities.has(identity);
 }
 
 function shouldMigrateDefaultExtensionReplacements(extension, { force }) {
@@ -261,7 +263,7 @@ function applyDefaultExtensionPackageDedupes(settings, defaultExtensions, disabl
 	}
 }
 
-function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disabledIds, changes, { force }) {
+function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disabledIds, changes, { force, managedPackageIdentities = new Set() }) {
 	const updatedIdentities = new Set();
 	if (!Array.isArray(settings.packages)) return updatedIdentities;
 
@@ -275,7 +277,7 @@ function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disable
 		const current = settings.packages[index];
 		const currentSource = packageSourceOf(current);
 		if (!currentSource) continue;
-		if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force })) continue;
+		if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities })) continue;
 
 		const sourceNeedsUpdate = currentSource !== extension.source;
 		const removesCriticalExtensionFilter = extension.critical === true
@@ -603,7 +605,11 @@ function main() {
 	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
 	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
 	applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
-	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, { force: args.force });
+	const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
+	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
+		force: args.force,
+		managedPackageIdentities: managedDefaultExtensionProvenance,
+	});
 	applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
 	applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });
 	applyDisabledDefaultExtensions(next, defaultExtensions, disabledIds, changes);

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -129,6 +129,21 @@ function packageIdentityExists(packages, identity) {
 	return Boolean(identity) && packages.some((entry) => packageIdentity(entry) === identity);
 }
 
+function isPinnedNpmSource(source) {
+	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) !== source.trim();
+}
+
+function isUnpinnedNpmSource(source) {
+	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) === source.trim();
+}
+
+function shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force }) {
+	if (force || extension.critical === true) return true;
+	return isPinnedNpmSource(extension.source)
+		&& isUnpinnedNpmSource(currentSource)
+		&& packageIdentity(currentSource) === packageIdentity(extension.source);
+}
+
 function shouldMigrateDefaultExtensionReplacements(extension, { force }) {
 	return force || extension.migrateReplacements === true;
 }
@@ -251,7 +266,6 @@ function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disable
 	if (!Array.isArray(settings.packages)) return updatedIdentities;
 
 	for (const extension of defaultExtensions) {
-		if (!force && extension.critical !== true) continue;
 		if (disabledIds.has(extension.id)) continue;
 		const identity = packageIdentity(extension.source);
 		if (!identity) continue;
@@ -261,6 +275,7 @@ function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disable
 		const current = settings.packages[index];
 		const currentSource = packageSourceOf(current);
 		if (!currentSource) continue;
+		if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force })) continue;
 
 		const sourceNeedsUpdate = currentSource !== extension.source;
 		const removesCriticalExtensionFilter = extension.critical === true

--- a/scripts/tlh-defaults.mjs
+++ b/scripts/tlh-defaults.mjs
@@ -327,7 +327,7 @@ function commandSources(settings, defaultExtensions, { criticalOnly = false } = 
 			continue;
 		}
 		if (!isDefaultDisabled(settings, extension, defaultExtensions) && !isDefaultSourceDeferred(settings, extension)) {
-			console.log(findPackageSource(settings, extension.source) || extension.source);
+			console.log(extension.source);
 		}
 	}
 }

--- a/scripts/tlh-gnosis.mjs
+++ b/scripts/tlh-gnosis.mjs
@@ -15,6 +15,7 @@ import {
 const VALIDATION_TIMEOUT_MS = 5000;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_GNOSIS_REPO = "skorokithakis/gnosis";
+const DEFAULT_GNOSIS_VERSION = "0.5.3";
 
 function usage() {
 	return `Usage: tlh-gnosis.mjs <command>
@@ -30,7 +31,7 @@ Options:
   --agent-dir <dir>    Isolated Pi agent dir (default: ~/.the-last-harness/agent, or PI_CODING_AGENT_DIR)
   --target <path>      Managed gn install target (default: <agent-dir>/bin/gn)
   --gnosis-repo <r>    Gnosis GitHub repo, owner/name (default: skorokithakis/gnosis)
-  --gnosis-version <v> Gnosis version to install (default: latest)
+  --gnosis-version <v> Gnosis version to install (default: 0.5.3)
   --detail             Print verbose/dry-run installer details
   --dry-run            Print intended changes without writing
   --quiet              Only print errors
@@ -43,7 +44,7 @@ function parseArgs(argv) {
 		agentDir: undefined,
 		target: undefined,
 		gnosisRepo: process.env.TLH_GNOSIS_REPO || DEFAULT_GNOSIS_REPO,
-		gnosisVersion: process.env.TLH_GNOSIS_VERSION || "latest",
+		gnosisVersion: process.env.TLH_GNOSIS_VERSION || DEFAULT_GNOSIS_VERSION,
 		command: undefined,
 		commandArgs: [],
 		dryRun: false,
@@ -331,7 +332,10 @@ async function installManagedGnosis(args, agentDir) {
 
 	if (args.dryRun) {
 		logStderr(args, `Would install Gnosis into isolated profile: ${target}`);
-		logStderr(args, `Would download latest compatible release from https://github.com/${args.gnosisRepo}`);
+		const versionLabel = args.gnosisVersion === "latest"
+			? "latest compatible release"
+			: `Gnosis ${args.gnosisVersion.replace(/^v/, "")}`;
+		logStderr(args, `Would download ${versionLabel} from https://github.com/${args.gnosisRepo}`);
 		return target;
 	}
 

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -66,7 +66,7 @@ const MIN_NODE_VERSION = "22.19.0";
 const MIN_PI_VERSION = "0.79.1";
 const MAX_PI_VERSION = PINNED_PI_VERSION;
 const DEFAULT_GNOSIS_REPO = "skorokithakis/gnosis";
-const DEFAULT_GNOSIS_VERSION = "latest";
+const DEFAULT_GNOSIS_VERSION = "0.5.3";
 const DEFAULT_WRAPPER_NAME = "tlh";
 const VALID_UPDATE_TRACKS = new Set(["latest-release", "pinned-tag", "ref", "custom"]);
 const COMMAND_MAX_BUFFER = 20 * 1024 * 1024;
@@ -148,7 +148,7 @@ Environment overrides:
   TLH_UPDATE_TRACK     Update track for future tlh update
   TLH_PACKAGE_SOURCE   Package source passed to \`pi install\`
   TLH_RAW_BASE         Base URL for installer support files
-  TLH_GNOSIS_VERSION   Gnosis version to install (default: latest)
+  TLH_GNOSIS_VERSION   Gnosis version to install (default: 0.5.3)
   TLH_GNOSIS_REPO      Gnosis GitHub repo, owner/name (default: skorokithakis/gnosis)
 `;
 }

--- a/tests/check-package-versions.test.mjs
+++ b/tests/check-package-versions.test.mjs
@@ -79,6 +79,7 @@ test("check-package-versions passes with pinned dependency exceptions and ignore
 			eslint: "9.39.4",
 			aliased: "npm:helper@1.2.3",
 			githubHelper: "github:example/github-helper#v1.2.3",
+			githubExplicitTagHelper: "github:example/github-explicit-tag-helper#refs/tags/v1.2.3",
 			releaseHelper: "https://github.com/example/release-helper/releases/download/v1.2.3/release-helper-1.2.3.tgz",
 			archiveTagHelper: "https://github.com/example/archive-tag-helper/archive/refs/tags/v1.2.3.tar.gz",
 			workspaceHelper: "workspace:*",
@@ -96,6 +97,7 @@ test("check-package-versions passes with pinned dependency exceptions and ignore
 		defaultExtensions: [
 			{ id: "helper", source: "npm:helper@1.2.3" },
 			{ id: "forked-helper", source: "git:github.com/example/helper@tlh-v1.2.3" },
+			{ id: "forked-helper-explicit-tag", source: "git:github.com/example/helper-explicit-tag@refs/tags/v1.2.3" },
 		],
 	});
 
@@ -144,19 +146,24 @@ test("check-package-versions rejects loose dependencies and devDependencies", ()
 	assert.doesNotMatch(result.stderr, /peerDependencies/);
 });
 
-test("check-package-versions rejects floating git/github/http/ssh package sources", () => {
+test("check-package-versions rejects floating and branch-like git/github/http/ssh package refs", () => {
 	const fixture = tempFixture({
 		packageVersion: "1.2.3",
 		dependencies: {
 			gitHelper: "git+https://github.com/example/git-helper.git",
 			githubHelper: "github:example/github-helper",
+			githubDevelopHelper: "github:example/github-develop-helper#develop",
+			githubExplicitTagMainHelper: "github:example/github-explicit-tag-main-helper#refs/tags/main",
+			gitFeatureHelper: "git+https://github.com/example/git-feature-helper.git#feature/foo",
 			httpArchiveBranchHelper: "https://github.com/example/http-archive-branch-helper/archive/refs/heads/main.tar.gz",
 		},
 		devDependencies: {
 			httpHelper: "https://github.com/example/http-helper/releases/latest/download/http-helper.tgz",
+			httpReleaseHelper: "https://github.com/example/http-release-helper/releases/download/release-2026/http-release-helper.tgz",
 			httpTarballBranchHelper: "https://github.com/example/http-tarball-branch-helper/tarball/refs/heads/main",
-			httpZipballBranchHelper: "https://github.com/example/http-zipball-branch-helper/zipball/refs/heads/main",
-			sshHelper: "ssh://git@github.com/example/ssh-helper.git#main",
+			httpZipballTagBranchHelper: "https://github.com/example/http-zipball-tag-branch-helper/zipball/refs/tags/feature/foo",
+			httpZipballBranchHelper: "https://github.com/example/http-zipball-branch-helper/zipball/HEAD",
+			sshHelper: "ssh://git@github.com/example/ssh-helper.git#heads/main",
 		},
 	});
 
@@ -165,11 +172,16 @@ test("check-package-versions rejects floating git/github/http/ssh package source
 	assert.equal(result.status, 1);
 	assert.match(result.stderr, /package\.json#dependencies\.gitHelper must use an exact version or pinned non-registry source, found "git\+https:\/\/github\.com\/example\/git-helper\.git"/);
 	assert.match(result.stderr, /package\.json#dependencies\.githubHelper must use an exact version or pinned non-registry source, found "github:example\/github-helper"/);
+	assert.match(result.stderr, /package\.json#dependencies\.githubDevelopHelper must use an exact version or pinned non-registry source, found "github:example\/github-develop-helper#develop"/);
+	assert.match(result.stderr, /package\.json#dependencies\.githubExplicitTagMainHelper must use an exact version or pinned non-registry source, found "github:example\/github-explicit-tag-main-helper#refs\/tags\/main"/);
+	assert.match(result.stderr, /package\.json#dependencies\.gitFeatureHelper must use an exact version or pinned non-registry source, found "git\+https:\/\/github\.com\/example\/git-feature-helper\.git#feature\/foo"/);
 	assert.match(result.stderr, /package\.json#dependencies\.httpArchiveBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-archive-branch-helper\/archive\/refs\/heads\/main\.tar\.gz"/);
 	assert.match(result.stderr, /package\.json#devDependencies\.httpHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-helper\/releases\/latest\/download\/http-helper\.tgz"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpReleaseHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-release-helper\/releases\/download\/release-2026\/http-release-helper\.tgz"/);
 	assert.match(result.stderr, /package\.json#devDependencies\.httpTarballBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-tarball-branch-helper\/tarball\/refs\/heads\/main"/);
-	assert.match(result.stderr, /package\.json#devDependencies\.httpZipballBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-zipball-branch-helper\/zipball\/refs\/heads\/main"/);
-	assert.match(result.stderr, /package\.json#devDependencies\.sshHelper must use an exact version or pinned non-registry source, found "ssh:\/\/git@github\.com\/example\/ssh-helper\.git#main"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpZipballTagBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-zipball-tag-branch-helper\/zipball\/refs\/tags\/feature\/foo"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpZipballBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-zipball-branch-helper\/zipball\/HEAD"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.sshHelper must use an exact version or pinned non-registry source, found "ssh:\/\/git@github\.com\/example\/ssh-helper\.git#heads\/main"/);
 });
 
 test("check-package-versions rejects unversioned bundled npm defaults", () => {
@@ -198,6 +210,30 @@ test("check-package-versions rejects bundled git defaults without refs", () => {
 
 	assert.equal(result.status, 1);
 	assert.match(result.stderr, /default-extensions\.json#forked-helper\.source must pin git defaults to an explicit ref, found "git:github\.com\/example\/helper"/);
+});
+
+test("check-package-versions rejects bundled git defaults pinned to branch-like refs", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		defaultExtensions: [
+			{ id: "forked-helper-main", source: "git:github.com/example/helper-main@main" },
+			{ id: "forked-helper-develop", source: "git:github.com/example/helper-develop@develop" },
+			{ id: "forked-helper-explicit-tag-main", source: "git:github.com/example/helper-explicit-tag-main@refs/tags/main" },
+			{ id: "forked-helper-feature", source: "git:github.com/example/helper-feature@feature/foo" },
+			{ id: "forked-helper-explicit-tag-feature", source: "git:github.com/example/helper-explicit-tag-feature@refs/tags/feature/foo" },
+			{ id: "forked-helper-release", source: "git:github.com/example/helper-release@release-2026" },
+		],
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-main\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-main@main"/);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-develop\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-develop@develop"/);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-explicit-tag-main\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-explicit-tag-main@refs\/tags\/main"/);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-feature\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-feature@feature\/foo"/);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-explicit-tag-feature\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-explicit-tag-feature@refs\/tags\/feature\/foo"/);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper-release\.source must pin git defaults to a tag- or commit-like ref, found "git:github\.com\/example\/helper-release@release-2026"/);
 });
 
 test("check-package-versions rejects latest as the managed Gnosis default", () => {

--- a/tests/check-package-versions.test.mjs
+++ b/tests/check-package-versions.test.mjs
@@ -8,12 +8,32 @@ import test from "node:test";
 const repoRoot = resolve(import.meta.dirname, "..");
 const checkPackageVersionsScript = join(repoRoot, "scripts", "check-package-versions.mjs");
 
-function tempFixture({ packageVersion, lockfileVersion = packageVersion, rootPackageVersion = packageVersion }) {
+function tempFixture({
+	packageVersion,
+	lockfileVersion = packageVersion,
+	rootPackageVersion = packageVersion,
+	dependencies = {},
+	devDependencies = {},
+	peerDependencies = {},
+	defaultExtensions = [{ id: "helper", source: "npm:helper@1.2.3" }],
+	gnosisVersion = "0.5.3",
+	installVersion = gnosisVersion,
+	includeLatestReleaseUrl = true,
+} = {}) {
 	const dir = mkdtempSync(join(tmpdir(), "tlh-check-package-versions-test-"));
 	const packagePath = join(dir, "package.json");
 	const lockfilePath = join(dir, "package-lock.json");
+	const defaultExtensionsPath = join(dir, "default-extensions.json");
+	const gnosisScriptPath = join(dir, "tlh-gnosis.mjs");
+	const installScriptPath = join(dir, "tlh-install.mjs");
 
-	writeFileSync(packagePath, `${JSON.stringify({ name: "fixture", version: packageVersion }, null, 2)}\n`);
+	writeFileSync(packagePath, `${JSON.stringify({
+		name: "fixture",
+		version: packageVersion,
+		dependencies,
+		devDependencies,
+		peerDependencies,
+	}, null, 2)}\n`);
 	writeFileSync(lockfilePath, `${JSON.stringify({
 		name: "fixture",
 		version: lockfileVersion,
@@ -25,8 +45,17 @@ function tempFixture({ packageVersion, lockfileVersion = packageVersion, rootPac
 			},
 		},
 	}, null, 2)}\n`);
+	writeFileSync(defaultExtensionsPath, `${JSON.stringify(defaultExtensions, null, 2)}\n`);
+	writeFileSync(gnosisScriptPath, `const DEFAULT_GNOSIS_VERSION = ${JSON.stringify(gnosisVersion)};\n`);
+	writeFileSync(installScriptPath, [
+		`const DEFAULT_GNOSIS_VERSION = ${JSON.stringify(installVersion)};`,
+		includeLatestReleaseUrl
+			? 'const LATEST_RELEASE_URL = "https://github.com/example/the-last-harness/releases/latest/download/install.sh";'
+			: "",
+		"",
+	].join("\n"));
 
-	return { packagePath, lockfilePath };
+	return { packagePath, lockfilePath, defaultExtensionsPath, gnosisScriptPath, installScriptPath };
 }
 
 function runCheckPackageVersions(fixture) {
@@ -34,19 +63,46 @@ function runCheckPackageVersions(fixture) {
 		checkPackageVersionsScript,
 		"--package", fixture.packagePath,
 		"--lockfile", fixture.lockfilePath,
+		"--default-extensions", fixture.defaultExtensionsPath,
+		"--gnosis-script", fixture.gnosisScriptPath,
+		"--gnosis-script", fixture.installScriptPath,
 	], {
 		cwd: repoRoot,
 		encoding: "utf8",
 	});
 }
 
-test("check-package-versions passes when package metadata versions match", () => {
-	const fixture = tempFixture({ packageVersion: "1.2.3" });
+test("check-package-versions passes with pinned dependency exceptions and ignores allowed ranges/URLs", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		dependencies: {
+			eslint: "9.39.4",
+			aliased: "npm:helper@1.2.3",
+			githubHelper: "github:example/github-helper#v1.2.3",
+			releaseHelper: "https://github.com/example/release-helper/releases/download/v1.2.3/release-helper-1.2.3.tgz",
+			archiveTagHelper: "https://github.com/example/archive-tag-helper/archive/refs/tags/v1.2.3.tar.gz",
+			workspaceHelper: "workspace:*",
+		},
+		devDependencies: {
+			typescript: "6.0.3",
+			fileHelper: "file:../file-helper",
+			linkHelper: "link:../link-helper",
+			zipballTagHelper: "https://github.com/example/zipball-tag-helper/zipball/refs/tags/v1.2.3",
+			sshHelper: "git+ssh://git@github.com/example/ssh-helper.git#abcdef1234567",
+		},
+		peerDependencies: {
+			"@earendil-works/pi-coding-agent": ">=0.79.1 <=0.79.7",
+		},
+		defaultExtensions: [
+			{ id: "helper", source: "npm:helper@1.2.3" },
+			{ id: "forked-helper", source: "git:github.com/example/helper@tlh-v1.2.3" },
+		],
+	});
 
 	const result = runCheckPackageVersions(fixture);
 
 	assert.equal(result.status, 0);
-	assert.match(result.stdout, /all tracked version fields match \(1\.2\.3\)/);
+	assert.match(result.stdout, /all tracked version fields match \(1\.2\.3\), and managed dependency pins are valid/);
 	assert.equal(result.stderr, "");
 });
 
@@ -64,4 +120,96 @@ test("check-package-versions reports the mismatched file fields", () => {
 	assert.match(result.stderr, /package\.json#version: "1\.2\.3"/);
 	assert.match(result.stderr, /package-lock\.json#version: "1\.2\.4"/);
 	assert.match(result.stderr, /package-lock\.json#packages\[""\]\.version: "1\.2\.3"/);
+});
+
+test("check-package-versions rejects loose dependencies and devDependencies", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		dependencies: {
+			eslint: "^9.39.4",
+		},
+		devDependencies: {
+			typescript: "latest",
+		},
+		peerDependencies: {
+			allowed: "^1.0.0",
+		},
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /package\.json#dependencies\.eslint must use an exact version or pinned non-registry source, found "\^9\.39\.4"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.typescript must use an exact version or pinned non-registry source, found "latest"/);
+	assert.doesNotMatch(result.stderr, /peerDependencies/);
+});
+
+test("check-package-versions rejects floating git/github/http/ssh package sources", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		dependencies: {
+			gitHelper: "git+https://github.com/example/git-helper.git",
+			githubHelper: "github:example/github-helper",
+			httpArchiveBranchHelper: "https://github.com/example/http-archive-branch-helper/archive/refs/heads/main.tar.gz",
+		},
+		devDependencies: {
+			httpHelper: "https://github.com/example/http-helper/releases/latest/download/http-helper.tgz",
+			httpTarballBranchHelper: "https://github.com/example/http-tarball-branch-helper/tarball/refs/heads/main",
+			httpZipballBranchHelper: "https://github.com/example/http-zipball-branch-helper/zipball/refs/heads/main",
+			sshHelper: "ssh://git@github.com/example/ssh-helper.git#main",
+		},
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /package\.json#dependencies\.gitHelper must use an exact version or pinned non-registry source, found "git\+https:\/\/github\.com\/example\/git-helper\.git"/);
+	assert.match(result.stderr, /package\.json#dependencies\.githubHelper must use an exact version or pinned non-registry source, found "github:example\/github-helper"/);
+	assert.match(result.stderr, /package\.json#dependencies\.httpArchiveBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-archive-branch-helper\/archive\/refs\/heads\/main\.tar\.gz"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-helper\/releases\/latest\/download\/http-helper\.tgz"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpTarballBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-tarball-branch-helper\/tarball\/refs\/heads\/main"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.httpZipballBranchHelper must use an exact version or pinned non-registry source, found "https:\/\/github\.com\/example\/http-zipball-branch-helper\/zipball\/refs\/heads\/main"/);
+	assert.match(result.stderr, /package\.json#devDependencies\.sshHelper must use an exact version or pinned non-registry source, found "ssh:\/\/git@github\.com\/example\/ssh-helper\.git#main"/);
+});
+
+test("check-package-versions rejects unversioned bundled npm defaults", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		defaultExtensions: [
+			{ id: "helper", source: "npm:helper" },
+		],
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /default-extensions\.json#helper\.source must pin npm defaults to an exact version, found "npm:helper"/);
+});
+
+test("check-package-versions rejects bundled git defaults without refs", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		defaultExtensions: [
+			{ id: "forked-helper", source: "git:github.com/example/helper" },
+		],
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /default-extensions\.json#forked-helper\.source must pin git defaults to an explicit ref, found "git:github\.com\/example\/helper"/);
+});
+
+test("check-package-versions rejects latest as the managed Gnosis default", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		gnosisVersion: "latest",
+		installVersion: "latest",
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /tlh-gnosis\.mjs#DEFAULT_GNOSIS_VERSION must use an exact version, found "latest"/);
+	assert.match(result.stderr, /tlh-install\.mjs#DEFAULT_GNOSIS_VERSION must use an exact version, found "latest"/);
 });

--- a/tests/check-package-versions.test.mjs
+++ b/tests/check-package-versions.test.mjs
@@ -198,6 +198,20 @@ test("check-package-versions rejects unversioned bundled npm defaults", () => {
 	assert.match(result.stderr, /default-extensions\.json#helper\.source must pin npm defaults to an exact version, found "npm:helper"/);
 });
 
+test("check-package-versions rejects bundled default sources that are neither npm nor git", () => {
+	const fixture = tempFixture({
+		packageVersion: "1.2.3",
+		defaultExtensions: [
+			{ id: "local-helper", source: "./extensions/local-helper" },
+		],
+	});
+
+	const result = runCheckPackageVersions(fixture);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /default-extensions\.json#local-helper\.source must use a pinned npm or git source, found "\.\/extensions\/local-helper"/);
+});
+
 test("check-package-versions rejects bundled git defaults without refs", () => {
 	const fixture = tempFixture({
 		packageVersion: "1.2.3",

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -698,6 +698,25 @@ test("tlh-defaults sources emit bundled pinned npm sources for existing unpinned
 	assert.deepEqual(sources, ["npm:@diegopetrucci/pi-oracle@0.1.12"]);
 });
 
+test("tlh-defaults sources emit the bundled npm pin when the installed managed package has an older same-identity pin", () => {
+	const fixture = tempFixture();
+	writeFileSync(fixture.extensions, JSON.stringify([
+		{
+			id: "oracle",
+			source: "npm:@diegopetrucci/pi-oracle@0.1.13",
+		},
+	], null, 2));
+	writeFileSync(fixture.settings, JSON.stringify({
+		packages: ["npm:@diegopetrucci/pi-oracle@0.1.12"],
+	}, null, 2));
+
+	const sources = runNode(defaultsScript, ["--settings", fixture.settings, "--defaults", fixture.extensions, "sources"])
+		.trim()
+		.split("\n")
+		.filter(Boolean);
+	assert.deepEqual(sources, ["npm:@diegopetrucci/pi-oracle@0.1.13"]);
+});
+
 test("tlh-defaults sources still respect disabled and deferred defaults while pinning managed npm defaults", () => {
 	const fixture = tempFixture();
 	writeFileSync(fixture.extensions, JSON.stringify([

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -13,6 +13,19 @@ const mergeScript = join(repoRoot, "scripts", "merge-settings.mjs");
 const defaultsScript = join(repoRoot, "scripts", "tlh-defaults.mjs");
 const harnessPackage = "git:github.com/diegopetrucci/the-last-harness";
 const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
+const expectedBundledNpmSources = new Map([
+	["oracle", "npm:@diegopetrucci/pi-oracle@0.1.12"],
+	["openai-fast", "npm:@diegopetrucci/pi-openai-fast@0.1.4"],
+	["anthropic-auth", "npm:@gotgenes/pi-anthropic-auth@0.6.2"],
+	["librarian", "npm:@diegopetrucci/pi-librarian@0.1.5"],
+	["fff", "npm:@ff-labs/pi-fff@0.9.5"],
+	["inline-bash", "npm:@diegopetrucci/pi-inline-bash@0.1.2"],
+	["notify", "npm:@diegopetrucci/pi-notify@0.1.5"],
+	["context-inspector", "npm:@diegopetrucci/pi-context-inspector@0.1.2"],
+	["quiet-tools", "npm:@diegopetrucci/pi-quiet-tools@0.1.3"],
+	["dirty-repo-guard", "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.2"],
+	["triage-comments", "npm:@diegopetrucci/pi-triage-comments@0.1.3"],
+]);
 
 function tempFixture() {
 	const dir = mkdtempSync(join(tmpdir(), "tlh-defaults-test-"));
@@ -114,7 +127,7 @@ test("bundled manifest keeps quiet-tools-compatible rtk load order", () => {
 	const dirtyRepoGuard = bundled.find(({ id }) => id === "dirty-repo-guard");
 
 	assert.ok(dirtyRepoGuard, "bundled dirty-repo-guard default should exist");
-	assert.equal(dirtyRepoGuard.source, "npm:@diegopetrucci/pi-dirty-repo-guard");
+	assert.equal(dirtyRepoGuard.source, expectedBundledNpmSources.get("dirty-repo-guard"));
 	assert.equal(ids.includes("permission-gate"), false);
 	assert.equal(ids.includes("confirm-destructive"), false);
 	assert.ok(rtk, "bundled rtk default should exist");
@@ -128,6 +141,15 @@ test("bundled manifest keeps quiet-tools-compatible rtk load order", () => {
 	assert.equal(rtk.critical, false);
 	assert.equal(rtk.source, "git:github.com/diegopetrucci/pi-rtk@tlh-v0.6.0-5");
 	assert(ids.indexOf("rtk") < ids.indexOf("quiet-tools"), "quiet-tools should load after rtk");
+});
+
+test("bundled manifest pins every managed npm default to an explicit version", () => {
+	const bundled = readDefaultExtensions(join(repoRoot, "config", "default-extensions.json"));
+	const bundledById = new Map(bundled.map((extension) => [extension.id, extension]));
+
+	for (const [id, source] of expectedBundledNpmSources) {
+		assert.equal(bundledById.get(id)?.source, source, `${id} should stay pinned to ${source}`);
+	}
 });
 
 test("tlh-defaults errors when the default-extension manifest is missing", () => {
@@ -655,6 +677,58 @@ test("tlh-defaults keeps non-critical allowlisted package entrypoints enabled", 
 		.split("\n")
 		.filter(Boolean);
 	assert.deepEqual(sources, ["npm:helper"]);
+});
+
+test("tlh-defaults sources emit bundled pinned npm sources for existing unpinned managed defaults", () => {
+	const fixture = tempFixture();
+	writeFileSync(fixture.extensions, JSON.stringify([
+		{
+			id: "oracle",
+			source: "npm:@diegopetrucci/pi-oracle@0.1.12",
+		},
+	], null, 2));
+	writeFileSync(fixture.settings, JSON.stringify({
+		packages: ["npm:@diegopetrucci/pi-oracle"],
+	}, null, 2));
+
+	const sources = runNode(defaultsScript, ["--settings", fixture.settings, "--defaults", fixture.extensions, "sources"])
+		.trim()
+		.split("\n")
+		.filter(Boolean);
+	assert.deepEqual(sources, ["npm:@diegopetrucci/pi-oracle@0.1.12"]);
+});
+
+test("tlh-defaults sources still respect disabled and deferred defaults while pinning managed npm defaults", () => {
+	const fixture = tempFixture();
+	writeFileSync(fixture.extensions, JSON.stringify([
+		{
+			id: "oracle",
+			source: "npm:@diegopetrucci/pi-oracle@0.1.12",
+		},
+		{
+			id: "notify",
+			source: "npm:@diegopetrucci/pi-notify@0.1.5",
+		},
+		{
+			id: "pi-web-access",
+			replaces: ["npm:pi-web-access", "git:github.com/nicobailon/pi-web-access"],
+			source: "git:github.com/diegopetrucci/pi-web-access@tlh-v0.10.7-1",
+		},
+	], null, 2));
+	writeFileSync(fixture.settings, JSON.stringify({
+		packages: [
+			"npm:@diegopetrucci/pi-oracle",
+			"npm:@diegopetrucci/pi-notify",
+			"npm:pi-web-access",
+		],
+		tlh: { disabledDefaultExtensions: ["notify"] },
+	}, null, 2));
+
+	const sources = runNode(defaultsScript, ["--settings", fixture.settings, "--defaults", fixture.extensions, "sources"])
+		.trim()
+		.split("\n")
+		.filter(Boolean);
+	assert.deepEqual(sources, ["npm:@diegopetrucci/pi-oracle@0.1.12"]);
 });
 
 test("tlh-defaults sources defers non-migrating replacements and ignores stale/manual critical opt-outs", () => {

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -995,6 +995,24 @@ test("stage-1 infers update track unless env or CLI overrides", (t) => {
 	assert.equal(configFor(["--track", "ref"], { TLH_REF: "v1.2.3", TLH_UPDATE_TRACK: "latest-release" }).updateTrack, "ref");
 });
 
+test("stage-1 defaults managed Gnosis to the pinned release and still honors env overrides", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	mkdirSync(homeDir, { recursive: true });
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const configFor = (overrides = {}) => {
+		const env = scrubInstallerEnv({ HOME: homeDir, ...overrides });
+		return buildInstallConfig(parseArgs(["--agent-dir", agentDir, "--bin-dir", binDir], env), env);
+	};
+
+	assert.equal(configFor().gnosisVersion, "0.5.3");
+	assert.equal(configFor({ TLH_GNOSIS_VERSION: "latest" }).gnosisVersion, "latest");
+	assert.equal(configFor({ TLH_GNOSIS_VERSION: "0.5.2" }).gnosisVersion, "0.5.2");
+});
+
 test("stage-1 --no-settings does not short-circuit Gnosis configure", (t) => {
 	const root = makeTempDir();
 	const homeDir = join(root, "home");

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -476,6 +476,33 @@ test("merge --force preserves tlh.telemetry.enabled=false while applying default
 	assert.equal(settings.tlh.telemetry.enabled, false, "telemetry opt-out must survive forced reruns");
 });
 
+test("merge migrates existing unpinned managed npm default package sources to bundled pinned sources without --force", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				"npm:@diegopetrucci/pi-oracle",
+			],
+		},
+		[
+			{
+				id: "oracle",
+				source: "npm:@diegopetrucci/pi-oracle@0.1.12",
+			},
+		],
+	);
+
+	runMerge(fixture);
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(settings.packages, [
+		harnessPackage,
+		"npm:@diegopetrucci/pi-oracle@0.1.12",
+	]);
+	assert.deepEqual(settings.tlh?.defaultExtensionProvenance?.managedPackageIdentities, ["npm:@diegopetrucci/pi-oracle"]);
+});
+
 test("critical source updates dedupe stale same-identity filtered packages", () => {
 	const criticalSource = "git:github.com/example/pi-critical@v2";
 	const fixture = tempFixture(

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -503,6 +503,79 @@ test("merge migrates existing unpinned managed npm default package sources to bu
 	assert.deepEqual(settings.tlh?.defaultExtensionProvenance?.managedPackageIdentities, ["npm:@diegopetrucci/pi-oracle"]);
 });
 
+test("merge updates managed pinned npm default package sources when the bundled manifest pin changes", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				"npm:@diegopetrucci/pi-oracle@0.1.12",
+			],
+			tlh: {
+				defaultExtensionProvenance: {
+					managedPackageIdentities: ["npm:@diegopetrucci/pi-oracle"],
+				},
+			},
+		},
+		[
+			{
+				id: "oracle",
+				source: "npm:@diegopetrucci/pi-oracle@0.1.13",
+			},
+		],
+	);
+
+	runMerge(fixture);
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(settings.packages, [
+		harnessPackage,
+		"npm:@diegopetrucci/pi-oracle@0.1.13",
+	]);
+	assert.deepEqual(settings.tlh?.defaultExtensionProvenance?.managedPackageIdentities, ["npm:@diegopetrucci/pi-oracle"]);
+});
+
+test("merge preserves older pinned npm package sources without managed default provenance", () => {
+	const fixture = tempFixture(
+		{ packages: [] },
+		{
+			packages: [
+				harnessPackage,
+				"npm:@diegopetrucci/pi-oracle@0.1.12",
+			],
+		},
+		[
+			{
+				id: "oracle",
+				source: "npm:@diegopetrucci/pi-oracle@0.1.13",
+			},
+		],
+	);
+
+	const firstOutput = runMerge(fixture, { quiet: false });
+	const afterFirst = readJson(fixture.settings);
+	const afterFirstRaw = readFileSync(fixture.settings, "utf8");
+
+	assert.doesNotMatch(firstOutput, /update default extension package source/);
+	assert.deepEqual(afterFirst.packages, [
+		harnessPackage,
+		"npm:@diegopetrucci/pi-oracle@0.1.12",
+	]);
+	assert.deepEqual(afterFirst.tlh?.defaultExtensionProvenance?.managedPackageIdentities ?? [], []);
+
+	const secondOutput = runMerge(fixture, { quiet: false });
+	const afterSecond = readJson(fixture.settings);
+
+	assert.match(secondOutput, /No settings changes needed\./);
+	assert.doesNotMatch(secondOutput, /update default extension package source/);
+	assert.equal(readFileSync(fixture.settings, "utf8"), afterFirstRaw);
+	assert.deepEqual(afterSecond.packages, [
+		harnessPackage,
+		"npm:@diegopetrucci/pi-oracle@0.1.12",
+	]);
+	assert.deepEqual(afterSecond.tlh?.defaultExtensionProvenance?.managedPackageIdentities ?? [], []);
+});
+
 test("critical source updates dedupe stale same-identity filtered packages", () => {
 	const criticalSource = "git:github.com/example/pi-critical@v2";
 	const fixture = tempFixture(

--- a/tests/tlh-gnosis.test.mjs
+++ b/tests/tlh-gnosis.test.mjs
@@ -60,6 +60,47 @@ function sha256File(path) {
 	return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
+test("install-managed dry-run uses the pinned default Gnosis release", () => {
+	const fixture = tempFixture();
+
+	const result = runGnosis([
+		"--agent-dir", fixture.agent,
+		"--target", join(fixture.agent, "bin", "gn"),
+		"--dry-run",
+		"install-managed",
+	], { env: { HOME: fixture.home } });
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stderr, /Would download Gnosis 0\.5\.3 from https:\/\/github\.com\/skorokithakis\/gnosis/);
+	assert.equal(result.stdout.trim(), join(fixture.agent, "bin", "gn"));
+});
+
+test("install-managed dry-run still honors TLH_GNOSIS_VERSION and CLI overrides", () => {
+	const fixture = tempFixture();
+	const target = join(fixture.agent, "bin", "gn");
+
+	const envOverride = runGnosis([
+		"--agent-dir", fixture.agent,
+		"--target", target,
+		"--dry-run",
+		"install-managed",
+	], {
+		env: { HOME: fixture.home, TLH_GNOSIS_VERSION: "latest" },
+	});
+	assert.equal(envOverride.status, 0, envOverride.stderr);
+	assert.match(envOverride.stderr, /Would download latest compatible release from https:\/\/github\.com\/skorokithakis\/gnosis/);
+
+	const cliOverride = runGnosis([
+		"--agent-dir", fixture.agent,
+		"--target", target,
+		"--gnosis-version", "0.5.2",
+		"--dry-run",
+		"install-managed",
+	], { env: { HOME: fixture.home, TLH_GNOSIS_VERSION: "latest" } });
+	assert.equal(cliOverride.status, 0, cliOverride.stderr);
+	assert.match(cliOverride.stderr, /Would download Gnosis 0\.5\.2 from https:\/\/github\.com\/skorokithakis\/gnosis/);
+});
+
 test("install-managed rejects agent bin symlink before network or writes", () => {
 	const fixture = tempFixture();
 	symlinkDirectory(fixture.external, join(fixture.agent, "bin"));


### PR DESCRIPTION
## Summary

- Pin top-level package dependencies/devDependencies, bundled npm default extensions, and the managed Gnosis default.
- Add validation guards against loose TLH-controlled dependency specs and floating managed defaults.
- Migrate existing unversioned managed npm defaults to manifest-pinned sources during normal install/update.

## Validation

- `npm run validate` — passed

## Review notes

- Peer dependency ranges are intentionally preserved for upstream compatibility.
- Existing TLH git-fork defaults remain tag-pinned.

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/pin-tlh-dependencies/install.sh | bash -s -- --ref pin-tlh-dependencies --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated install and integration guides to document pinned default versions and override options.
  * Added contributor guidance for handling CI checks and PR review comments.

* **Changes**
  * Managed Gnosis now defaults to pinned version `v0.5.3` instead of latest (overridable via environment variable or CLI flag).
  * Default extension packages are now pinned to explicit versions in the bundle.
  * Package dependencies use exact version pinning (removed semver ranges).

* **Tests**
  * Added test coverage for version pinning behavior and Gnosis default handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->