### PR TITLE
Fix migrated runtime uninstall safety

### DIFF
--- a/scripts/check-installer-smoke.sh
+++ b/scripts/check-installer-smoke.sh
@@ -131,30 +131,26 @@ EOF_MANAGED_WRAPPER
   chmod +x "${wrapper_path}"
 }
 
-write_runtime_ownership_marker() {
-  # Write a valid .tlh-runtime-owned marker into an existing runtime dir.
-  # runtimeAbsPath is derived via pwd -P so macOS /var -> /private/var resolves
-  # correctly and matches what Node.js realpathSync returns in tlh-install.mjs.
-  local runtime_dir="$1"
-  local _marker_abs
-  _marker_abs="$(cd "${runtime_dir}" >/dev/null 2>&1 && pwd -P)"
-  printf '{"schemaVersion":1,"packageName":"@earendil-works/pi-coding-agent","runtimeAbsPath":"%s","origin":"created"}' \
-    "${_marker_abs}" >"${runtime_dir}/.tlh-runtime-owned"
-}
-
 write_tlh_pi_runtime() {
   # Seed the TLH pi runtime layout produced by:
   #   npm install -g --ignore-scripts --prefix <runtime_dir> @earendil-works/pi-coding-agent
   # Presence of both runtime_dir/bin/pi and
-  # runtime_dir/lib/node_modules/@earendil-works/pi-coding-agent is the ownership
-  # predicate checked by the uninstaller before rm -rf.
-  # A valid .tlh-runtime-owned marker is also written so the installer's and
-  # uninstaller's ownership gates both pass.
+  # runtime_dir/lib/node_modules/@earendil-works/pi-coding-agent is the base
+  # ownership/layout predicate checked by the uninstaller.
   local runtime_dir="$1"
   mkdir -p "${runtime_dir}/bin" "${runtime_dir}/lib/node_modules/@earendil-works/pi-coding-agent"
   printf '#!/bin/sh\n' >"${runtime_dir}/bin/pi"
   chmod +x "${runtime_dir}/bin/pi"
-  write_runtime_ownership_marker "${runtime_dir}"
+}
+
+write_tlh_runtime_marker() {
+  local runtime_dir="$1"
+  local origin="$2"
+  local marker_abs
+
+  marker_abs="$(cd "${runtime_dir}" >/dev/null 2>&1 && pwd -P)"
+  printf '{"schemaVersion":1,"packageName":"@earendil-works/pi-coding-agent","runtimeAbsPath":"%s","origin":"%s"}' \
+    "${marker_abs}" "${origin}" >"${runtime_dir}/.tlh-runtime-owned"
 }
 
 assert_pi_commands_isolated() {
@@ -1401,7 +1397,7 @@ EOF_PRESENT_GIT
   # Write a valid ownership marker for the pre-seeded runtime so the installer's
   # assertRuntimePrefixOwnedOrEmpty gate passes and the reuse path runs.
   # runtimeAbsPath uses pwd -P so macOS /var -> /private/var matches Node.js realpathSync.
-  write_runtime_ownership_marker "${present_dir}/runtime"
+  write_tlh_runtime_marker "${present_dir}/runtime" created
   # Seed a valid private runtime pi (pinned version) at the expected location.
   cat >"${present_runtime_bin}/pi" <<'EOF_PRESENT_RUNTIME_PI'
 #!/bin/sh
@@ -1539,12 +1535,12 @@ run_uninstall_dry_run_pi_smoke() {
   local combined_file="${case_dir}/combined.log"
   mkdir -p "${case_dir}"
 
-  # ── piInstalledByTlh:true → plan shows private runtime removal ───────────
+  # ── piInstalledByTlh:true + origin=created marker → rm -rf plan ──────────
   local true_agent="${case_dir}/pi-true/agent"
   local true_runtime="${case_dir}/pi-true/runtime"
   mkdir -p "${true_agent}/tlh"
-  # Seed the TLH pi layout so the ownership check passes.
   write_tlh_pi_runtime "${true_runtime}"
+  write_tlh_runtime_marker "${true_runtime}" created
   cat >"${true_agent}/tlh/install-state.json" <<'EOF_UNINSTALL_STATE_TRUE'
 {
   "schemaVersion": 1,
@@ -1556,6 +1552,69 @@ EOF_UNINSTALL_STATE_TRUE
   bash uninstall.sh --dry-run --agent-dir "${true_agent}" --bin-dir "${case_dir}/bin-true" >"${stdout_file}" 2>"${stderr_file}"
   combine_output "${stdout_file}" "${stderr_file}" "${combined_file}"
   assert_contains "${combined_file}" "would remove private runtime: rm -rf ${true_runtime}"
+
+  # ── piInstalledByTlh:true + origin=migrated marker → npm uninstall plan ──
+  local migrated_agent="${case_dir}/pi-migrated/agent"
+  local migrated_runtime="${case_dir}/pi-migrated/runtime"
+  mkdir -p "${migrated_agent}/tlh"
+  write_tlh_pi_runtime "${migrated_runtime}"
+  write_tlh_runtime_marker "${migrated_runtime}" migrated
+  cat >"${migrated_agent}/tlh/install-state.json" <<'EOF_UNINSTALL_STATE_MIGRATED'
+{
+  "schemaVersion": 1,
+  "repo": "diegopetrucci/the-last-harness",
+  "piInstalledByTlh": true
+}
+EOF_UNINSTALL_STATE_MIGRATED
+
+  : >"${stdout_file}"
+  : >"${stderr_file}"
+  bash uninstall.sh --dry-run --agent-dir "${migrated_agent}" --bin-dir "${case_dir}/bin-migrated" >"${stdout_file}" 2>"${stderr_file}"
+  combine_output "${stdout_file}" "${stderr_file}" "${combined_file}"
+  assert_contains "${combined_file}" "would remove migrated TLH pi from shared runtime (npm): npm uninstall -g --ignore-scripts --prefix \"${migrated_runtime}\" @earendil-works/pi-coding-agent"
+  assert_not_contains "${combined_file}" "would remove private runtime: rm -rf ${migrated_runtime}"
+
+  # ── piInstalledByTlh:true + unmarked runtime → plan shows skip ────────────
+  local unmarked_agent="${case_dir}/pi-unmarked/agent"
+  local unmarked_runtime="${case_dir}/pi-unmarked/runtime"
+  mkdir -p "${unmarked_agent}/tlh"
+  write_tlh_pi_runtime "${unmarked_runtime}"
+  cat >"${unmarked_agent}/tlh/install-state.json" <<'EOF_UNINSTALL_STATE_UNMARKED'
+{
+  "schemaVersion": 1,
+  "repo": "diegopetrucci/the-last-harness",
+  "piInstalledByTlh": true
+}
+EOF_UNINSTALL_STATE_UNMARKED
+
+  : >"${stdout_file}"
+  : >"${stderr_file}"
+  bash uninstall.sh --dry-run --agent-dir "${unmarked_agent}" --bin-dir "${case_dir}/bin-unmarked" >"${stdout_file}" 2>"${stderr_file}"
+  combine_output "${stdout_file}" "${stderr_file}" "${combined_file}"
+  assert_contains "${combined_file}" "would skip pi/runtime removal"
+  assert_contains "${combined_file}" "${unmarked_runtime} looks like a TLH pi runtime but has no valid TLH runtime ownership marker"
+
+  # ── origin=migrated marker overrides piInstalledByTlh:false → npm uninstall plan ──
+  local migrated_false_agent="${case_dir}/pi-migrated-false/agent"
+  local migrated_false_runtime="${case_dir}/pi-migrated-false/runtime"
+  mkdir -p "${migrated_false_agent}/tlh"
+  write_tlh_pi_runtime "${migrated_false_runtime}"
+  write_tlh_runtime_marker "${migrated_false_runtime}" migrated
+  cat >"${migrated_false_agent}/tlh/install-state.json" <<'EOF_UNINSTALL_STATE_MIGRATED_FALSE'
+{
+  "schemaVersion": 1,
+  "repo": "diegopetrucci/the-last-harness",
+  "piInstalledByTlh": false
+}
+EOF_UNINSTALL_STATE_MIGRATED_FALSE
+
+  : >"${stdout_file}"
+  : >"${stderr_file}"
+  bash uninstall.sh --dry-run --agent-dir "${migrated_false_agent}" --bin-dir "${case_dir}/bin-migrated-false" >"${stdout_file}" 2>"${stderr_file}"
+  combine_output "${stdout_file}" "${stderr_file}" "${combined_file}"
+  assert_contains "${combined_file}" "would remove migrated TLH pi from shared runtime (npm): npm uninstall -g --ignore-scripts --prefix \"${migrated_false_runtime}\" @earendil-works/pi-coding-agent"
+  assert_not_contains "${combined_file}" "would skip pi/runtime removal (install-state: piInstalledByTlh=false)"
+  assert_not_contains "${combined_file}" "would remove private runtime: rm -rf ${migrated_false_runtime}"
 
   # ── piInstalledByTlh:false → plan shows skip ──────────────────────────────
   local false_agent="${case_dir}/pi-false/agent"
@@ -1606,8 +1665,9 @@ run_uninstall_flag_override_smoke() {
   local force_agent="${case_dir}/force-include/agent"
   local force_runtime="${case_dir}/force-include/runtime"
   mkdir -p "${force_agent}/tlh"
-  # Seed the TLH pi layout so the ownership gate passes.
+  # Seed the TLH pi layout and origin=created marker so the runtime-removal path is eligible.
   write_tlh_pi_runtime "${force_runtime}"
+  write_tlh_runtime_marker "${force_runtime}" created
   cat >"${force_agent}/tlh/install-state.json" <<'EOF_FORCE_STATE'
 {
   "schemaVersion": 1,
@@ -2085,15 +2145,17 @@ run_uninstall_runtime_ownership_smoke() {
   assert_present "${unrelated_runtime}/not-tlh.txt"
   assert_present "${unrelated_runtime}"
 
-  # ── Case 2: TLH-owned runtime (proper layout) → IS removed ────────────────
-  # piInstalledByTlh=true AND RUNTIME_DIR has the expected TLH pi layout.
-  # The uninstaller must plan and execute removal.
+  # ── Case 2: TLH-created runtime (proper layout + marker) → IS removed ─────
+  # piInstalledByTlh=true, the runtime has the expected TLH pi layout, and the
+  # origin=created ownership marker is present. The uninstaller must plan and
+  # execute removal.
   local owned_dir="${case_dir}/owned"
   local owned_agent="${owned_dir}/agent"
   local owned_runtime="${owned_dir}/runtime"
   assert_safe_uninstall_smoke_paths "${owned_agent}" "${case_dir}/bin-owned"
   write_tlh_install_state "${owned_agent}" true
   write_tlh_pi_runtime "${owned_runtime}"
+  write_tlh_runtime_marker "${owned_runtime}" created
 
   # dry-run: plan must show removal.
   : >"${stdout_file}"
@@ -2119,6 +2181,7 @@ run_uninstall_runtime_ownership_smoke() {
   assert_safe_uninstall_smoke_paths "${mixed_agent}" "${case_dir}/bin-mixed"
   write_tlh_install_state "${mixed_agent}" true
   write_tlh_pi_runtime "${mixed_runtime}"
+  write_tlh_runtime_marker "${mixed_runtime}" created
   # Seed the co-located sentinel alongside the TLH pi layout.
   printf 'user co-located data — must survive\n' >"${mixed_sentinel}"
 
@@ -2150,6 +2213,7 @@ run_uninstall_runtime_ownership_smoke() {
   assert_safe_uninstall_smoke_paths "${dotdot_agent}" "${case_dir}/bin-dotdot"
   write_tlh_install_state "${dotdot_agent}" true
   write_tlh_pi_runtime "${dotdot_runtime}"
+  write_tlh_runtime_marker "${dotdot_runtime}" created
   # Seed a '..userdata' sentinel alongside the TLH pi layout.
   printf 'user dotdot-named data — must survive\n' >"${dotdot_sentinel}"
 
@@ -2169,6 +2233,53 @@ run_uninstall_runtime_ownership_smoke() {
   assert_absent "${dotdot_agent}"
   assert_present "${dotdot_sentinel}"
   assert_present "${dotdot_runtime}"
+
+  # ── Case 5: migrated runtime → surgical uninstall clears marker only ───────
+  # origin=migrated must preserve the shared prefix and foreign packages while
+  # clearing TLH's ownership marker after npm uninstall succeeds.
+  local migrated_dir="${case_dir}/migrated"
+  local migrated_agent="${migrated_dir}/agent"
+  local migrated_runtime="${migrated_dir}/runtime"
+  local migrated_fakebin="${migrated_dir}/fakebin"
+  local migrated_npm_log="${migrated_dir}/npm.log"
+  local foreign_package_dir="${migrated_runtime}/lib/node_modules/foreign-package"
+  local foreign_package_file="${foreign_package_dir}/package.json"
+  assert_safe_uninstall_smoke_paths "${migrated_agent}" "${case_dir}/bin-migrated"
+  write_tlh_install_state "${migrated_agent}" true
+  write_tlh_pi_runtime "${migrated_runtime}"
+  write_tlh_runtime_marker "${migrated_runtime}" migrated
+  mkdir -p "${migrated_fakebin}" "${foreign_package_dir}"
+  printf '{"name":"foreign-package"}\n' >"${foreign_package_file}"
+  cat >"${migrated_fakebin}/npm" <<EOF_MIGRATED_NPM
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >"${migrated_npm_log}"
+if [[ "\$#" -ne 6 || "\$1" != "uninstall" || "\$2" != "-g" || "\$3" != "--ignore-scripts" || "\$4" != "--prefix" || "\$5" != "${migrated_runtime}" || "\$6" != "@earendil-works/pi-coding-agent" ]]; then
+  printf 'unexpected npm args: %s\n' "\$*" >&2
+  exit 97
+fi
+rm -rf "${migrated_runtime}/lib/node_modules/@earendil-works/pi-coding-agent"
+rm -f "${migrated_runtime}/bin/pi"
+EOF_MIGRATED_NPM
+  chmod +x "${migrated_fakebin}/npm"
+
+  : >"${stdout_file}"
+  : >"${stderr_file}"
+  set +e
+  PATH="${migrated_fakebin}:${PATH}" bash uninstall.sh --agent-dir "${migrated_agent}" --bin-dir "${case_dir}/bin-migrated" >"${stdout_file}" 2>"${stderr_file}"
+  status=$?
+  set -e
+  combine_output "${stdout_file}" "${stderr_file}" "${combined_file}"
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${combined_file}" >&2
+    fail "migrated runtime uninstall smoke exited with non-zero status: ${status}"
+  fi
+  assert_contains "${migrated_npm_log}" "uninstall -g --ignore-scripts --prefix ${migrated_runtime} @earendil-works/pi-coding-agent"
+  assert_absent "${migrated_runtime}/.tlh-runtime-owned"
+  assert_absent "${migrated_runtime}/lib/node_modules/@earendil-works/pi-coding-agent"
+  assert_absent "${migrated_runtime}/bin/pi"
+  assert_present "${foreign_package_file}"
+  assert_present "${migrated_runtime}"
 }
 
 run_uninstall_sibling_preservation_smoke() {
@@ -2231,8 +2342,9 @@ run_uninstall_marker_authoritative_smoke() {
   mkdir -p "${bin_dir}"
   # piInstalledByTlh=false: install-state does NOT authorize removal.
   write_tlh_install_state "${agent_dir}" false
-  # Valid-marker runtime: write_tlh_pi_runtime seeds bin/pi, lib/node_modules, and marker.
+  # Valid-marker runtime: seed bin/pi, lib/node_modules, and the ownership marker.
   write_tlh_pi_runtime "${runtime_dir}"
+  write_tlh_runtime_marker "${runtime_dir}" created
   wrapper_path="$(cd "${bin_dir}" >/dev/null 2>&1 && pwd -P)/tlh"
   write_managed_wrapper "${wrapper_path}"
 

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -3148,6 +3148,87 @@ test("uninstall.sh does not remove legacy ~/.local/bin/pi without --force-includ
 	assert.equal(existsSync(join(legacyBin, "pi")), false, "legacy pi should have been removed with --force-include-pi");
 });
 
+test("uninstall.sh regression (tlht-h7vq): migrated runtime marker preserves nested foreign packages during surgical uninstall", (t) => {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const profileRoot = join(root, "profile");
+	const agentDir = join(profileRoot, "agent");
+	const runtimeDir = join(profileRoot, "runtime");
+	const binDir = join(root, "bin");
+	const fakeNpmDir = join(root, "fakenpm");
+	const npmLog = join(root, "npm.log");
+	const markerPath = join(runtimeDir, ".tlh-runtime-owned");
+	const tlhPackageDir = join(runtimeDir, "lib", "node_modules", "@earendil-works", "pi-coding-agent");
+	const foreignPackageDir = join(runtimeDir, "lib", "node_modules", "foreign-package");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(join(agentDir, "tlh"), { recursive: true });
+	mkdirSync(join(runtimeDir, "bin"), { recursive: true });
+	mkdirSync(tlhPackageDir, { recursive: true });
+	mkdirSync(foreignPackageDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(join(agentDir, "tlh", "install-state.json"), JSON.stringify({
+		schemaVersion: 1,
+		repo: "diegopetrucci/the-last-harness",
+		piInstalledByTlh: true,
+	}, null, 2));
+	writeFileSync(join(runtimeDir, "bin", "pi"), "#!/bin/sh\n", "utf8");
+	chmodSync(join(runtimeDir, "bin", "pi"), 0o755);
+	writeFileSync(markerPath, JSON.stringify({
+		schemaVersion: 1,
+		packageName: "@earendil-works/pi-coding-agent",
+		runtimeAbsPath: realpathSync(runtimeDir),
+		origin: "migrated",
+	}), "utf8");
+	writeFileSync(join(tlhPackageDir, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent" }, null, 2));
+	writeFileSync(join(foreignPackageDir, "package.json"), JSON.stringify({ name: "foreign-package" }, null, 2));
+
+	const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const dryResult = spawnSync("bash", [join(repoRoot, "uninstall.sh"), "--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], {
+		cwd: repoRoot,
+		env: scrubInstallerEnv({ HOME: homeDir }),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const dryOutput = `${dryResult.stdout}\n${dryResult.stderr}`;
+
+	assert.equal(dryResult.status, 0, `dry-run failed:\n${dryOutput}`);
+	assert.match(
+		dryOutput,
+		new RegExp(`would remove migrated TLH pi from shared runtime \\(npm\\): npm uninstall -g --ignore-scripts --prefix "${escapeRegex(runtimeDir)}" @earendil-works/pi-coding-agent`),
+	);
+	assert.doesNotMatch(dryOutput, new RegExp(`would remove private runtime: rm -rf ${escapeRegex(runtimeDir)}`));
+	assert.equal(existsSync(foreignPackageDir), true, "dry-run must not remove nested foreign package");
+
+	writeFakeCommand(fakeNpmDir, "npm", [
+		`printf '%s\\n' "$*" >>"${npmLog}"`,
+		`if [[ "$1" != "uninstall" ]]; then printf 'unexpected npm command: %s\\n' "$*" >&2; exit 98; fi`,
+		`rm -f "${join(runtimeDir, "bin", "pi")}"`,
+		`rm -rf "${tlhPackageDir}"`,
+	].join("\n"));
+
+	const realResult = spawnSync("bash", [join(repoRoot, "uninstall.sh"), "--agent-dir", agentDir, "--bin-dir", binDir], {
+		cwd: repoRoot,
+		env: scrubInstallerEnv({ HOME: homeDir, PATH: `${fakeNpmDir}:${process.env.PATH || ""}` }),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const realOutput = `${realResult.stdout}\n${realResult.stderr}`;
+
+	assert.equal(realResult.status, 0, `real uninstall failed:\n${realOutput}`);
+	assert.deepEqual(readFileSync(npmLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [
+		`uninstall -g --ignore-scripts --prefix ${runtimeDir} @earendil-works/pi-coding-agent`,
+	]);
+	assert.equal(existsSync(agentDir), false, "agent dir should be removed after uninstall");
+	assert.equal(existsSync(join(runtimeDir, "bin", "pi")), false, "TLH runtime launcher should be removed surgically");
+	assert.equal(existsSync(tlhPackageDir), false, "TLH runtime package should be removed surgically");
+	assert.equal(existsSync(markerPath), false, "migrated runtime ownership marker should be cleared after uninstall");
+	assert.equal(existsSync(foreignPackageDir), true, "nested foreign package must survive migrated runtime uninstall");
+	assert.equal(readFileSync(join(foreignPackageDir, "package.json"), "utf8"), JSON.stringify({ name: "foreign-package" }, null, 2));
+	assert.equal(existsSync(runtimeDir), true, "shared runtime prefix must survive migrated runtime uninstall");
+});
+
 test("stage-1 refuses to install into a runtime prefix containing a foreign top-level entry", (t) => {
 	const scenarios = [
 		{ label: "normal file", foreignName: "userdata.txt", dryRun: false },

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -636,33 +636,33 @@ fi
 
 # ── disambiguate what pi/runtime removal means (new-model vs legacy) ───────────
 #
-#  private runtime — TLH-owned (valid marker + layout)  → rm -rf RUNTIME_DIR
-#  private runtime — unowned / shared / symlinked       → skip with conditional hint
-#  legacy ~/.local/bin/pi                               → npm uninstall (--force-include-pi only)
-#  neither exists                                       → no-op (skip with reason)
+#  private runtime + valid origin=created marker  → rm -rf RUNTIME_DIR (after layout/tripwire checks)
+#  private runtime + valid origin=migrated marker → npm uninstall -g --prefix RUNTIME_DIR (preserve shared prefix)
+#  private runtime + missing/invalid marker       → skip with conditional hint
+#  legacy ~/.local/bin/pi                         → npm uninstall -g (ONLY with --force-include-pi; never auto)
+#  neither exists                                 → no-op (skip with reason)
 #
 # Safety invariant: never delete ~/.local/bin/pi without --force-include-pi.
 # The uninstall script cannot snapshot pre-install state and therefore cannot
 # know whether ~/.local/bin/pi belongs to TLH or the user.  It is always kept
 # unless the operator explicitly passes --force-include-pi.
 #
-# Ownership gate for RUNTIME_DIR (ALL must hold to rm -rf):
+# Ownership gate for RUNTIME_DIR:
 #   1. Valid RUNTIME_MARKER_FILENAME marker: parseable JSON, schemaVersion=1,
-#      packageName match, origin in {created, migrated}.  Fail-closed: any
+#      packageName match, origin in {created, migrated}. Fail-closed: any
 #      missing / malformed / symlinked / unreadable / schema-mismatched state
 #      → treat as no valid claim → SKIP.
-#   2. Recorded runtimeAbsPath equals realpath of RUNTIME_DIR.  Defends
-#      against marker-copied-into-foreign-dir and relocation.
+#   2. Recorded runtimeAbsPath equals realpath of RUNTIME_DIR. Defends against
+#      marker-copied-into-foreign-dir and relocation.
 #   3. Neither RUNTIME_DIR nor the marker file is a symlink.
 #   4. Positive pi layout present: bin/pi and lib/node_modules/<PI_PACKAGE_NAME>.
 #
-# Exclusivity check (advisory defense-in-depth, DEMOTED from gate to tripwire):
-#   Run after all four gate conditions pass.  Unexpected top-level entries can
-#   only DOWNGRADE to SKIP — never upgrade a failed gate to delete.
-#   RUNTIME_MARKER_FILENAME is in the allow-list so a properly marked runtime
-#   is not wrongly tripped by the marker dotfile.
+# origin=created means TLH created the prefix exclusively, so rm -rf remains
+# eligible — but ONLY after the existing top-level tripwire passes. origin=migrated
+# means TLH adopted an existing prefix, so uninstall must be surgical:
+# npm uninstall -g --ignore-scripts --prefix <prefix> ${PI_PACKAGE_NAME}.
 
-PI_REMOVE_MODE="none"   # "runtime" | "legacy" | "none"
+PI_REMOVE_MODE="none"   # "runtime" | "runtime-package" | "legacy" | "none"
 PI_UNINSTALL_DISPLAY=""
 
 if [[ -d "${RUNTIME_DIR}" && "${KEEP_PI}" != "true" ]]; then
@@ -673,17 +673,18 @@ if [[ -d "${RUNTIME_DIR}" && "${KEEP_PI}" != "true" ]]; then
   _runtime_marker_file="${RUNTIME_DIR}/${RUNTIME_MARKER_FILENAME}"
   _runtime_marker_valid=false
   _runtime_gate_skip_reason=""
+  _runtime_marker_origin=""
 
   if [[ -L "${RUNTIME_DIR}" ]]; then
     _runtime_gate_skip_reason="${RUNTIME_DIR} is a symlink; cannot verify TLH ownership"
   elif [[ -L "${_runtime_marker_file}" ]]; then
     _runtime_gate_skip_reason="ownership marker ${_runtime_marker_file} is a symlink; cannot verify TLH ownership"
   elif [[ ! -f "${_runtime_marker_file}" ]]; then
-    _runtime_gate_skip_reason="no TLH ownership marker found at ${_runtime_marker_file}; ${RUNTIME_DIR} may not be TLH-owned"
+    _runtime_gate_skip_reason="${RUNTIME_DIR} looks like a TLH pi runtime but has no valid TLH runtime ownership marker at ${_runtime_marker_file}. Not removing to protect co-located files"
   else
     # Parse marker JSON (fail-closed; no jq, no node — uninstaller is self-contained).
     # JSON.stringify() produces compact single-line output; each field is extracted by
-    # a BRE sed pattern.  An empty result for any field means absent/malformed → SKIP.
+    # a BRE sed pattern. An empty result for any field means absent/malformed → SKIP.
     _marker_raw="$(cat "${_runtime_marker_file}" 2>/dev/null || true)"
     _mver="$(printf '%s\n' "${_marker_raw}" | sed -n 's/.*"schemaVersion"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
     _mpkg="$(printf '%s\n' "${_marker_raw}" | sed -n 's/.*"packageName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
@@ -691,19 +692,20 @@ if [[ -d "${RUNTIME_DIR}" && "${KEEP_PI}" != "true" ]]; then
     _morigin="$(printf '%s\n' "${_marker_raw}" | sed -n 's/.*"origin"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 
     if [[ "${_mver}" != "1" ]]; then
-      _runtime_gate_skip_reason="ownership marker at ${_runtime_marker_file} has invalid or missing schemaVersion (expected 1, got '${_mver}')"
+      _runtime_gate_skip_reason="${RUNTIME_DIR} looks like a TLH pi runtime but its ownership marker is invalid: ${_runtime_marker_file} (expected schemaVersion 1, got '${_mver}')"
     elif [[ "${_mpkg}" != "${PI_PACKAGE_NAME}" ]]; then
-      _runtime_gate_skip_reason="ownership marker at ${_runtime_marker_file} packageName mismatch (expected '${PI_PACKAGE_NAME}', got '${_mpkg}')"
+      _runtime_gate_skip_reason="${RUNTIME_DIR} looks like a TLH pi runtime but its ownership marker is invalid: ${_runtime_marker_file} (expected packageName '${PI_PACKAGE_NAME}', got '${_mpkg}')"
     elif [[ "${_morigin}" != "created" && "${_morigin}" != "migrated" ]]; then
-      _runtime_gate_skip_reason="ownership marker at ${_runtime_marker_file} has unrecognised origin '${_morigin}' (expected created or migrated)"
+      _runtime_gate_skip_reason="${RUNTIME_DIR} looks like a TLH pi runtime but its ownership marker is invalid: ${_runtime_marker_file} (unrecognised origin '${_morigin}')"
     elif [[ -z "${_mpath}" ]]; then
-      _runtime_gate_skip_reason="ownership marker at ${_runtime_marker_file} has empty runtimeAbsPath"
+      _runtime_gate_skip_reason="${RUNTIME_DIR} looks like a TLH pi runtime but its ownership marker is invalid: ${_runtime_marker_file} (empty runtimeAbsPath)"
     else
       _runtime_real="$(realpath_for_compare "${RUNTIME_DIR}")"
       if [[ "${_mpath}" != "${_runtime_real}" ]]; then
         _runtime_gate_skip_reason="ownership marker runtimeAbsPath '${_mpath}' does not match realpath '${_runtime_real}' of ${RUNTIME_DIR}"
       else
         _runtime_marker_valid=true
+        _runtime_marker_origin="${_morigin}"
       fi
     fi
   fi
@@ -720,14 +722,15 @@ if [[ -d "${RUNTIME_DIR}" && "${KEEP_PI}" != "true" ]]; then
     # Marker valid but positive pi layout absent.
     REMOVE_PI=false
     PI_SKIP_REASON="${RUNTIME_DIR} has a valid TLH ownership marker but the expected pi layout is missing (expected ${RUNTIME_BIN} and ${RUNTIME_DIR}/lib/node_modules/${PI_PACKAGE_NAME}). If this is TLH's private runtime and you no longer need its contents, run: ${_runtime_rm_hint}; otherwise leave it"
+  elif [[ "${_runtime_marker_origin}" == "migrated" ]]; then
+    # Marker is authoritative: origin=migrated always removes surgically,
+    # regardless of install-state or co-located packages.
+    REMOVE_PI=true
+    PI_REMOVE_MODE="runtime-package"
+    PI_UNINSTALL_DISPLAY="npm uninstall -g --ignore-scripts --prefix \"${RUNTIME_DIR}\" ${PI_PACKAGE_NAME}"
   else
-    # All four gate conditions passed.  Exclusivity check (advisory only):
+    # origin=created: exclusivity check remains an advisory tripwire before rm -rf.
     # unexpected top-level entries can DOWNGRADE to SKIP, never upgrade to delete.
-    # Use shopt dotglob+nullglob so a single '*' matches ALL real entries —
-    # including dotfiles — while never matching '.' or '..'.
-    # Save and restore prior shopt state so we don't leak options into the rest
-    # of the script; `eval "${_prev_shopt_state}"` is safe because shopt -p
-    # output is always of the form 'shopt -s|-u <name>'.
     _prev_shopt_state="$(shopt -p dotglob nullglob || true)"
     shopt -s dotglob nullglob
     _runtime_exclusive=true
@@ -744,15 +747,12 @@ if [[ -d "${RUNTIME_DIR}" && "${KEEP_PI}" != "true" ]]; then
           ;;
       esac
     done
-    eval "${_prev_shopt_state}"   # restore dotglob+nullglob to their prior state
+    eval "${_prev_shopt_state}"
     if [[ "${_runtime_exclusive}" == "true" ]]; then
-      # Marker is authoritative: authorize removal regardless of install-state.
       REMOVE_PI=true
       PI_REMOVE_MODE="runtime"
       PI_UNINSTALL_DISPLAY="rm -rf \"${RUNTIME_DIR}\""
     else
-      # Exclusivity tripwire fired (advisory): unexpected entry found.
-      # Downgrade to SKIP to protect co-located files.
       REMOVE_PI=false
       PI_SKIP_REASON="${RUNTIME_DIR} contains unexpected top-level entries alongside the TLH pi layout (e.g. ${_runtime_unexpected_entry}); not removing to protect co-located files. If this is TLH's private runtime and you no longer need its contents, run: ${_runtime_rm_hint}; otherwise leave it"
     fi
@@ -765,14 +765,10 @@ elif [[ "${REMOVE_PI}" == "true" ]]; then
       PI_REMOVE_MODE="legacy"
       PI_UNINSTALL_DISPLAY="npm uninstall -g --ignore-scripts --prefix \"${HOME}/.local\" ${PI_PACKAGE_NAME}"
     else
-      # Never auto-remove legacy ~/.local/bin/pi — the uninstall script cannot snapshot
-      # pre-install state and therefore cannot determine whether this binary belongs to
-      # TLH or to the user.  Require --force-include-pi for any legacy removal.
       REMOVE_PI=false
       PI_SKIP_REASON="legacy ~/.local/bin/pi was not removed automatically (pass --force-include-pi to remove it). To remove manually: npm uninstall -g --ignore-scripts --prefix \"${HOME}/.local\" ${PI_PACKAGE_NAME}"
     fi
   else
-    # Neither the private runtime nor a legacy ~/.local pi is present.
     REMOVE_PI=false
     PI_SKIP_REASON="no pi installation found (neither private runtime at ${RUNTIME_DIR} nor legacy ~/.local/bin/pi)"
   fi
@@ -838,9 +834,17 @@ if [[ "${REMOVE_PI}" == "true" ]]; then
     fi
   else
     if [[ "${DRY_RUN}" == "true" ]]; then
-      say "  ${STEP}. would remove legacy pi (npm): ${PI_UNINSTALL_DISPLAY}"
+      if [[ "${PI_REMOVE_MODE}" == "runtime-package" ]]; then
+        say "  ${STEP}. would remove migrated TLH pi from shared runtime (npm): ${PI_UNINSTALL_DISPLAY}"
+      else
+        say "  ${STEP}. would remove legacy pi (npm): ${PI_UNINSTALL_DISPLAY}"
+      fi
     else
-      say "  ${STEP}. Remove legacy pi (npm): ${PI_UNINSTALL_DISPLAY}"
+      if [[ "${PI_REMOVE_MODE}" == "runtime-package" ]]; then
+        say "  ${STEP}. Remove migrated TLH pi from shared runtime (npm): ${PI_UNINSTALL_DISPLAY}"
+      else
+        say "  ${STEP}. Remove legacy pi (npm): ${PI_UNINSTALL_DISPLAY}"
+      fi
     fi
   fi
 else
@@ -891,6 +895,16 @@ if [[ "${REMOVE_PI}" == "true" ]]; then
       say "  + rmdir ${PROFILE_ROOT}"
     fi
     rmdir "${PROFILE_ROOT}" 2>/dev/null || true
+  elif [[ "${PI_REMOVE_MODE}" == "runtime-package" ]]; then
+    if ! command -v npm >/dev/null 2>&1; then
+      warn "npm not found on PATH; migrated TLH runtime package must be removed manually."
+      warn "To remove: ${PI_UNINSTALL_DISPLAY}"
+    else
+      log "Removing migrated TLH pi from shared runtime via npm..."
+      removal_run npm uninstall -g --ignore-scripts --prefix "${RUNTIME_DIR}" "${PI_PACKAGE_NAME}"
+      log "Clearing migrated TLH runtime ownership marker: ${RUNTIME_DIR}/${RUNTIME_MARKER_FILENAME}"
+      removal_run rm -f "${RUNTIME_DIR}/${RUNTIME_MARKER_FILENAME}"
+    fi
   elif [[ "${PI_REMOVE_MODE}" == "legacy" ]]; then
     if ! command -v npm >/dev/null 2>&1; then
       warn "npm not found on PATH; legacy pi must be removed manually."


### PR DESCRIPTION
## Summary

Fixes the `tlht-h7vq` migrated-runtime uninstall safety edge. Migrated runtime ownership markers now uninstall the TLH runtime package surgically with npm instead of deleting the whole runtime prefix, preserving co-located packages in shared npm prefixes.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `npm run validate` — passed
- `bash scripts/check-installer-smoke.sh` — passed
- `node --test tests/install-stage1.test.mjs --test-name-pattern 'uninstall\.sh regression \(tlht-h7vq\)|runtime ownership:|uninstall\.sh:|RUNTIME_MARKER_FILENAME \.tlh-runtime-owned is in RUNTIME_OWNED_TOPLEVEL'` — passed
- `bash -n uninstall.sh scripts/check-installer-smoke.sh` — passed
- `node --check scripts/tlh-install.mjs` — passed

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/migrated-runtime-surgical-uninstall/install.sh | bash -s -- --ref fix/migrated-runtime-surgical-uninstall --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the uninstall process to more intelligently handle shared runtime environments, preserving non-product packages and directories when removing the installation.

* **Tests**
  * Added regression test coverage for uninstall scenarios with shared runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->