### PR TITLE
Pin pi-subagents to tlh-v0.26.0-12 (review fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - Replaced the bundled `pi-oracle` extension (`npm:@diegopetrucci/pi-oracle`) with a first-party oracle subagent that performs direct high-reasoning read-only analysis. The subagent uses the opposite-provider model pattern (mirroring `code-reviewer`) with high thinking, so it reasons independently from the primary session. No external extension is required.
+- Updated the bundled `pi-subagents` pin and TLH provider-aware review defaults: when TLH injects an opposite-provider model for `code-reviewer` or `oracle`, it now also supplies a same/current-provider fallback plus a warning notice that review independence is reduced if the fallback is used.
 
 ## [0.24.0] - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ TLH subagents are fresh child sessions, not a giant shared swarm. They get the t
 - `web-scout` for web research
 - `oracle` for a deeper second opinion.
 
-For review independence, `code-reviewer` intentionally prefers an available opposite provider. Anthropic sessions try to use the OpenAI Codex subscription provider for review when it is available, while OpenAI/OpenAI-Codex sessions try Anthropic review when it is available. If you only have regular OpenAI API access and not the Codex subscription provider, TLH does not force `code-reviewer` onto unavailable Codex-only defaults.
+For review independence, `code-reviewer` and `oracle` intentionally prefer an available opposite provider. Anthropic sessions try to use the OpenAI Codex subscription provider for review when it is available, while OpenAI/OpenAI-Codex sessions try Anthropic review when it is available. When TLH injects one of those opposite-provider review models, it also supplies a same/current-provider fallback candidate for retryable model failures; if that fallback is used, the subagent output includes a notice that review independence is reduced. If you only have regular OpenAI API access and not the Codex subscription provider, TLH does not force `code-reviewer` or `oracle` onto unavailable Codex-only defaults.
 
 ## Why this workflow is useful
 
@@ -85,7 +85,7 @@ Use `Shift+Tab` to cycle the current session through `architect` → `rush` → 
 
 ### Model and thinking defaults
 
-TLH applies bundled model/thinking defaults per primary agent. For active non-locked primaries, user `/model` choices are respected and persisted per primary under `tlh.primaryAgent.modelOverrides.<primary>`; reset the current primary's override with `/switch-primary-agent model reset`. Locked primaries such as Rush keep their fixed defaults. For review independence, `code-reviewer` prefers the opposite available provider: Anthropic primaries try OpenAI Codex for review, and OpenAI/OpenAI-Codex primaries try Anthropic.
+TLH applies bundled model/thinking defaults per primary agent. For active non-locked primaries, user `/model` choices are respected and persisted per primary under `tlh.primaryAgent.modelOverrides.<primary>`; reset the current primary's override with `/switch-primary-agent model reset`. Locked primaries such as Rush keep their fixed defaults. For review independence, `code-reviewer` and `oracle` prefer the opposite available provider: Anthropic primaries try OpenAI Codex for review, and OpenAI/OpenAI-Codex primaries try Anthropic. TLH adds a dynamic same/current-provider fallback only when it injects that opposite-provider review model; a displayed fallback notice means the run completed with reduced review independence.
 
 #### Hidden model defaults in the TLH profile
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -79,7 +79,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-11",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/extensions/the-last-harness/model-defaults.ts
+++ b/extensions/the-last-harness/model-defaults.ts
@@ -23,6 +23,8 @@ export type ProviderAwareAgentDefaults<T extends ProviderModelReference = Provid
 
 const OPENAI_PROVIDERS = new Set(["openai-codex", "openai"]);
 const ANTHROPIC_PROVIDERS = new Set(["anthropic"]);
+const OPPOSITE_PROVIDER_FALLBACK_NOTICE =
+	"TLH fell back to a same-provider review model; review independence is reduced.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -56,7 +58,17 @@ export function findAvailableProviderModel<T extends ProviderModelReference>(
 	if (!parsed) {
 		return undefined;
 	}
-	return availableModels.find((entry) => entry.provider === parsed.provider && entry.id === parsed.id);
+	return findAvailableProviderModelReference(availableModels, parsed);
+}
+
+function findAvailableProviderModelReference<T extends ProviderModelReference>(
+	availableModels: readonly T[],
+	model: ProviderModelReference | undefined,
+): T | undefined {
+	if (!model) {
+		return undefined;
+	}
+	return availableModels.find((entry) => entry.provider === model.provider && entry.id === model.id);
 }
 
 function availableOpenaiCandidate<T extends ProviderModelReference>(
@@ -151,6 +163,27 @@ function selectOppositeProviderPreferredAgentModel<T extends ProviderModelRefere
 	return undefined;
 }
 
+function selectOppositeProviderFallbackModel<T extends ProviderModelReference>(
+	agent: AgentModelDefaults | undefined,
+	availableModels: readonly T[],
+	currentProvider: string | undefined,
+	currentModel: ProviderModelReference | undefined,
+): T | undefined {
+	if (!agent?.preferOppositeProvider) {
+		return undefined;
+	}
+
+	if (currentModel?.provider === currentProvider) {
+		const availableCurrentModel = findAvailableProviderModelReference(availableModels, currentModel);
+		if (availableCurrentModel) {
+			return availableCurrentModel;
+		}
+	}
+
+	return currentProviderOpenaiCandidate(agent, availableModels, currentProvider)
+		?? currentProviderAnthropicCandidate(agent, availableModels, currentProvider);
+}
+
 function selectStandardProviderAwareAgentModel<T extends ProviderModelReference>(
 	agent: AgentModelDefaults | undefined,
 	availableModels: readonly T[],
@@ -228,6 +261,11 @@ function hasExplicitModel(target: Record<string, unknown>): boolean {
 	return Object.hasOwn(target, "model") && target.model !== undefined;
 }
 
+function hasExplicitFallbackField(target: Record<string, unknown>): boolean {
+	return (Object.hasOwn(target, "fallbackModels") && target.fallbackModels !== undefined)
+		|| (Object.hasOwn(target, "modelFallbackNotice") && target.modelFallbackNotice !== undefined);
+}
+
 function agentNameForTarget(target: Record<string, unknown>): string | undefined {
 	return typeof target.agent === "string" ? target.agent : undefined;
 }
@@ -237,14 +275,33 @@ function applyModelToRunnableTarget(
 	agents: ReadonlyMap<string, AgentModelDefaults>,
 	availableModels: readonly ProviderModelReference[],
 	currentProvider: string | undefined,
+	currentModel: ProviderModelReference | undefined,
 ): number {
-	if (!isRecord(target) || hasExplicitModel(target)) {
+	if (!isRecord(target) || hasExplicitModel(target) || hasExplicitFallbackField(target)) {
 		return 0;
 	}
 
 	const agentName = agentNameForTarget(target);
 	const agent = agentName ? agents.get(agentName) : undefined;
-	const selectedModel = selectProviderAwareAgentModelId(agent, availableModels, currentProvider);
+	const oppositeProviderModel = selectOppositeProviderPreferredAgentModel(agent, availableModels, currentProvider);
+	if (oppositeProviderModel) {
+		const selectedModel = formatProviderModelReference(oppositeProviderModel);
+		if (selectedModel === agent?.model) {
+			return 0;
+		}
+
+		target.model = selectedModel;
+		const fallbackModel = selectOppositeProviderFallbackModel(agent, availableModels, currentProvider, currentModel);
+		const fallbackModelId = fallbackModel ? formatProviderModelReference(fallbackModel) : undefined;
+		if (fallbackModelId && fallbackModelId !== selectedModel) {
+			target.fallbackModels = [fallbackModelId];
+			target.modelFallbackNotice = OPPOSITE_PROVIDER_FALLBACK_NOTICE;
+		}
+		return 1;
+	}
+
+	const standardModel = selectStandardProviderAwareAgentModel(agent, availableModels, currentProvider);
+	const selectedModel = standardModel ? formatProviderModelReference(standardModel) : undefined;
 	if (!selectedModel || selectedModel === agent?.model) {
 		return 0;
 	}
@@ -258,16 +315,17 @@ export function applyProviderAwareSubagentModels(
 	agents: ReadonlyMap<string, AgentModelDefaults>,
 	availableModels: readonly ProviderModelReference[],
 	currentProvider?: string,
+	currentModel?: ProviderModelReference,
 ): number {
 	if (!isRecord(input)) {
 		return 0;
 	}
 
-	let mutations = applyModelToRunnableTarget(input, agents, availableModels, currentProvider);
+	let mutations = applyModelToRunnableTarget(input, agents, availableModels, currentProvider, currentModel);
 
 	if (Array.isArray(input.tasks)) {
 		for (const task of input.tasks) {
-			mutations += applyModelToRunnableTarget(task, agents, availableModels, currentProvider);
+			mutations += applyModelToRunnableTarget(task, agents, availableModels, currentProvider, currentModel);
 		}
 	}
 
@@ -278,11 +336,11 @@ export function applyProviderAwareSubagentModels(
 			}
 			if (Array.isArray(step.parallel)) {
 				for (const task of step.parallel) {
-					mutations += applyModelToRunnableTarget(task, agents, availableModels, currentProvider);
+					mutations += applyModelToRunnableTarget(task, agents, availableModels, currentProvider, currentModel);
 				}
 				continue;
 			}
-			mutations += applyModelToRunnableTarget(step, agents, availableModels, currentProvider);
+			mutations += applyModelToRunnableTarget(step, agents, availableModels, currentProvider, currentModel);
 		}
 	}
 

--- a/extensions/the-last-harness/model-defaults.ts
+++ b/extensions/the-last-harness/model-defaults.ts
@@ -261,11 +261,6 @@ function hasExplicitModel(target: Record<string, unknown>): boolean {
 	return Object.hasOwn(target, "model") && target.model !== undefined;
 }
 
-function hasExplicitFallbackField(target: Record<string, unknown>): boolean {
-	return (Object.hasOwn(target, "fallbackModels") && target.fallbackModels !== undefined)
-		|| (Object.hasOwn(target, "modelFallbackNotice") && target.modelFallbackNotice !== undefined);
-}
-
 function agentNameForTarget(target: Record<string, unknown>): string | undefined {
 	return typeof target.agent === "string" ? target.agent : undefined;
 }
@@ -277,7 +272,7 @@ function applyModelToRunnableTarget(
 	currentProvider: string | undefined,
 	currentModel: ProviderModelReference | undefined,
 ): number {
-	if (!isRecord(target) || hasExplicitModel(target) || hasExplicitFallbackField(target)) {
+	if (!isRecord(target) || hasExplicitModel(target)) {
 		return 0;
 	}
 
@@ -294,8 +289,12 @@ function applyModelToRunnableTarget(
 		const fallbackModel = selectOppositeProviderFallbackModel(agent, availableModels, currentProvider, currentModel);
 		const fallbackModelId = fallbackModel ? formatProviderModelReference(fallbackModel) : undefined;
 		if (fallbackModelId && fallbackModelId !== selectedModel) {
-			target.fallbackModels = [fallbackModelId];
-			target.modelFallbackNotice = OPPOSITE_PROVIDER_FALLBACK_NOTICE;
+			if (!Object.hasOwn(target, "fallbackModels") || target.fallbackModels === undefined) {
+				target.fallbackModels = [fallbackModelId];
+			}
+			if (!Object.hasOwn(target, "modelFallbackNotice") || target.modelFallbackNotice === undefined) {
+				target.modelFallbackNotice = OPPOSITE_PROVIDER_FALLBACK_NOTICE;
+			}
 		}
 		return 1;
 	}

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -800,7 +800,7 @@ function createTlhPrimaryAgentRuntime(
 			if (event.toolName !== "subagent") {
 				return undefined;
 			}
-			applyProviderAwareSubagentModels(event.input, subagentsByName, getUnfilteredAvailableModels(ctx.modelRegistry), ctx.model?.provider);
+			applyProviderAwareSubagentModels(event.input, subagentsByName, getUnfilteredAvailableModels(ctx.modelRegistry), ctx.model?.provider, ctx.model);
 			syncPrimaryAgentState(ctx);
 			const selection = currentPrimaryAgentSelection();
 			if (!isEnabledPrimaryAgentSelection(selection)) {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1069,7 +1069,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-11");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -325,7 +325,7 @@ test("extension wires switch-primary-agent and active-primary safety", () => {
 	assert.doesNotMatch(primaryRuntimeSource, /pi\.registerCommand\("harness"/);
 	assert.match(toolCall, /if \(event\.toolName === "bash"\) \{[\s\S]*resolveTlhCommitAttribution\(getTlhGlobalSettings\(ctx\.cwd\)\.tlh\?\.attribution\)/);
 	assert.match(toolCall, /getTlhGitCommitAttributionBlockReason\(event\.input\.command, commitAttributionState\)/);
-	assert.match(toolCall, /applyProviderAwareSubagentModels\(event\.input, subagentsByName, getUnfilteredAvailableModels\(ctx\.modelRegistry\), ctx\.model\?\.provider\)/);
+	assert.match(toolCall, /applyProviderAwareSubagentModels\(event\.input, subagentsByName, getUnfilteredAvailableModels\(ctx\.modelRegistry\), ctx\.model\?\.provider, ctx\.model\)/);
 	assert.match(toolCall, /const selection = currentPrimaryAgentSelection\(\)/);
 	assert.match(toolCall, /if \(selection === "rush" && isSubagentResumeAction\(event\.input\)\)/);
 	assert.match(toolCall, /if \(selection === "rush" && subagentCallTargetsAgent\(event\.input, "developer"\)\)/);

--- a/tests/the-last-harness-model-defaults.test.mjs
+++ b/tests/the-last-harness-model-defaults.test.mjs
@@ -22,6 +22,13 @@ const codeReviewer = {
 	preferOppositeProvider: true,
 };
 
+const oracle = {
+	name: "oracle",
+	tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+	preferOppositeProvider: true,
+};
+
 const anthropicParentPrefersCodexReviewer = {
 	name: "anthropic-parent-prefers-codex-reviewer",
 	model: "anthropic/claude-opus-4-8",
@@ -56,6 +63,7 @@ const anthropicFirstPrimary = {
 const agents = new Map([
 	[developer.name, developer],
 	[codeReviewer.name, codeReviewer],
+	[oracle.name, oracle],
 ]);
 
 const anthropicAvailable = [
@@ -72,6 +80,8 @@ const openaiAvailable = [
 	{ provider: "openai", id: "gpt-5.4" },
 	{ provider: "openai", id: "gpt-5.5" },
 ];
+
+const reducedIndependenceNotice = "TLH fell back to a same-provider review model; review independence is reduced.";
 
 test("provider-aware model resolver keeps Anthropic when the default model is available", () => {
 	assert.equal(selectProviderAwareAgentModelId(developer, anthropicAvailable, "anthropic"), "anthropic/claude-sonnet-4-6");
@@ -114,6 +124,8 @@ test("provider-aware opposite-provider preference picks Codex for opted-in Anthr
 	const input = { agent: anthropicParentPrefersCodexReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "anthropic"), 1);
 	assert.equal(input.model, "openai-codex/gpt-5.5");
+	assert.deepEqual(input.fallbackModels, ["anthropic/claude-opus-4-8"]);
+	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
 
 test("provider-aware opposite-provider preference picks Anthropic for opted-in OpenAI-family reviewers", () => {
@@ -132,6 +144,8 @@ test("provider-aware opposite-provider preference picks Anthropic for opted-in O
 	const input = { agent: openaiParentPrefersAnthropicReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "openai-codex"), 1);
 	assert.equal(input.model, "anthropic/claude-opus-4-8");
+	assert.deepEqual(input.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
 
 test("provider-aware opposite-provider preference does not inject regular OpenAI API models for opted-in Anthropic sessions", () => {
@@ -143,20 +157,60 @@ test("provider-aware opposite-provider preference does not inject regular OpenAI
 	assert.equal(input.model, undefined);
 });
 
-test("provider-aware subagent mutation gives code-reviewer the opposite available provider", () => {
+test("provider-aware subagent mutation gives code-reviewer the opposite available provider with same-provider fallback", () => {
 	const available = [...anthropicAvailable, ...codexAvailable];
 
 	const anthropicInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(anthropicInput, agents, available, "anthropic"), 1);
 	assert.equal(anthropicInput.model, "openai-codex/gpt-5.5");
+	assert.deepEqual(anthropicInput.fallbackModels, ["anthropic/claude-opus-4-8"]);
+	assert.equal(anthropicInput.modelFallbackNotice, reducedIndependenceNotice);
 
 	const codexInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(codexInput, agents, available, "openai-codex"), 1);
 	assert.equal(codexInput.model, "anthropic/claude-opus-4-8");
+	assert.deepEqual(codexInput.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.equal(codexInput.modelFallbackNotice, reducedIndependenceNotice);
 
 	const noOppositeInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(noOppositeInput, agents, openaiAvailable, "anthropic"), 0);
 	assert.equal(Object.hasOwn(noOppositeInput, "model"), false);
+	assert.equal(Object.hasOwn(noOppositeInput, "fallbackModels"), false);
+	assert.equal(Object.hasOwn(noOppositeInput, "modelFallbackNotice"), false);
+});
+
+test("provider-aware subagent mutation gives code-reviewer and oracle current-session model fallback first", () => {
+	const available = [...anthropicAvailable, ...codexAvailable];
+
+	const reviewerInput = { agent: "code-reviewer" };
+	assert.equal(
+		applyProviderAwareSubagentModels(
+			reviewerInput,
+			agents,
+			available,
+			"anthropic",
+			{ provider: "anthropic", id: "claude-sonnet-4-6" },
+		),
+		1,
+	);
+	assert.equal(reviewerInput.model, "openai-codex/gpt-5.5");
+	assert.deepEqual(reviewerInput.fallbackModels, ["anthropic/claude-sonnet-4-6"]);
+	assert.equal(reviewerInput.modelFallbackNotice, reducedIndependenceNotice);
+
+	const oracleInput = { agent: "oracle" };
+	assert.equal(
+		applyProviderAwareSubagentModels(
+			oracleInput,
+			agents,
+			available,
+			"openai-codex",
+			{ provider: "openai-codex", id: "gpt-5.4" },
+		),
+		1,
+	);
+	assert.equal(oracleInput.model, "anthropic/claude-opus-4-8");
+	assert.deepEqual(oracleInput.fallbackModels, ["openai-codex/gpt-5.4"]);
+	assert.equal(oracleInput.modelFallbackNotice, reducedIndependenceNotice);
 });
 
 test("provider-aware primary defaults switch Rush-like thinking off for bundled Codex models", () => {
@@ -266,12 +320,26 @@ test("tlhAnthropicModels: regression – agents with only tlhOpenaiModels are un
 	const input = { agent: "developer", task: "Implement the ticket" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 1);
 	assert.equal(input.model, "openai-codex/gpt-5.4");
+	assert.equal(Object.hasOwn(input, "fallbackModels"), false);
+	assert.equal(Object.hasOwn(input, "modelFallbackNotice"), false);
 });
 
 test("provider-aware subagent mutation preserves explicit user-supplied model values", () => {
 	const input = { agent: "developer", task: "Implement the ticket", model: "openai/gpt-5.4" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 0);
 	assert.equal(input.model, "openai/gpt-5.4");
+});
+
+test("provider-aware subagent mutation preserves explicit fallback overrides", () => {
+	const available = [...anthropicAvailable, ...codexAvailable];
+
+	const withFallbackModels = { agent: "code-reviewer", fallbackModels: ["custom/provider-model"] };
+	assert.equal(applyProviderAwareSubagentModels(withFallbackModels, agents, available, "anthropic"), 0);
+	assert.deepEqual(withFallbackModels, { agent: "code-reviewer", fallbackModels: ["custom/provider-model"] });
+
+	const withFallbackNotice = { agent: "oracle", modelFallbackNotice: "custom fallback notice" };
+	assert.equal(applyProviderAwareSubagentModels(withFallbackNotice, agents, available, "openai-codex"), 0);
+	assert.deepEqual(withFallbackNotice, { agent: "oracle", modelFallbackNotice: "custom fallback notice" });
 });
 
 test("provider-aware subagent mutation handles parallel tasks", () => {

--- a/tests/the-last-harness-model-defaults.test.mjs
+++ b/tests/the-last-harness-model-defaults.test.mjs
@@ -330,16 +330,30 @@ test("provider-aware subagent mutation preserves explicit user-supplied model va
 	assert.equal(input.model, "openai/gpt-5.4");
 });
 
-test("provider-aware subagent mutation preserves explicit fallback overrides", () => {
+test("provider-aware subagent mutation injects model but preserves caller-supplied fallback fields", () => {
 	const available = [...anthropicAvailable, ...codexAvailable];
 
+	// Caller supplies fallbackModels but no model → opposite-provider model is injected,
+	// caller-provided fallbackModels kept, TLH auto-adds modelFallbackNotice.
 	const withFallbackModels = { agent: "code-reviewer", fallbackModels: ["custom/provider-model"] };
-	assert.equal(applyProviderAwareSubagentModels(withFallbackModels, agents, available, "anthropic"), 0);
-	assert.deepEqual(withFallbackModels, { agent: "code-reviewer", fallbackModels: ["custom/provider-model"] });
+	assert.equal(applyProviderAwareSubagentModels(withFallbackModels, agents, available, "anthropic"), 1);
+	assert.equal(withFallbackModels.model, "openai-codex/gpt-5.5");
+	assert.deepEqual(withFallbackModels.fallbackModels, ["custom/provider-model"]);
+	assert.equal(withFallbackModels.modelFallbackNotice, reducedIndependenceNotice);
 
+	// Caller supplies modelFallbackNotice but no model → opposite-provider model is injected,
+	// TLH auto-adds fallbackModels, caller-provided modelFallbackNotice kept.
 	const withFallbackNotice = { agent: "oracle", modelFallbackNotice: "custom fallback notice" };
-	assert.equal(applyProviderAwareSubagentModels(withFallbackNotice, agents, available, "openai-codex"), 0);
-	assert.deepEqual(withFallbackNotice, { agent: "oracle", modelFallbackNotice: "custom fallback notice" });
+	assert.equal(applyProviderAwareSubagentModels(withFallbackNotice, agents, available, "openai-codex"), 1);
+	assert.equal(withFallbackNotice.model, "anthropic/claude-opus-4-8");
+	assert.deepEqual(withFallbackNotice.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.equal(withFallbackNotice.modelFallbackNotice, "custom fallback notice");
+
+	// Explicit model still prevents all injection regardless of other fallback fields.
+	const withExplicitModel = { agent: "code-reviewer", model: "anthropic/claude-opus-4-8", fallbackModels: ["my/fallback"] };
+	assert.equal(applyProviderAwareSubagentModels(withExplicitModel, agents, available, "anthropic"), 0);
+	assert.equal(withExplicitModel.model, "anthropic/claude-opus-4-8");
+	assert.deepEqual(withExplicitModel.fallbackModels, ["my/fallback"]);
 });
 
 test("provider-aware subagent mutation handles parallel tasks", () => {

--- a/tests/tlh-ticket-docs-static.test.mjs
+++ b/tests/tlh-ticket-docs-static.test.mjs
@@ -128,15 +128,16 @@ test("commands docs keep /experimental registered with delta-follow-up-reviews a
 	assert.match(commandsDoc, /stale `run-tests-last` values/i);
 });
 
-test("README and changelog describe code-reviewer opposite-provider policy", () => {
+test("README and changelog describe review opposite-provider fallback policy", () => {
 	const readme = readRepoFile("README.md");
 	const changelog = readRepoFile("CHANGELOG.md");
 
-	assert.match(readme, /`code-reviewer` intentionally prefers an available opposite provider/i);
+	assert.match(readme, /`code-reviewer` and `oracle` intentionally prefer an available opposite provider/i);
 	assert.match(readme, /Anthropic sessions[\s\S]{0,180}OpenAI Codex subscription provider[\s\S]{0,80}available/i);
 	assert.match(readme, /OpenAI\/OpenAI-Codex sessions[\s\S]{0,120}Anthropic review[\s\S]{0,80}available/i);
-	assert.match(readme, /OpenAI API access[\s\S]{0,160}does not force `code-reviewer` onto unavailable Codex-only defaults/i);
-	assert.match(changelog, /`code-reviewer` now prefers an available opposite provider/i);
-	assert.match(changelog, /OpenAI API-only setups are not forced onto unavailable Codex-only defaults/i);
+	assert.match(readme, /same\/current-provider fallback[\s\S]{0,160}review independence is reduced/i);
+	assert.match(readme, /OpenAI API access[\s\S]{0,180}does not force `code-reviewer` or `oracle` onto unavailable Codex-only defaults/i);
+	assert.match(changelog, /opposite-provider model[\s\S]{0,120}`code-reviewer` or `oracle`/i);
+	assert.match(changelog, /same\/current-provider fallback[\s\S]{0,160}review independence is reduced/i);
 	assert.doesNotMatch(changelog, /`code-reviewer` now defaults to `openai-codex\/gpt-5\.5`/);
 });


### PR DESCRIPTION
## Summary

Fixes #167 by adding resilient review-provider fallback behavior for `code-reviewer` and `oracle` when TLH injects an opposite-provider review model. This pins the reviewed `pi-subagents` fallback support tag and adds TLH-side provider-aware fallback model + reduced-independence notice injection, while preserving explicit caller overrides.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

Not applicable.

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

Not docs-only.

_Paste the relevant output or a summary here:_

- TLH `npm run validate` — passed.
- TLH `git diff --check` — passed.
- Final code review — no issues requiring changes.
- pi-subagents `npm run test:all` on tagged commit — passed: unit 511/511, integration 368/368.
- pi-subagents PR checks for https://github.com/diegopetrucci/pi-subagents/pull/24 — passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

- Provider-agnostic per-execution `fallbackModels` and `modelFallbackNotice` in `pi-subagents`.
- Fallback retry plumbing for single, parallel, chain, chain-parallel, and async runs.
- Notice rendering only when a fallback retry is actually used.

**Link to merged fork PR:**

https://github.com/diegopetrucci/pi-subagents/pull/24

**Before → after pin:**

`tlh-v0.26.0-11` → `tlh-v0.26.0-12`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/review-provider-fallback/install.sh | bash -s -- --ref fix/review-provider-fallback --track ref
```
