### PR TITLE
Update docs for telemetry and safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ TLH is not just “Pi, but with a new prompt.” The harness bakes in workflow a
 - **Context is capped on purpose**: TLH uses a 200k context cap, expects compaction instead of endless chat growth, and provides `/context` so you can inspect where your tokens are going.
 - **Fresh child contexts are the default**: child sessions start clean and focused rather than inheriting an entire messy parent transcript.
 - **Model defaults are role-aware**: TLH ships bundled per-role model/thinking defaults instead of expecting every user to tune everything manually.
-- **Safety and quiet-by-default UX matter**: destructive-action confirmations, quieter tool rendering, trimmed footer noise, usage-window visibility, notifications when turns finish, and dirty-repo prompts are part of the package.
+- **Safety and quiet-by-default UX matter**: isolated-profile guards, quieter tool rendering, trimmed footer noise, usage-window visibility, notifications when turns finish, and dirty-repo prompts are part of the package.
 - **Useful integrations are already wired in**: web research and MCP support are part of the default story rather than an afterthought.
 
 ## What you get beyond the workflow

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -50,3 +50,12 @@ Opt out persistently by adding this to `~/.the-last-harness/agent/settings.json`
 ```
 
 That settings opt-out is preserved by `tlh update` and installer reruns.
+
+For a single run, set one of:
+
+- `PI_OFFLINE=1`
+- `TLH_SKIP_TELEMETRY=1`
+- `TLH_TELEMETRY_DISABLED=1`
+- `PI_TELEMETRY=0`
+
+To reset only the pseudonymous install ID, remove `~/.the-last-harness/agent/tlh/telemetry-state.json`.


### PR DESCRIPTION
## Summary
- replace the stale README claim about destructive-action confirmations with current isolated-profile safety wording
- document per-run launch telemetry opt-outs and the telemetry install-ID reset path in docs/telemetry.md

## Validation
- npm run validate

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/codex/update-docs-telemetry-safety/install.sh | bash -s -- --ref codex/update-docs-telemetry-safety --track ref
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated safety and quiet-by-default UX documentation with clearer terminology about isolated-profile guard protections
* Added telemetry opt-out guidance with environment variable options and instructions to reset your pseudonymous install ID

<!-- end of auto-generated comment: release notes by coderabbit.ai -->