### PR TITLE
Add never-auto-commit rule to TLH system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 - Replaced the bundled `pi-oracle` extension (`npm:@diegopetrucci/pi-oracle`) with a first-party oracle subagent that performs direct high-reasoning read-only analysis. The subagent uses the opposite-provider model pattern (mirroring `code-reviewer`) with high thinking, so it reasons independently from the primary session. No external extension is required.
 - Updated the bundled `pi-subagents` pin and TLH provider-aware review defaults: when TLH injects an opposite-provider model for `code-reviewer` or `oracle`, it now also supplies a same/current-provider fallback plus a warning notice that review independence is reduced if the fallback is used.
+- TLH now instructs agents never to create a git commit on their own; all commits require explicit user approval before proceeding.
 
 ## [0.24.0] - 2026-06-22
 

--- a/config/APPEND_SYSTEM.md
+++ b/config/APPEND_SYSTEM.md
@@ -5,6 +5,7 @@ The Last Harness (`tlh`) profile is active. Prefer safe, transparent, and review
 - Refer to this environment as `tlh` or The Last Harness in user-facing text.
 - Mention Pi only when specifically discussing the upstream Pi runtime or compatibility.
 - Explain high-impact actions before taking them.
+- Never create a git commit on your own. Always ask the user and get explicit approval before running git commit (or any commit-creating command), even when changes look complete.
 - Use the narrowest tool or command that solves the task.
 - Preserve user-owned configuration unless explicitly asked to change it.
 - Make installer and setup changes idempotent whenever possible.

--- a/extensions/the-last-harness/constants.ts
+++ b/extensions/the-last-harness/constants.ts
@@ -32,6 +32,7 @@ The Last Harness (tlh) profile is active. Prefer safe, transparent, and reviewab
 - Refer to this environment as "tlh" or "The Last Harness" in user-facing text.
 - Mention Pi only when specifically discussing the upstream Pi runtime or compatibility.
 - Explain high-impact actions before taking them.
+- Never create a git commit on your own. Always ask the user and get explicit approval before running git commit (or any commit-creating command), even when changes look complete.
 - Use the narrowest tool or command that solves the task.
 - Preserve user-owned configuration unless explicitly asked to change it.
 - Make installer and setup changes idempotent whenever possible.


### PR DESCRIPTION
## Summary

TLH had no rule preventing agents from committing on their own, so they would sometimes auto-commit eagerly. This adds an explicit rule that agents must never create a git commit by themselves and must always ask the user for explicit approval first.

The rule is added to `HARNESS_PROMPT` in `extensions/the-last-harness/constants.ts`, which is injected into both `buildTlhSystemPrompt` (every primary agent) and `buildChildSubagentSystemPrompt` (every child subagent, including `developer`) — so one bullet covers all TLH contexts. The identical bullet is mirrored into `config/APPEND_SYSTEM.md` (the packaged duplicate) to keep them in sync.

This is prompt guidance, not a hard block: `attribution.ts` (which only enforces the commit footer) and `git push` behavior are untouched.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

All stages passed: package-version check, installer smoke checks, TypeScript typecheck, all test suites, ESLint, settings merge dry-run, and pack dry-run.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/never-auto-commit-prompt-rule/install.sh | bash -s -- --ref never-auto-commit-prompt-rule --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced safeguards to require explicit user approval before executing git commit operations, preventing unintended automatic commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->