### PR TITLE
Pin pi-subagents runtime spawn fix and allow opaque resume

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -79,7 +79,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/extensions/the-last-harness-subagent-safety.mjs
+++ b/extensions/the-last-harness-subagent-safety.mjs
@@ -73,10 +73,8 @@ function contrarianExperimentalDisabledReason() {
 	return "TLH contrarian is an experimental minor agent and is currently disabled. Enable it with /experimental enable contrarian in the isolated TLH profile before delegating to contrarian.";
 }
 
-function contrarianResumeBlockedReason({ opaque = false } = {}) {
-	return opaque
-		? `${contrarianExperimentalDisabledReason()} TLH primary-agent subagent action=resume is blocked unless TLH can prove the resumed run is not contrarian.`
-		: `${contrarianExperimentalDisabledReason()} TLH primary-agent subagent action=resume may not continue a prior contrarian run while the experiment is disabled.`;
+function contrarianResumeBlockedReason() {
+	return `${contrarianExperimentalDisabledReason()} TLH primary-agent subagent action=resume may not continue a prior contrarian run while the experiment is disabled.`;
 }
 
 function collectSubagentTargets(input) {
@@ -186,17 +184,14 @@ function validateNestedFreshSubagentContexts(input) {
 	return undefined;
 }
 
-// Resume-by-id/index is target-opaque. Trusted callers may pass options.resumeTargetAgent
-// after resolving the stored run target; otherwise fail closed while contrarian is disabled.
+// Resume-by-id/index is target-opaque. Allow opaque resumes by default;
+// trusted callers may pass options.resumeTargetAgent to block known contrarian resumes.
 function validateResumeTarget(allowedSubagentSet, options = {}) {
 	if (allowedSubagentSet.has("contrarian")) {
 		return undefined;
 	}
 
 	const resumeTargetAgent = normalizeAllowedSubagent(options.resumeTargetAgent);
-	if (!resumeTargetAgent) {
-		return contrarianResumeBlockedReason({ opaque: true });
-	}
 	if (resumeTargetAgent === "contrarian") {
 		return contrarianResumeBlockedReason();
 	}

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1069,7 +1069,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -243,24 +243,20 @@ test("disabled primary mode keeps malformed mixed experimental arrays fail-close
 	});
 });
 
-test("disabled primary mode blocks opaque resume unless contrarian is enabled", async (t) => {
+test("disabled primary mode allows opaque resume while contrarian is disabled", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const branchEntries = [{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "disabled" } }];
 	const ctx = createToolCallContext(branchEntries, undefined, { cwd: fixture.cwd });
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
-		const blockedResumeEvent = {
+		const opaqueResumeEvent = {
 			toolName: "subagent",
 			input: { action: "resume", id: "run-123", message: "Continue the approved ticket.", agentScope: "", context: "" },
 		};
-		assert.deepEqual(await toolCall(blockedResumeEvent, ctx), {
-			block: true,
-			reason:
-				"TLH contrarian is an experimental minor agent and is currently disabled. Enable it with /experimental enable contrarian in the isolated TLH profile before delegating to contrarian. TLH primary-agent subagent action=resume is blocked unless TLH can prove the resumed run is not contrarian.",
-		});
-		assert.equal(blockedResumeEvent.input.agentScope, "user");
-		assert.equal(blockedResumeEvent.input.context, "fresh");
+		assert.equal(await toolCall(opaqueResumeEvent, ctx), undefined);
+		assert.equal(opaqueResumeEvent.input.agentScope, "user");
+		assert.equal(opaqueResumeEvent.input.context, "fresh");
 
 		writeFileSync(
 			join(fixture.agent, "settings.json"),
@@ -1424,7 +1420,7 @@ test("enabled primary mode blocks disallowed nested delegation targets after for
 	assert.equal(event.input.context, "fresh");
 });
 
-test("enabled primary mode normalizes safe management list/get inputs and blocks opaque or unsafe resume calls", async () => {
+test("enabled primary mode normalizes safe management list/get/resume inputs and blocks unsafe resume calls", async () => {
 	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
 	const ctx = createToolCallContext([
 		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
@@ -1453,18 +1449,10 @@ test("enabled primary mode normalizes safe management list/get inputs and blocks
 	assert.equal(getEvent.input.agentScope, "user");
 	assert.equal(await toolCall(getBothEvent, ctx), undefined);
 	assert.equal(getBothEvent.input.agentScope, "user");
-	assert.deepEqual(await toolCall(resumeEvent, ctx), {
-		block: true,
-		reason:
-			"TLH contrarian is an experimental minor agent and is currently disabled. Enable it with /experimental enable contrarian in the isolated TLH profile before delegating to contrarian. TLH primary-agent subagent action=resume is blocked unless TLH can prove the resumed run is not contrarian.",
-	});
+	assert.equal(await toolCall(resumeEvent, ctx), undefined);
 	assert.equal(resumeEvent.input.agentScope, "user");
 	assert.equal(resumeEvent.input.context, "fresh");
-	assert.deepEqual(await toolCall(resumeBothEvent, ctx), {
-		block: true,
-		reason:
-			"TLH contrarian is an experimental minor agent and is currently disabled. Enable it with /experimental enable contrarian in the isolated TLH profile before delegating to contrarian. TLH primary-agent subagent action=resume is blocked unless TLH can prove the resumed run is not contrarian.",
-	});
+	assert.equal(await toolCall(resumeBothEvent, ctx), undefined);
 	assert.equal(resumeBothEvent.input.agentScope, "user");
 	assert.equal(resumeBothEvent.input.context, "fresh");
 	assert.deepEqual(await toolCall(blockedGetEvent, ctx), {

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -189,7 +189,7 @@ test("validateSubagentToolInput allows approved management calls and keeps enabl
 	}
 });
 
-test("validateSubagentToolInput blocks opaque disabled-contrarian resume and unsafe scopes/contexts", () => {
+test("validateSubagentToolInput allows opaque disabled-contrarian resume and blocks unsafe scopes/contexts", () => {
 	assert.match(validateSubagentToolInput({ action: "delete" }), /may not use subagent management action 'delete'/);
 	assert.match(validateSubagentToolInput({ agent: "developer", agentScope: "both" }), /may not use agentScope: "both"/);
 	assert.match(validateSubagentToolInput({ agent: "developer", agentScope: "project" }), /may not use agentScope: "project"/);
@@ -205,9 +205,7 @@ test("validateSubagentToolInput blocks opaque disabled-contrarian resume and uns
 	assert.match(validateSubagentToolInput({ action: "resume", context: 1 }), /subagent resume must use context: "fresh"/);
 
 	const opaqueResume = { action: "resume", id: "run-123", message: "Continue with the approved ticket.", agentScope: "", context: "" };
-	const opaqueReason = validateSubagentToolInput(opaqueResume);
-	assert.match(opaqueReason, /experimental minor agent/i);
-	assert.match(opaqueReason, /action=resume is blocked unless TLH can prove the resumed run is not contrarian/i);
+	assertAllowed(opaqueResume);
 	assert.equal(opaqueResume.agentScope, "user");
 	assert.equal(opaqueResume.context, "fresh");
 


### PR DESCRIPTION
## Summary

- Pin bundled `pi-subagents` to `tlh-v0.26.0-13`, which includes the merged parent-runtime spawn fix from PR #25.
- Restore opaque `subagent` `action: "resume"` calls while contrarian is disabled.
- Keep explicit `resumeTargetAgent: "contrarian"` blocked while the contrarian experiment is disabled.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
# Not run separately; npm run validate includes installer smoke checks.
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `node --test tests/tlh-subagent-safety.test.mjs tests/the-last-harness-primary-agent-runtime.test.mjs tests/default-extensions.test.mjs` passed.
- `npm run validate` passed.
- `git diff --check` passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

`pi-subagents@tlh-v0.26.0-13` includes the merged runtime spawn fix so child subagents spawn through the resolved parent/runtime Pi CLI instead of ambient `pi`.

**Link to merged fork PR:**

https://github.com/diegopetrucci/pi-subagents/pull/25

**Before → after pin:**

`git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12` → `git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/codex/tlh-daily-review-2026-06-24/install.sh | bash -s -- --ref codex/tlh-daily-review-2026-06-24 --track ref
```
