### PR TITLE
Update dependency and extension pins

### DIFF
--- a/.tickets/tlh-2plr.md
+++ b/.tickets/tlh-2plr.md
@@ -1,0 +1,20 @@
+---
+id: tlh-2plr
+status: open
+deps: []
+links: []
+created: 2026-06-24T19:17:28Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+external-ref: gh-187
+tags: [stress-test, default-extensions, pi-web-access]
+---
+# Fix pi-web-access dirty checkout after default-extension install
+
+Stress testing PR #187 found that a fresh isolated TLH install succeeds but leaves the bundled git checkout github.com/diegopetrucci/pi-web-access dirty: package-lock.json is rewritten from version 0.10.7 to 0.10.7-tlh.1. This appears to come from fork package metadata/lockfile drift rather than the dependency-update branch itself, but it creates noisy local diffs in the installed profile after install/update.
+
+## Acceptance Criteria
+
+Fresh isolated install/update of bundled defaults leaves the pi-web-access checkout clean; package.json and package-lock.json versions in the pinned fork/tag are aligned; web-scout smoke still fetches a simple page; if the fork tag changes, config/default-extensions.json is updated to the reviewed reachable tag.
+

--- a/.tickets/tlh-nt4r.md
+++ b/.tickets/tlh-nt4r.md
@@ -1,0 +1,20 @@
+---
+id: tlh-nt4r
+status: open
+deps: []
+links: []
+created: 2026-06-24T19:17:28Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+external-ref: gh-187
+tags: [stress-test, default-extensions, pi-subagents]
+---
+# Eliminate pi-subagents dirty-checkout backup warning on fresh install
+
+Stress testing PR #187 found that a fresh isolated temp install prints a dirty checkout backup warning for github.com/diegopetrucci/pi-subagents and creates a refs/tlh-backup/... ref, even though the pi-subagents checkout ends clean. This is noisy during otherwise successful installs and should be investigated in the fork/update path.
+
+## Acceptance Criteria
+
+Fresh isolated install of bundled defaults completes without a dirty-checkout warning for pi-subagents; no refs/tlh-backup ref is created for a clean install; subagent discovery still lists the TLH minor agents and a read-only web-scout smoke can run successfully.
+

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Normal `tlh update` runs are conservative: they preserve user-owned isolated-pro
 
 Node.js >=22.19.0 must be available on your `PATH`.
 
-TLH runs its own pinned Pi 0.79.7 from a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. The installer always provisions the private runtime automatically (per-user, no sudo) and hard-fails with an actionable error if it cannot.
+TLH runs its own pinned Pi 0.80.2 from a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. The installer always provisions the private runtime automatically (per-user, no sudo) and hard-fails with an actionable error if it cannot.
 
 The installer writes an ownership marker (`.tlh-runtime-owned`) into the runtime prefix on every successful install or repair. Ownership is determined by this marker, not by directory shape alone — `npm install --prefix` produces an identical `bin/lib` layout regardless of who ran it, so shape alone is not a reliable signal. Accordingly, the installer refuses a non-empty unmarked runtime prefix that has no recorded TLH provenance; this matters most when using a non-default `--agent-dir` whose sibling `runtime/` directory could belong to a separate installation. Older TLH installs from before the marker was introduced gain it automatically on the next `tlh update` or installer rerun — no action required.
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "openai-fast",
-    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.4",
+    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.6",
     "description": "Enable optional OpenAI Codex Fast mode commands for eligible ChatGPT-auth GPT-5.4/GPT-5.5 sessions."
   },
   {
     "id": "anthropic-auth",
-    "source": "npm:@gotgenes/pi-anthropic-auth@0.6.2",
+    "source": "npm:@gotgenes/pi-anthropic-auth@0.6.3",
     "description": "Improve compatibility with Anthropic Claude Pro/Max OAuth while preserving normal API-key behavior."
   },
   {
     "id": "librarian",
-    "source": "npm:@diegopetrucci/pi-librarian@0.1.5",
+    "source": "npm:@diegopetrucci/pi-librarian@0.1.7",
     "description": "Research GitHub repositories and optionally cache local checkouts."
   },
   {
@@ -30,22 +30,22 @@
   },
   {
     "id": "fff",
-    "source": "npm:@ff-labs/pi-fff@0.9.5",
+    "source": "npm:@ff-labs/pi-fff@0.9.6",
     "description": "FFF-powered fuzzy file and content search."
   },
   {
     "id": "inline-bash",
-    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.2",
+    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.3",
     "description": "Expand inline bash commands in user prompts."
   },
   {
     "id": "notify",
-    "source": "npm:@diegopetrucci/pi-notify@0.1.5",
+    "source": "npm:@diegopetrucci/pi-notify@0.1.7",
     "description": "Send a notification when an agent turn finishes."
   },
   {
     "id": "context-inspector",
-    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.2",
+    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.3",
     "description": "Open a local HTML dashboard explaining where the current session context is going."
   },
   {
@@ -60,17 +60,17 @@
     "id": "quiet-tools",
     "aliases": ["compact-bash"],
     "replaces": ["npm:@diegopetrucci/pi-compact-bash"],
-    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.3",
+    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.4",
     "description": "Compact collapsed built-in tool output in the TUI without changing model-visible results."
   },
   {
     "id": "dirty-repo-guard",
-    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.2",
+    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.3",
     "description": "Prompt before session changes when the current git repo has uncommitted changes."
   },
   {
     "id": "triage-comments",
-    "source": "npm:@diegopetrucci/pi-triage-comments@0.1.3",
+    "source": "npm:@diegopetrucci/pi-triage-comments@0.1.4",
     "description": "Add /triage-comments and a read-only triage_comments subagent tool for review-comment triage."
   },
   {
@@ -79,7 +79,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-Requires Node.js >=22.19.0 on `PATH`. TLH always installs its own pinned Pi 0.79.7 into a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. Install or repair failures stop with an actionable error.
+Requires Node.js >=22.19.0 on `PATH`. TLH always installs its own pinned Pi 0.80.2 into a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. Install or repair failures stop with an actionable error.
 
 Run the one-liner:
 
@@ -57,7 +57,7 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 
 You can just run `tlh update`.
 
-This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. While the upstream 0.79.8 breakage is active, `tlh update` also repairs the private Pi runtime at `~/.the-last-harness/runtime` back to the pinned 0.79.7 when needed. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
+This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. `tlh update` also repairs the private Pi runtime at `~/.the-last-harness/runtime` back to the pinned 0.80.2 when needed. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
 
 If TLH starts with the notice ``TLH extension updates are available. Run `tlh update --extensions` to update them.``, that notice refers to isolated extension/package updates only. `tlh update --extensions` runs the upstream package refresh against the TLH profile without changing installer-managed checkout state, wrapper files, or update-track metadata. Installer-track and installer-owned options such as `--track`, `--ref`, `--repo`, `--package-source`, `--force`, `--no-settings`, and `--no-wrapper` require plain `tlh update` instead.
 

--- a/extensions/annotate-git-diff/ui.ts
+++ b/extensions/annotate-git-diff/ui.ts
@@ -34,6 +34,51 @@ function safeReadResolvedAsset(specifier: string): string {
 	return readFileSync(require.resolve(specifier), "utf8");
 }
 
+function resolveMonacoEditorWorkerJs(monacoBasePath: string): string {
+	const legacyWorkerPath = join(monacoBasePath, "base", "worker", "workerMain.js");
+	if (existsSync(legacyWorkerPath)) {
+		return readFileSync(legacyWorkerPath, "utf8");
+	}
+
+	const assetsDir = join(monacoBasePath, "assets");
+	if (existsSync(assetsDir)) {
+		const editorWorkerAsset = readdirSync(assetsDir)
+			.sort()
+			.find((entry) => /^editor\.worker-.*\.js$/.test(entry));
+		if (editorWorkerAsset) {
+			return readFileSync(join(assetsDir, editorWorkerAsset), "utf8");
+		}
+	}
+
+	throw new Error(`Unable to locate Monaco editor worker under ${monacoBasePath}`);
+}
+
+function resolveMonacoRuntimeJs(monacoBasePath: string): string {
+	const excludedFiles = new Set([
+		join(monacoBasePath, "loader.js"),
+		join(monacoBasePath, "editor", "editor.main.js"),
+	]);
+	const scripts: string[] = [];
+
+	const visit = (dir: string): void => {
+		for (const entry of readdirSync(dir, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
+			const entryPath = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (entry.name === "assets") continue;
+				visit(entryPath);
+				continue;
+			}
+			if (!entry.isFile() || !entry.name.endsWith(".js") || excludedFiles.has(entryPath)) {
+				continue;
+			}
+			scripts.push(readFileSync(entryPath, "utf8"));
+		}
+	};
+
+	visit(monacoBasePath);
+	return scripts.join("\n");
+}
+
 function resolveReviewUiAssets(): ReviewUiAssets {
 	try {
 		const tailwindBrowserJs = safeReadResolvedAsset("@tailwindcss/browser");
@@ -41,23 +86,15 @@ function resolveReviewUiAssets(): ReviewUiAssets {
 		const monacoLoaderJs = readFileSync(join(monacoBasePath, "loader.js"), "utf8");
 		const monacoEditorJs = readFileSync(join(monacoBasePath, "editor", "editor.main.js"), "utf8");
 		const monacoEditorCss = readFileSync(join(monacoBasePath, "editor", "editor.main.css"), "utf8");
-		const monacoWorkerJs = readFileSync(join(monacoBasePath, "base", "worker", "workerMain.js"), "utf8");
-		const basicLanguagesDir = join(monacoBasePath, "basic-languages");
-		const basicLanguagesJs = readdirSync(basicLanguagesDir)
-			.sort()
-			.map((lang) => {
-				const filePath = join(basicLanguagesDir, lang, `${lang}.js`);
-				return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
-			})
-			.filter(Boolean)
-			.join("\n");
+		const monacoWorkerJs = resolveMonacoEditorWorkerJs(monacoBasePath);
+		const monacoRuntimeJs = resolveMonacoRuntimeJs(monacoBasePath);
 		return {
 			tailwindBrowserJs,
 			monacoLoaderJs,
 			monacoEditorJs,
 			monacoEditorCss,
 			monacoWorkerJs,
-			monacoBasicLanguagesJs: basicLanguagesJs,
+			monacoBasicLanguagesJs: monacoRuntimeJs,
 			bootstrapError: null,
 		};
 	} catch (error) {

--- a/extensions/the-last-harness/attribution.ts
+++ b/extensions/the-last-harness/attribution.ts
@@ -1188,7 +1188,6 @@ function getUnsupportedEnvGitCommitAttributionBlockReason(
 	let index = 1;
 	while (index < tokens.length) {
 		if (tokens[index] === "--") {
-			index += 1;
 			break;
 		}
 		const parseResult = getEnvLeadingOptionParseResult(tokens, index);

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ REPO="${TLH_REPO:-diegopetrucci/the-last-harness}"
 REF="${TLH_REF:-main}"
 # Keep in sync with MIN_NODE_VERSION, MIN_PI_VERSION, and PINNED_PI_VERSION in scripts/tlh-install.mjs.
 TLH_MIN_NODE_VERSION="22.19.0"
-TLH_MIN_PI_VERSION="0.79.1"
-TLH_PINNED_PI_VERSION="0.79.7"
+TLH_MIN_PI_VERSION="0.80.1"
+TLH_PINNED_PI_VERSION="0.80.2"
 
 DRY_RUN=false
 NO_SETTINGS=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,40 +9,40 @@
       "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/browser": "4.3.0",
+        "@tailwindcss/browser": "4.3.1",
         "glimpseui": "0.8.1",
-        "monaco-editor": "0.52.2"
+        "monaco-editor": "0.55.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.79.7",
-        "@earendil-works/pi-tui": "0.79.7",
-        "@eslint/js": "9.39.4",
-        "@types/node": "22.19.21",
-        "eslint": "9.39.4",
-        "globals": "14.0.0",
+        "@earendil-works/pi-coding-agent": "0.80.2",
+        "@earendil-works/pi-tui": "0.80.2",
+        "@eslint/js": "10.0.1",
+        "@types/node": "26.0.0",
+        "eslint": "10.5.0",
+        "globals": "17.7.0",
         "jiti": "2.7.0",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.60.1"
+        "typescript-eslint": "8.62.0"
       },
       "engines": {
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.79.1 <=0.79.7",
-        "@earendil-works/pi-tui": ">=0.79.1 <=0.79.7"
+        "@earendil-works/pi-coding-agent": ">=0.80.1 <=0.80.2",
+        "@earendil-works/pi-tui": ">=0.80.1 <=0.80.2"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.7.tgz",
-      "integrity": "sha512-oEV3+jL4nD6taBiBZxiZifBaMx3FEcyYDlVlcKfPtrv6r3x4FUu4EOR6ISB+MA8IRLYp6NsGs3d5q8BHmVhE+g==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
+      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.7",
-        "@earendil-works/pi-ai": "^0.79.7",
-        "@earendil-works/pi-tui": "^0.79.7",
+        "@earendil-works/pi-agent-core": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -56,7 +56,7 @@
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -532,12 +532,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.7.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.7",
+        "@earendil-works/pi-ai": "^0.80.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -547,15 +547,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.7.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -564,15 +565,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.7.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -814,15 +815,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -837,6 +847,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -860,9 +890,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -880,13 +910,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1734,9 +1757,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1744,15 +1767,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1867,9 +1889,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1910,9 +1932,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1984,9 +2006,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.7.tgz",
-      "integrity": "sha512-FtPN6H8gBvaVJWmPAmtB2dviecoCyrxB6SJUBuZ62p8zdiDgDlfAiYxNqTA2/R2iklqBZA83YcLLFWeMAyFuHw==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
+      "integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2034,91 +2056,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2178,7 +2198,16 @@
       }
     },
     "node_modules/@tailwindcss/browser": {
-      "version": "4.3.0",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/browser/-/browser-4.3.1.tgz",
+      "integrity": "sha512-TkWxiQLpHO3xAKY8OyaA3FVU09xH/TQhQ4+KfOILErFKgcFLo4JluAVJHjzFUGZcHcSwYsC+EnOEBIej0f/XZg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2188,29 +2217,40 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2223,13 +2263,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2237,14 +2279,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2260,12 +2304,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2280,12 +2326,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2296,7 +2344,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2311,13 +2361,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2334,7 +2386,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2346,14 +2400,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2371,48 +2427,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2427,11 +2452,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2442,19 +2469,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/acorn": {
-      "version": "8.16.0",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2466,6 +2484,8 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2474,6 +2494,8 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2487,82 +2509,28 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2598,6 +2566,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "dev": true,
@@ -2610,31 +2587,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2644,8 +2623,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2653,7 +2631,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -2668,42 +2646,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2722,6 +2708,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2749,11 +2737,15 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2764,6 +2756,8 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2860,7 +2854,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2870,35 +2866,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -2941,27 +2916,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
@@ -2969,6 +2923,8 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3011,11 +2967,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/marked": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -3030,19 +2981,42 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "license": "MIT"
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3098,17 +3072,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -3127,6 +3090,8 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3146,22 +3111,18 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/semver": {
-      "version": "7.8.2",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3190,30 +3151,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3229,6 +3170,8 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3262,14 +3205,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.1",
-        "@typescript-eslint/parser": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3284,14 +3229,16 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,23 +58,23 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.79.1 <=0.79.7",
-    "@earendil-works/pi-tui": ">=0.79.1 <=0.79.7"
+    "@earendil-works/pi-coding-agent": ">=0.80.1 <=0.80.2",
+    "@earendil-works/pi-tui": ">=0.80.1 <=0.80.2"
   },
   "dependencies": {
-    "@tailwindcss/browser": "4.3.0",
+    "@tailwindcss/browser": "4.3.1",
     "glimpseui": "0.8.1",
-    "monaco-editor": "0.52.2"
+    "monaco-editor": "0.55.1"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.79.7",
-    "@earendil-works/pi-tui": "0.79.7",
-    "@eslint/js": "9.39.4",
-    "@types/node": "22.19.21",
-    "eslint": "9.39.4",
-    "globals": "14.0.0",
+    "@earendil-works/pi-coding-agent": "0.80.2",
+    "@earendil-works/pi-tui": "0.80.2",
+    "@eslint/js": "10.0.1",
+    "@types/node": "26.0.0",
+    "eslint": "10.5.0",
+    "globals": "17.7.0",
     "jiti": "2.7.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.1"
+    "typescript-eslint": "8.62.0"
   }
 }

--- a/scripts/check-installer-smoke.sh
+++ b/scripts/check-installer-smoke.sh
@@ -384,7 +384,7 @@ make_fake_present_pi() {
   cat >"${fakebin}/pi" <<'EOF_FAKE_PRESENT_PI'
 #!/bin/sh
 if [ "${1:-}" = "--version" ]; then
-  printf '0.79.1\n'
+  printf '0.80.1\n'
   exit 0
 fi
 printf 'fake pi should only be invoked with --version during dry-run; got: %s\n' "$*" >&2
@@ -1401,7 +1401,7 @@ EOF_PRESENT_GIT
   # Seed a valid private runtime pi (pinned version) at the expected location.
   cat >"${present_runtime_bin}/pi" <<'EOF_PRESENT_RUNTIME_PI'
 #!/bin/sh
-if [ "${1:-}" = "--version" ]; then printf '0.79.7\n'; exit 0; fi
+if [ "${1:-}" = "--version" ]; then printf '0.80.2\n'; exit 0; fi
 printf 'fake private runtime pi invoked unexpectedly\n' >&2; exit 98
 EOF_PRESENT_RUNTIME_PI
   chmod +x "${present_runtime_bin}/pi"

--- a/scripts/check-package-versions.mjs
+++ b/scripts/check-package-versions.mjs
@@ -114,7 +114,8 @@ function readTextFile(path) {
 	try {
 		return readFileSync(path, "utf8").replace(/^\uFEFF/, "");
 	} catch (error) {
-		throw new Error(`Unable to read ${path}: ${error.message}`);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Unable to read ${path}: ${message}`, { cause: error });
 	}
 }
 
@@ -124,7 +125,8 @@ function readJsonFile(path) {
 	try {
 		return JSON.parse(raw);
 	} catch (error) {
-		throw new Error(`Invalid JSON in ${path}: ${error.message}`);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in ${path}: ${message}`, { cause: error });
 	}
 }
 

--- a/scripts/lib/default-extensions.mjs
+++ b/scripts/lib/default-extensions.mjs
@@ -16,7 +16,8 @@ function readManifestJson(path, { allowMissing }) {
 	try {
 		return JSON.parse(raw);
 	} catch (error) {
-		throw new Error(`Invalid JSON in ${path}: ${error.message}`);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in ${path}: ${message}`, { cause: error });
 	}
 }
 

--- a/scripts/lib/tlh-install-package-source.mjs
+++ b/scripts/lib/tlh-install-package-source.mjs
@@ -58,8 +58,8 @@ export function parseGitSource(source) {
 
 	const { repo: repoWithoutRef, ref } = splitGitRef(url);
 	let repo = repoWithoutRef;
-	let host = "";
-	let repoPath = "";
+	let host;
+	let repoPath;
 	const scpLikeMatch = repoWithoutRef.match(/^git@([^:]+):(.+)$/);
 	if (scpLikeMatch) {
 		host = scpLikeMatch[1] || "";

--- a/scripts/lib/tlh-install-utils.mjs
+++ b/scripts/lib/tlh-install-utils.mjs
@@ -88,7 +88,8 @@ export function readJsonFile(path, { missingValue, emptyValue = {} } = {}) {
 	try {
 		return JSON.parse(raw);
 	} catch (error) {
-		throw new Error(`Invalid JSON in ${path}: ${error.message}`);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in ${path}: ${message}`, { cause: error });
 	}
 }
 

--- a/scripts/lib/tlh-safe-profile-write.mjs
+++ b/scripts/lib/tlh-safe-profile-write.mjs
@@ -64,7 +64,7 @@ function tempDirIdentity(tempDir, action = "clean up") {
 		stats = lstatSync(tempDir);
 	} catch (error) {
 		if (error?.code === "ENOENT") {
-			throw new Error(`refusing to ${action} missing temp directory: ${tempDir}`);
+			throw new Error(`refusing to ${action} missing temp directory: ${tempDir}`, { cause: error });
 		}
 		throw error;
 	}
@@ -80,7 +80,7 @@ function tempFileIdentity(tempTarget, action = "commit") {
 		stats = lstatSync(tempTarget);
 	} catch (error) {
 		if (error?.code === "ENOENT") {
-			throw new Error(`refusing to ${action} missing temp file: ${tempTarget}`);
+			throw new Error(`refusing to ${action} missing temp file: ${tempTarget}`, { cause: error });
 		}
 		throw error;
 	}

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -63,11 +63,11 @@ import {
 const DEFAULT_REPO = "diegopetrucci/the-last-harness";
 const DEFAULT_REF = "main";
 const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
-const PINNED_PI_VERSION = "0.79.7";
+const PINNED_PI_VERSION = "0.80.2";
 const PI_PACKAGE_SPEC = `${PI_PACKAGE_NAME}@${PINNED_PI_VERSION}`;
 // Keep in sync with TLH_MIN_NODE_VERSION, TLH_MIN_PI_VERSION, and TLH_PINNED_PI_VERSION in install.sh.
 const MIN_NODE_VERSION = "22.19.0";
-const MIN_PI_VERSION = "0.79.1";
+const MIN_PI_VERSION = "0.80.1";
 const MAX_PI_VERSION = PINNED_PI_VERSION;
 const DEFAULT_GNOSIS_REPO = "skorokithakis/gnosis";
 const DEFAULT_GNOSIS_VERSION = "0.5.3";
@@ -90,7 +90,7 @@ const VALID_UPDATE_TRACKS = new Set(["latest-release", "pinned-tag", "ref", "cus
 const RUNTIME_MARKER_FILENAME = ".tlh-runtime-owned";
 const RUNTIME_MARKER_SCHEMA_VERSION = 1;
 // npm 11.x --prefix layout; empirically confirmed: npm 11.16.0 +
-// @earendil-works/pi-coding-agent@0.79.7.  Mirrors the advisory exclusivity
+// @earendil-works/pi-coding-agent@0.80.2.  Mirrors the advisory exclusivity
 // tripwire in uninstall.sh (demoted from gate): the only top-level entries a
 // TLH-owned runtime prefix should contain are those created by
 // npm install -g --ignore-scripts --prefix, plus the TLH runtime ownership
@@ -647,7 +647,7 @@ function assertSupportedPiVersion(
 		versionCommandDisplay = "pi --version",
 	} = {},
 ) {
-	// `pi --version` prints a bare semver (e.g. "0.79.1") on stdout. Older builds may
+	// `pi --version` prints a bare semver (e.g. "0.80.1") on stdout. Older builds may
 	// differ, so we extract the first semver-shaped substring rather than match strictly.
 	const result = spawnCapture(config, [piCommand, "--version"], {
 		allowFailure: true,
@@ -1214,7 +1214,8 @@ function installDefaultExtensions(config) {
 			"sources",
 		], { captureStdout: true });
 	} catch (error) {
-		throw new Error(`failed to read bundled default extension sources: ${error.message}`);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`failed to read bundled default extension sources: ${message}`, { cause: error });
 	}
 	try {
 		criticalSourcesOutput = runNodeScript(config, config.supportFilePaths.TLH_DEFAULTS_SCRIPT, [
@@ -1228,7 +1229,8 @@ function installDefaultExtensions(config) {
 		if (defaultExtensionsFileRequiresCriticalInstall(config.supportFilePaths.DEFAULT_EXTENSIONS_FILE, {
 			noSettings: config.noSettings,
 		})) {
-			throw new Error(`failed to read critical bundled default extension sources: ${error.message}`);
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`failed to read critical bundled default extension sources: ${message}`, { cause: error });
 		}
 		warn("installed default-extension helper does not support critical source queries; treating this ref as having no critical defaults.");
 		criticalSourcesOutput = "";
@@ -1282,7 +1284,7 @@ function configureGnosis(config) {
 		config.gnosisSummary = runNodeScript(config, config.supportFilePaths.TLH_GNOSIS_SCRIPT, args, { captureStdout: true }).trimEnd();
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`failed to configure Gnosis integration: ${message}`);
+		throw new Error(`failed to configure Gnosis integration: ${message}`, { cause: error });
 	}
 }
 

--- a/scripts/tlh-tickets.mjs
+++ b/scripts/tlh-tickets.mjs
@@ -680,7 +680,7 @@ function validateOpenedFileForDirectWrite(fd, path, intendedRoot, label) {
 		pathStats = lstatSync(path);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`Refusing to write ${label} because the opened path could not be validated: ${path} (${message})`);
+		throw new Error(`Refusing to write ${label} because the opened path could not be validated: ${path} (${message})`, { cause: error });
 	}
 
 	if (pathStats.isSymbolicLink()) {

--- a/scripts/tlh-update.mjs
+++ b/scripts/tlh-update.mjs
@@ -271,8 +271,8 @@ function parseGitHubPackageSource(source) {
 	if (value.startsWith("git:")) value = value.slice("git:".length).trim();
 	if (value.startsWith("git+")) value = value.slice("git+".length);
 
-	let host = "";
-	let repoPathWithRef = "";
+	let host;
+	let repoPathWithRef;
 	const scpLike = value.match(/^git@([^:]+):(.+)$/);
 	if (scpLike) {
 		host = scpLike[1] || "";

--- a/tests/check-package-versions.test.mjs
+++ b/tests/check-package-versions.test.mjs
@@ -92,7 +92,7 @@ test("check-package-versions passes with pinned dependency exceptions and ignore
 			sshHelper: "git+ssh://git@github.com/example/ssh-helper.git#abcdef1234567",
 		},
 		peerDependencies: {
-			"@earendil-works/pi-coding-agent": ">=0.79.1 <=0.79.7",
+			"@earendil-works/pi-coding-agent": ">=0.80.1 <=0.80.2",
 		},
 		defaultExtensions: [
 			{ id: "helper", source: "npm:helper@1.2.3" },

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -14,16 +14,16 @@ const defaultsScript = join(repoRoot, "scripts", "tlh-defaults.mjs");
 const harnessPackage = "git:github.com/diegopetrucci/the-last-harness";
 const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
 const expectedBundledNpmSources = new Map([
-	["openai-fast", "npm:@diegopetrucci/pi-openai-fast@0.1.4"],
-	["anthropic-auth", "npm:@gotgenes/pi-anthropic-auth@0.6.2"],
-	["librarian", "npm:@diegopetrucci/pi-librarian@0.1.5"],
-	["fff", "npm:@ff-labs/pi-fff@0.9.5"],
-	["inline-bash", "npm:@diegopetrucci/pi-inline-bash@0.1.2"],
-	["notify", "npm:@diegopetrucci/pi-notify@0.1.5"],
-	["context-inspector", "npm:@diegopetrucci/pi-context-inspector@0.1.2"],
-	["quiet-tools", "npm:@diegopetrucci/pi-quiet-tools@0.1.3"],
-	["dirty-repo-guard", "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.2"],
-	["triage-comments", "npm:@diegopetrucci/pi-triage-comments@0.1.3"],
+	["openai-fast", "npm:@diegopetrucci/pi-openai-fast@0.1.6"],
+	["anthropic-auth", "npm:@gotgenes/pi-anthropic-auth@0.6.3"],
+	["librarian", "npm:@diegopetrucci/pi-librarian@0.1.7"],
+	["fff", "npm:@ff-labs/pi-fff@0.9.6"],
+	["inline-bash", "npm:@diegopetrucci/pi-inline-bash@0.1.3"],
+	["notify", "npm:@diegopetrucci/pi-notify@0.1.7"],
+	["context-inspector", "npm:@diegopetrucci/pi-context-inspector@0.1.3"],
+	["quiet-tools", "npm:@diegopetrucci/pi-quiet-tools@0.1.4"],
+	["dirty-repo-guard", "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.3"],
+	["triage-comments", "npm:@diegopetrucci/pi-triage-comments@0.1.4"],
 ]);
 
 function tempFixture() {
@@ -1069,7 +1069,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -27,6 +27,10 @@ const TLH_PINNED_PI_VERSION = "0.80.2";
 
 const TLH_PI_PACKAGE_SPEC = `@earendil-works/pi-coding-agent@${TLH_PINNED_PI_VERSION}`;
 
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function pathWithoutRepoNodeModulesBin(pathValue = process.env.PATH || "") {
 	return pathValue.split(delimiter).filter((entry) => entry && resolve(entry) !== repoNodeModulesBin).join(delimiter);
 }
@@ -339,7 +343,7 @@ test("stage-1 repairs the TLH private Pi runtime to the pinned version when it h
 	const output = `${result.stdout}\n${result.stderr}`;
 
 	assert.equal(result.status, 0, output);
-	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
+	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${escapeRegExp(TLH_PINNED_PI_VERSION)}`));
 	assert.deepEqual(readFileSync(npmLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [
 		`install -g --ignore-scripts --prefix ${runtimeDir} ${TLH_PI_PACKAGE_SPEC}`,
 	]);
@@ -422,7 +426,7 @@ test("stage-1 repairs the TLH private Pi runtime even when a supported Pi exists
 	const output = `${result.stdout}\n${result.stderr}`;
 
 	assert.equal(result.status, 0, output);
-	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
+	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${escapeRegExp(TLH_PINNED_PI_VERSION)}`));
 	assert.deepEqual(readFileSync(npmLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [
 		`install -g --ignore-scripts --prefix ${runtimeDir} ${TLH_PI_PACKAGE_SPEC}`,
 	]);
@@ -623,7 +627,7 @@ test("installer helpers no longer support the removed --no-pi-install opt-out", 
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 	assert.equal(stage0Help.status, 0, stage0Help.stderr);
-	assert.match(stage0Help.stdout, new RegExp(`Upstream Pi ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
+	assert.match(stage0Help.stdout, new RegExp(`Upstream Pi ${escapeRegExp(TLH_PINNED_PI_VERSION)}`));
 	assert.match(stage0Help.stdout, /installed into a private TLH runtime/);
 	assert.doesNotMatch(stage0Help.stdout, /--no-pi-install/);
 
@@ -638,7 +642,7 @@ test("installer helpers no longer support the removed --no-pi-install opt-out", 
 	assert.equal(stage0RemovedFlag.stdout, "");
 
 	assert.throws(() => parseArgs(["--no-pi-install"]), /unknown option: --no-pi-install/);
-	assert.match(usage(), new RegExp(`Upstream Pi ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
+	assert.match(usage(), new RegExp(`Upstream Pi ${escapeRegExp(TLH_PINNED_PI_VERSION)}`));
 	assert.doesNotMatch(usage(), /--no-pi-install/);
 
 	const updateHelp = spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-update.mjs"), "--help"], {
@@ -2549,7 +2553,7 @@ test("wrapper update --extensions helper prepends executable --pi-cmd directory 
 	]);
 	assert.equal(updateRecord.env.PI_CODING_AGENT_DIR, agentDir);
 	assert.equal(updateRecord.pi.status, 0, JSON.stringify(updateRecord));
-	assert.match(updateRecord.pi.stdout, new RegExp(TLH_MIN_PI_VERSION.replace(/\./g, "\\.")));
+	assert.match(updateRecord.pi.stdout, new RegExp(escapeRegExp(TLH_MIN_PI_VERSION)));
 
 	const updatePathEntries = updateRecord.env.PATH.split(delimiter);
 	assert.equal(updatePathEntries[0], pinnedPiDir, `expected pinned_dir first; got ${updatePathEntries.join(delimiter)}`);
@@ -3075,7 +3079,6 @@ test("uninstall.sh regression (tlht-h7vq): migrated runtime marker preserves nes
 	writeFileSync(join(tlhPackageDir, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent" }, null, 2));
 	writeFileSync(join(foreignPackageDir, "package.json"), JSON.stringify({ name: "foreign-package" }, null, 2));
 
-	const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 	const dryResult = spawnSync("bash", [join(repoRoot, "uninstall.sh"), "--dry-run", "--agent-dir", agentDir, "--bin-dir", binDir], {
 		cwd: repoRoot,
 		env: scrubInstallerEnv({ HOME: homeDir }),
@@ -3087,9 +3090,9 @@ test("uninstall.sh regression (tlht-h7vq): migrated runtime marker preserves nes
 	assert.equal(dryResult.status, 0, `dry-run failed:\n${dryOutput}`);
 	assert.match(
 		dryOutput,
-		new RegExp(`would remove migrated TLH pi from shared runtime \\(npm\\): npm uninstall -g --ignore-scripts --prefix "${escapeRegex(runtimeDir)}" @earendil-works/pi-coding-agent`),
+		new RegExp(`would remove migrated TLH pi from shared runtime \\(npm\\): npm uninstall -g --ignore-scripts --prefix "${escapeRegExp(runtimeDir)}" @earendil-works/pi-coding-agent`),
 	);
-	assert.doesNotMatch(dryOutput, new RegExp(`would remove private runtime: rm -rf ${escapeRegex(runtimeDir)}`));
+	assert.doesNotMatch(dryOutput, new RegExp(`would remove private runtime: rm -rf ${escapeRegExp(runtimeDir)}`));
 	assert.equal(existsSync(foreignPackageDir), true, "dry-run must not remove nested foreign package");
 
 	writeFakeCommand(fakeNpmDir, "npm", [

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -22,8 +22,8 @@ import { validateInstallerTargets } from "../scripts/lib/tlh-install-paths.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoNodeModulesBin = join(repoRoot, "node_modules", ".bin");
-const TLH_MIN_PI_VERSION = "0.79.1";
-const TLH_PINNED_PI_VERSION = "0.79.7";
+const TLH_MIN_PI_VERSION = "0.80.1";
+const TLH_PINNED_PI_VERSION = "0.80.2";
 
 const TLH_PI_PACKAGE_SPEC = `@earendil-works/pi-coding-agent@${TLH_PINNED_PI_VERSION}`;
 
@@ -105,7 +105,7 @@ function writeFakeTk(fakebin) {
 	writeFakeCommand(fakebin, "tk", "printf 'Usage: tk help\\nTicket CLI helper\\n'");
 }
 
-function writeLoggingPi(commandDir, logPath, version = "0.79.1") {
+function writeLoggingPi(commandDir, logPath, version = TLH_MIN_PI_VERSION) {
 	writeFakePi(commandDir, [
 		`printf '%s|%s|%s\\n' "\${PI_CODING_AGENT_DIR:-}" "$PWD" "$*" >>"${logPath}"`,
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${version}\\n'; exit 0; fi`,
@@ -113,7 +113,7 @@ function writeLoggingPi(commandDir, logPath, version = "0.79.1") {
 	].join("\n"));
 }
 
-function writeVersionedWrapperPi(commandDir, logPath, version = "0.79.1") {
+function writeVersionedWrapperPi(commandDir, logPath, version = TLH_MIN_PI_VERSION) {
 	writeFakePi(commandDir, [
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${version}\\n'; exit 0; fi`,
 		`{ printf 'cmd=%s\\n' "$0"; printf 'argv=%s\\n' "$*"; printf 'agent=%s\\n' "\${PI_CODING_AGENT_DIR:-}"; printf 'path=%s\\n' "\${PATH:-}"; } >"${logPath}"`,
@@ -311,10 +311,10 @@ test("stage-1 repairs the TLH private Pi runtime to the pinned version when it h
 	}, null, 2));
 	writeFakeCommand(fakebin, "git", "exit 0");
 	writeFakeTk(fakebin);
-	// Seed a stale private runtime binary at the expected path (version 0.79.8 is above pin).
+	// Seed a stale private runtime binary at the expected path (version 0.80.3 is above pin).
 	writeFakePi(runtimeBinDir, [
 		`printf '%s|%s|%s\\n' "\${PI_CODING_AGENT_DIR:-}" "$PWD" "$*" >>"${stalePiCallLog}"`,
-		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.79.8\\n'; exit 0; fi",
+		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.80.3\\n'; exit 0; fi",
 		"exit 0",
 	].join("\n"));
 	writeLoggingPi(templateDir, repairedPiLog, TLH_PINNED_PI_VERSION);
@@ -339,7 +339,7 @@ test("stage-1 repairs the TLH private Pi runtime to the pinned version when it h
 	const output = `${result.stdout}\n${result.stderr}`;
 
 	assert.equal(result.status, 0, output);
-	assert.match(output, /Repairing TLH private Pi runtime to pinned 0\.79\.7/);
+	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
 	assert.deepEqual(readFileSync(npmLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [
 		`install -g --ignore-scripts --prefix ${runtimeDir} ${TLH_PI_PACKAGE_SPEC}`,
 	]);
@@ -394,10 +394,10 @@ test("stage-1 repairs the TLH private Pi runtime even when a supported Pi exists
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_MIN_PI_VERSION}\\n'; exit 0; fi`,
 		"exit 0",
 	].join("\n"));
-	// Stale private runtime at 0.79.8 (above pin) triggers repair.
+	// Stale private runtime at 0.80.3 (above pin) triggers repair.
 	writeFakePi(runtimeBinDir, [
 		`printf '%s|%s|%s\\n' "\${PI_CODING_AGENT_DIR:-}" "$PWD" "$*" >>"${stalePiCallLog}"`,
-		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.79.8\\n'; exit 0; fi",
+		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.80.3\\n'; exit 0; fi",
 		"exit 0",
 	].join("\n"));
 	writeLoggingPi(templateDir, repairedPiLog, TLH_PINNED_PI_VERSION);
@@ -422,7 +422,7 @@ test("stage-1 repairs the TLH private Pi runtime even when a supported Pi exists
 	const output = `${result.stdout}\n${result.stderr}`;
 
 	assert.equal(result.status, 0, output);
-	assert.match(output, /Repairing TLH private Pi runtime to pinned 0\.79\.7/);
+	assert.match(output, new RegExp(`Repairing TLH private Pi runtime to pinned ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
 	assert.deepEqual(readFileSync(npmLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [
 		`install -g --ignore-scripts --prefix ${runtimeDir} ${TLH_PI_PACKAGE_SPEC}`,
 	]);
@@ -623,7 +623,7 @@ test("installer helpers no longer support the removed --no-pi-install opt-out", 
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 	assert.equal(stage0Help.status, 0, stage0Help.stderr);
-	assert.match(stage0Help.stdout, /Upstream Pi 0\.79\.7/);
+	assert.match(stage0Help.stdout, new RegExp(`Upstream Pi ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
 	assert.match(stage0Help.stdout, /installed into a private TLH runtime/);
 	assert.doesNotMatch(stage0Help.stdout, /--no-pi-install/);
 
@@ -638,7 +638,7 @@ test("installer helpers no longer support the removed --no-pi-install opt-out", 
 	assert.equal(stage0RemovedFlag.stdout, "");
 
 	assert.throws(() => parseArgs(["--no-pi-install"]), /unknown option: --no-pi-install/);
-	assert.match(usage(), /Upstream Pi 0\.79\.7/);
+	assert.match(usage(), new RegExp(`Upstream Pi ${TLH_PINNED_PI_VERSION.replace(/\./g, "\\.")}`));
 	assert.doesNotMatch(usage(), /--no-pi-install/);
 
 	const updateHelp = spawnSync(process.execPath, [join(repoRoot, "scripts/tlh-update.mjs"), "--help"], {
@@ -706,7 +706,7 @@ test("stage-1 --no-settings does not short-circuit Gnosis configure", (t) => {
 	const binDir = join(root, "bin");
 	const fakebin = join(root, "fakebin");
 	mkdirSync(homeDir, { recursive: true });
-	writeFakePi(fakebin, "if [[ \"${1:-}\" == \"--version\" ]]; then\n\tprintf '0.79.1\\n'\n\texit 0\nfi\nexit 0");
+	writeFakePi(fakebin, "if [[ \"${1:-}\" == \"--version\" ]]; then\n\tprintf '0.80.1\\n'\n\texit 0\nfi\nexit 0");
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	const result = spawnSync(process.execPath, [
@@ -1630,7 +1630,7 @@ function setupTicketsEnabledWrapperFixture(t) {
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	writeFakePi(fakebin, [
-		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.79.7\\n'; exit 0; fi",
+		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.80.2\\n'; exit 0; fi",
 		"printf 'path=%s\\n' \"${PATH:-}\" >\"${PI_WRAPPER_LOG}\"",
 	].join("\n"));
 
@@ -2505,7 +2505,7 @@ test("wrapper update --extensions helper prepends executable --pi-cmd directory 
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	mkdirSync(pinnedPiDir, { recursive: true });
-	writeFileSync(join(pinnedPiDir, "pi"), "#!/bin/sh\nif [ \"${1:-}\" = \"--version\" ]; then printf '0.79.1\\n'; exit 0; fi\nprintf 'unexpected args: %s\\n' \"$*\" >&2\nexit 1\n", "utf8");
+	writeFileSync(join(pinnedPiDir, "pi"), "#!/bin/sh\nif [ \"${1:-}\" = \"--version\" ]; then printf '0.80.1\\n'; exit 0; fi\nprintf 'unexpected args: %s\\n' \"$*\" >&2\nexit 1\n", "utf8");
 	chmodSync(join(pinnedPiDir, "pi"), 0o755);
 	writeFileSync(join(agentDir, "tlh", "recover-update.mjs"), `import { spawnSync } from "node:child_process";\nimport { writeFileSync } from "node:fs";\nconst pi = spawnSync("pi", ["--version"], { encoding: "utf8" });\nwriteFileSync(process.env.TLH_UPDATE_LOG, JSON.stringify({ argv: process.argv.slice(2), env: { PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR, PATH: process.env.PATH }, pi: { status: pi.status, stdout: pi.stdout, stderr: pi.stderr, error: pi.error?.message } }));\nprocess.exit(pi.status ?? (pi.error ? 1 : 0));\n`, "utf8");
 
@@ -2549,7 +2549,7 @@ test("wrapper update --extensions helper prepends executable --pi-cmd directory 
 	]);
 	assert.equal(updateRecord.env.PI_CODING_AGENT_DIR, agentDir);
 	assert.equal(updateRecord.pi.status, 0, JSON.stringify(updateRecord));
-	assert.match(updateRecord.pi.stdout, /0\.79\.1/);
+	assert.match(updateRecord.pi.stdout, new RegExp(TLH_MIN_PI_VERSION.replace(/\./g, "\\.")));
 
 	const updatePathEntries = updateRecord.env.PATH.split(delimiter);
 	assert.equal(updatePathEntries[0], pinnedPiDir, `expected pinned_dir first; got ${updatePathEntries.join(delimiter)}`);
@@ -2581,10 +2581,10 @@ test("wrapper update --extensions helper prepends the pinned private runtime dir
 	mkdirSync(cwdDir, { recursive: true });
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
-	// Pinned pi at 0.79.8 (soft-warn territory) — still prepended for --extensions.
+	// Pinned pi at 0.80.3 (soft-warn territory) — still prepended for --extensions.
 	writeFakePi(pinnedPiDir, [
 		`printf '%s\\n' "$*" >>"${pinnedPiCallLog}"`,
-		`if [[ "\${1:-}" == "--version" ]]; then printf '0.79.8\\n'; exit 0; fi`,
+		`if [[ "\${1:-}" == "--version" ]]; then printf '0.80.3\\n'; exit 0; fi`,
 		"exit 85",
 	].join("\n"));
 	writeFileSync(join(agentDir, "tlh", "recover-update.mjs"), `import { spawnSync } from "node:child_process";\nimport { writeFileSync } from "node:fs";\nconst pi = spawnSync("pi", ["--version"], { encoding: "utf8" });\nwriteFileSync(process.env.TLH_UPDATE_LOG, JSON.stringify({ argv: process.argv.slice(2), env: { PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR, PATH: process.env.PATH }, pi: { status: pi.status, stdout: pi.stdout, stderr: pi.stderr, error: pi.error?.message } }));\nprocess.exit(pi.status ?? (pi.error ? 1 : 0));\n`, "utf8");
@@ -2624,7 +2624,7 @@ test("wrapper update --extensions helper prepends the pinned private runtime dir
 	assert.equal(updatePathEntries.includes(cwdDir), false);
 	assert.equal(updatePathEntries.includes(agentBin), false);
 	// The update script invokes pi --version and finds the pinned runtime.
-	assert.match(updateRecord.pi.stdout, /0\.79\.8/);
+	assert.match(updateRecord.pi.stdout, /0\.80\.3/);
 });
 
 test("tlh update --extensions uses absolute private runtime pi and hard-fails when missing", (t) => {
@@ -2813,8 +2813,8 @@ test("stage-1 installPiIfNeeded: broken npm install (wrong pi version) throws", 
 	// Legacy pi at ~/.local/bin/pi — must NOT be removed when install fails.
 	writeFakePi(legacyBin, `if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_PINNED_PI_VERSION}\\n'; exit 0; fi\nexit 0`);
 
-	// Template pi with WRONG version (0.79.8 > MAX 0.79.7) — simulates a broken npm install.
-	writeFakePi(templateDir, "if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.79.8\\n'; exit 0; fi\nexit 0");
+	// Template pi with WRONG version (0.80.3 > MAX 0.80.2) — simulates a broken npm install.
+	writeFakePi(templateDir, "if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.80.3\\n'; exit 0; fi\nexit 0");
 
 	// Fake npm: always installs the wrong-version template pi.
 	writeFakeNpmInstaller(fakebin, {
@@ -2842,7 +2842,7 @@ test("stage-1 installPiIfNeeded: broken npm install (wrong pi version) throws", 
 
 	// Installer must fail: freshly installed pi has wrong version.
 	assert.notEqual(result.status, 0, `expected installer to fail on wrong-version pi, got exit 0:\n${output}`);
-	assert.match(output, /0\.79\.8/, "error output should mention the wrong version");
+	assert.match(output, /0\.80\.3/, "error output should mention the wrong version");
 
 	// ~/.local/bin/pi must NOT have been removed (install threw before any cleanup could run).
 	assert.equal(existsSync(legacyPiPath), true, "user-owned ~/.local/bin/pi was removed despite installer throwing");
@@ -2859,7 +2859,7 @@ test("stage-1 installPiIfNeeded: broken npm install (wrong pi version) throws", 
 });
 
 // Regression (tlht-5php, blocker): piInstalledByTlh=true, private runtime ABSENT at start,
-// user-owned ~/.local/bin/pi@0.79.7 present.  The installer must provision the private
+// user-owned ~/.local/bin/pi@0.80.2 present.  The installer must provision the private
 // runtime and succeed — without removing or executing ~/.local/bin/pi.
 test("stage-1 regression (tlht-5php): installer never removes or execs user-owned ~/.local/bin/pi when piInstalledByTlh=true and private runtime is absent", (t) => {
 	const root = makeTempDir();
@@ -2895,7 +2895,7 @@ test("stage-1 regression (tlht-5php): installer never removes or execs user-owne
 		piInstalledByTlh: true,
 	}, null, 2));
 
-	// User-owned ~/.local/bin/pi@0.79.7 — must NOT be removed or invoked by the installer.
+	// User-owned ~/.local/bin/pi@0.80.2 — must NOT be removed or invoked by the installer.
 	writeFakePi(legacyBin, [
 		`printf '%s\\n' "$*" >>"${legacyPiInvocationLog}"`,
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_PINNED_PI_VERSION}\\n'; exit 0; fi`,
@@ -2985,7 +2985,7 @@ test("uninstall.sh does not remove legacy ~/.local/bin/pi without --force-includ
 	}, null, 2));
 
 	// User-owned legacy pi at ~/.local/bin/pi.
-	writeFileSync(join(legacyBin, "pi"), "#!/bin/sh\nprintf '0.79.7\\n'\n", "utf8");
+	writeFileSync(join(legacyBin, "pi"), "#!/bin/sh\nprintf '0.80.2\\n'\n", "utf8");
 	chmodSync(join(legacyBin, "pi"), 0o755);
 
 	// ── (d1) dry-run without --force-include-pi: hint printed, pi NOT removed ──

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -103,14 +103,15 @@ test("annotate-git-diff review HTML inlines Monaco assets without file:// URLs i
 	// Regression guard: no file:// URL pointing into node_modules must appear in the built HTML.
 	assert.doesNotMatch(html, /file:\/\/[^\s'"]*node_modules/, "built HTML must not contain file:// URLs into node_modules");
 
-	// Monaco editor JS is inlined (editor.main.js contains 'vs/editor/edcore.main').
-	assert.match(html, /vs\/editor\/edcore\.main/, "editor.main.js content must be inlined");
+	// Monaco editor JS is inlined (editor.main.js defines 'vs/editor/editor.main').
+	assert.match(html, /define\("vs\/editor\/editor\.main"/, "editor.main.js content must be inlined");
+	assert.match(html, /"bootstrapError":null/, "packaged review assets should load without a bootstrap error");
 
 	// Monaco editor CSS is inlined (editor.main.css contains '.monaco-editor').
 	assert.match(html, /\.monaco-editor/, "editor.main.css content must be inlined");
 
-	// Monaco worker source is inlined (workerMain.js contains 'EditorSimpleWorker').
-	assert.match(html, /EditorSimpleWorker/, "workerMain.js content must be inlined");
+	// Monaco worker source is inlined as a non-empty bundled script.
+	assert.match(html, /window\.__reviewMonacoWorkerSource = "\(function\(\)\{/, "editor worker source must be inlined");
 
 	// No unreplaced template markers.
 	assert.doesNotMatch(html, /__INLINE_MONACO_EDITOR_JS__/);
@@ -118,10 +119,10 @@ test("annotate-git-diff review HTML inlines Monaco assets without file:// URLs i
 	assert.doesNotMatch(html, /__INLINE_MONACO_WORKER_SOURCE_JSON__/);
 	assert.doesNotMatch(html, /__INLINE_MONACO_BASIC_LANGUAGES_JS__/, "__INLINE_MONACO_BASIC_LANGUAGES_JS__ marker must be replaced");
 
-	// Basic-language tokenizers are inlined (representative sample).
-	assert.match(html, /define\("vs\/basic-languages\/typescript\/typescript"/, "TypeScript tokenizer must be inlined");
-	assert.match(html, /define\("vs\/basic-languages\/python\/python"/, "Python tokenizer must be inlined");
-	assert.match(html, /define\("vs\/basic-languages\/go\/go"/, "Go tokenizer must be inlined");
+	// Monaco language bundles are inlined (representative sample).
+	assert.match(html, /define\("vs\/typescript-/, "TypeScript tokenizer bundle must be inlined");
+	assert.match(html, /define\("vs\/python-/, "Python tokenizer bundle must be inlined");
+	assert.match(html, /define\("vs\/go-/, "Go tokenizer bundle must be inlined");
 
 	// The asset config must not expose monacoVsBaseUrl.
 	assert.doesNotMatch(html, /monacoVsBaseUrl/);

--- a/tests/the-last-harness-primary-tools.test.mjs
+++ b/tests/the-last-harness-primary-tools.test.mjs
@@ -38,7 +38,7 @@ test("disabled primary mode does not overwrite active tools changed after primar
 	const primaryToolState = createPrimaryToolState();
 	let activeTools = ["bash", "edit"];
 
-	activeTools = primaryToolState.apply(["read", "grep"], activeTools);
+	primaryToolState.apply(["read", "grep"], activeTools);
 	activeTools = ["bash"];
 
 	const restoredTools = primaryToolState.restoreIfAppropriate(activeTools, availableTools);

--- a/tests/trace-policy-checker.mjs
+++ b/tests/trace-policy-checker.mjs
@@ -759,22 +759,22 @@ function extractShellRedirectionTarget(command) {
 				continue;
 			}
 
-			let target = "";
-			if (candidate[cursor] === "'" || candidate[cursor] === '"') {
-				const quote = candidate[cursor];
-				cursor += 1;
-				const start = cursor;
-				while (cursor < candidate.length && candidate[cursor] !== quote) {
+			const target = (() => {
+				if (candidate[cursor] === "'" || candidate[cursor] === '"') {
+					const quote = candidate[cursor];
 					cursor += 1;
+					const start = cursor;
+					while (cursor < candidate.length && candidate[cursor] !== quote) {
+						cursor += 1;
+					}
+					return candidate.slice(start, cursor);
 				}
-				target = candidate.slice(start, cursor);
-			} else {
 				const start = cursor;
 				while (cursor < candidate.length && !/[\s;&|]/.test(candidate[cursor])) {
 					cursor += 1;
 				}
-				target = candidate.slice(start, cursor);
-			}
+				return candidate.slice(start, cursor);
+			})();
 
 			const normalizedTarget = normalizeText(target);
 			if (!normalizedTarget || isSafeShellSink(normalizedTarget)) {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,7 +15,7 @@ KEEP_PI=false
 QUIET=false
 VERBOSE=false
 PI_PACKAGE_NAME="@earendil-works/pi-coding-agent"
-PINNED_PI_VERSION="0.79.7"
+PINNED_PI_VERSION="0.80.2"
 RUNTIME_MARKER_FILENAME=".tlh-runtime-owned"
 TLH_WRAPPER_MARKER_LINE="# Managed by The Last Harness installer"
 


### PR DESCRIPTION
## Summary

Update TLH dependency pins and bundled default-extension pins to current releases:

- bump the pinned upstream Pi runtime/dev deps to `0.80.2` with supported peer range `>=0.80.1 <=0.80.2`
- refresh `package-lock.json`
- bump bundled npm default extensions to latest versions
- bump bundled `pi-subagents` fork tag to `tlh-v0.26.0-13`
- update installer/docs/tests for the new runtime pin and dependency tooling fallout
- adapt annotate git diff Monaco asset packaging for `monaco-editor@0.55.1`

## Change type

- [x] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

Covered by `npm run validate` via `scripts/check-installer-smoke.sh`.

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

N/A.

_Paste the relevant output or a summary here:_

- `npm run validate` — passed
- `git diff --check` — passed
- final code-reviewer pass found one stale `pi-subagents` tag; fixed and reran `npm run validate`

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

Updates bundled `pi-subagents` default-extension pin to the latest TLH fork tag available at implementation time.

**Link to merged fork PR:**

N/A — tag-only bundled default update.

**Before → after pin:**

`git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-12` → `git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/deps/update-all-dependencies/install.sh | bash -s -- --ref deps/update-all-dependencies --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the bundled installer/runtime to use a newer pinned Pi version (0.80.2).
  * Refreshed default extension/source pins to newer releases.
  * Improved Monaco editor asset loading for the review UI to better handle bundled assets.
* **Bug Fixes**
  * Improved error reporting during JSON/file/read and installer operations with clearer context.
  * Fixed attribution parsing behavior around the `--` token.
* **Documentation**
  * Updated installation and prerequisite documentation to reflect the new pinned runtime version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->