### PR TITLE
Add README downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The last harness you'll ever need.
 
 [![CI](https://github.com/diegopetrucci/the-last-harness/actions/workflows/ci.yml/badge.svg)](https://github.com/diegopetrucci/the-last-harness/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/github/downloads/diegopetrucci/the-last-harness/total)](https://github.com/diegopetrucci/the-last-harness/releases)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.19.0-339933?logo=nodedotjs)](package.json)
 
 `tlh` (The Last Harness) is an opinionated harness built on top of [Pi](https://github.com/earendil-works/pi).


### PR DESCRIPTION
## Summary

Adds a Shields.io badge showing total GitHub Release asset downloads.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Docs-only change; narrower validation used.

- Reviewed the README diff and confirmed the only source change is the intended badge insertion.
- Confirmed the badge uses `https://img.shields.io/github/downloads/diegopetrucci/the-last-harness/total`.
- Code review pass found no issue with the README badge itself.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a GitHub downloads badge to the project README to show release download totals at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->