### PR TITLE
Add CI monitoring guidance

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -130,3 +130,4 @@ When the incoming user turn's first line is exactly `[/review]`, skip the normal
 2. Verify no session-created `.tickets/` files remain tracked, staged, in the worktree, or in the final commit.
 3. If this workflow closed or modified a ticket that already existed in the repository, ask the user whether they want to keep the change, revert it, or delete the ticket.
 4. When opening PRs, if a PR template is present for the repository, always follow it.
+5. After opening a PR, monitor CI/status checks. If any fail, report the failure and ask the user whether to proceed. Do not investigate the failure, edit code, commit, or push follow-up changes unless the user explicitly asks.

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -52,3 +52,4 @@ If the task expands into product decisions, multi-ticket planning, or broader or
 ## Cleanup
 
 - When opening PRs, if a PR template is present for the repository, always follow it.
+- After opening a PR, monitor CI/status checks. If any fail, report the failure and ask the user whether to proceed. Do not investigate the failure, edit code, commit, or push follow-up changes unless the user explicitly asks.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ These commands are registered by the TLH extension bundled with this profile.
 |---------|-------------|
 | `/thinking` | Pick the model thinking level, subject to the active primary-agent thinking constraints |
 | `/effort` | Supported alias for `/thinking`, subject to the same active primary-agent thinking constraints |
-| `/experimental` | List or change TLH experimental features (`contrarian` and `delta-follow-up-reviews` are currently registered) |
+| `/experimental` | List or change TLH experimental features (`contrarian`, `delta-follow-up-reviews`, and `ci-failure-investigation` are currently registered) |
 | `/review` | Open an interactive code-review mode picker (requires the architect primary agent) |
 | `/switch-primary-agent` | Show or switch the active TLH primary agent (`architect`, `rush`, `product`, `bug-hunter`, `disabled`) |
 | `/tlh-changelog` | Show TLH release notes from the packaged `CHANGELOG.md` |
@@ -64,7 +64,7 @@ Both `/thinking` and `/effort` are subject to the active primary-agent thinking 
 
 ### `/experimental`
 
-`/experimental` currently registers `contrarian` and `delta-follow-up-reviews`. `contrarian` bundles the adversarial `contrarian` minor agent but keeps it disabled by default; enable it with `/experimental enable contrarian` and disable it with `/experimental disable contrarian`. It is intended mainly for sparing pre-ticket planning stress-tests when a proposed change genuinely warrants an adversarial brief, not the routine `code-reviewer` diff pass and not the broader `oracle` second-opinion path. `delta-follow-up-reviews` is an opt-in flag that adds architect and `code-reviewer` guidance for delta-scoped follow-up reviews after fixes. Both flags are disabled by default. Stale `run-tests-last` values in `tlh.experimental.enabledFeatures` do not re-enable retired behavior.
+`/experimental` currently registers `contrarian`, `delta-follow-up-reviews`, and `ci-failure-investigation`. `contrarian` bundles the adversarial `contrarian` minor agent but keeps it disabled by default; enable it with `/experimental enable contrarian` and disable it with `/experimental disable contrarian`. It is intended mainly for sparing pre-ticket planning stress-tests when a proposed change genuinely warrants an adversarial brief, not the routine `code-reviewer` diff pass and not the broader `oracle` second-opinion path. `delta-follow-up-reviews` is an opt-in flag that adds architect and `code-reviewer` guidance for delta-scoped follow-up reviews after fixes. `ci-failure-investigation` is an opt-in flag that lets the architect primary agent do read-only failed CI/status-check investigation after TLH opens a PR, then summarize and ask whether to proceed before any edits, commits, pushes, reruns, PR changes, or other follow-up changes. All three flags are disabled by default. Stale `run-tests-last` values in `tlh.experimental.enabledFeatures` do not re-enable retired behavior.
 
 ### `/tokens`
 

--- a/extensions/the-last-harness/experimental.ts
+++ b/extensions/the-last-harness/experimental.ts
@@ -12,6 +12,7 @@ import type { AgentPrompt, TlhExperimentalConfig, TlhExperimentalFeatureId, TlhS
 
 export const TLH_CONTRARIAN_FEATURE: TlhExperimentalFeatureId = CONTRARIAN_EXPERIMENTAL_FEATURE;
 export const DELTA_FOLLOW_UP_REVIEWS_FEATURE: TlhExperimentalFeatureId = "delta-follow-up-reviews";
+export const CI_FAILURE_INVESTIGATION_FEATURE: TlhExperimentalFeatureId = "ci-failure-investigation";
 
 const EXPERIMENTAL_COMMAND_HELP = [
 	"Usage: /experimental [list|status [feature]|enable <feature>|disable <feature>|toggle <feature>]",
@@ -82,6 +83,22 @@ Additional minor agent:
 - \`contrarian\`: adversarially stress-test bug hypotheses or review conclusions by steelmanning the strongest opposing case. Use it sparingly when you need to challenge your diagnosis; it does not replace \`code-reviewer\`, which reviews code changes, or \`oracle\`, which gives a broader second opinion.
 `;
 
+const CI_FAILURE_INVESTIGATION_ARCHITECT_PROMPT = `
+## TLH Experimental Feature: ci-failure-investigation
+
+This TLH experiment is enabled for the architect primary agent.
+
+This experiment overrides the default post-PR monitor-and-ask-only step for this specific case.
+
+After TLH opens a PR and CI/status checks fail:
+
+1. You may do a read-only investigation before asking the user whether to proceed.
+2. Keep that investigation read-only: inspect failed checks, logs, workflow/config files, diffs, and relevant code or tests as needed to understand the failure.
+3. Do not edit files, commit, push, rerun jobs, change the PR, or take any other follow-up action during this investigation.
+4. After the investigation, summarize the failure and likely cause, then ask the user whether to proceed.
+5. Before any edits, commits, pushes, reruns, PR changes, or other follow-up changes, ask for explicit user approval.
+`;
+
 type TlhExperimentalFeature = {
 	id: TlhExperimentalFeatureId;
 	description: string;
@@ -120,6 +137,13 @@ const TLH_EXPERIMENTAL_FEATURES: TlhExperimentalFeature[] = [
 			architect: DELTA_FOLLOW_UP_REVIEWS_ARCHITECT_PROMPT.trim(),
 		},
 		codeReviewerPrompt: DELTA_FOLLOW_UP_REVIEWS_CODE_REVIEWER_PROMPT.trim(),
+	},
+	{
+		id: CI_FAILURE_INVESTIGATION_FEATURE,
+		description: "Architect-only guidance to perform read-only PR CI/status-check investigation before asking whether to proceed.",
+		primaryAgentPrompts: {
+			architect: CI_FAILURE_INVESTIGATION_ARCHITECT_PROMPT.trim(),
+		},
 	},
 ];
 

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -33,6 +33,7 @@ const contracts = [
 				"architect captures only ticket-specific validation deviations",
 				/ticket-specific validation expectations.*differ from the repository's normal validation flow/i,
 			),
+			orderedTerms("architect monitors CI after opening PRs without autonomous follow-up", ["After opening a PR", "monitor CI/status checks", "If any fail", "ask the user whether to proceed", "Do not investigate", "unless the user explicitly asks"]),
 		],
 	},
 	{
@@ -48,6 +49,7 @@ const contracts = [
 			bodyPattern("Rush never delegates implementation to developer", /do not delegate implementation to [`']?developer[`']?/i),
 			orderedTerms("tickets are optional by default", ["do not create or require", "tk", "by default"]),
 			bodyPattern("broad work escalates to architect or product", /recommend switching to [`']?architect[`']?|recommend [`']?architect[`']? or [`']?product[`']?/i),
+			orderedTerms("Rush monitors CI after opening PRs without autonomous follow-up", ["After opening a PR", "monitor CI/status checks", "If any fail", "ask the user whether to proceed", "Do not investigate", "unless the user explicitly asks"]),
 		],
 	},
 	{

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -207,6 +207,17 @@ test("base primary prompts keep contrarian guidance behind the experimental flag
 	}
 });
 
+test("base architect and rush prompts keep ci failure investigation guidance behind the experimental flag", () => {
+	for (const name of ["architect", "rush"]) {
+		const { normalizedBody } = readAgentPrompt("primary", name);
+		assert.doesNotMatch(normalizedBody, /read-only investigation before asking the user whether to proceed/i);
+		assert.doesNotMatch(normalizedBody, /inspect failed checks, logs, workflow\/config files, diffs/i);
+		assert.doesNotMatch(normalizedBody, /rerun jobs, change the pr, or take any other follow-up action during this investigation/i);
+		assert.match(normalizedBody, /after opening a pr, monitor ci\/status checks/i);
+		assert.match(normalizedBody, /do not investigate .* unless the user explicitly asks/i);
+	}
+});
+
 test("base developer prompt does not inherit the architect final-validation workflow", () => {
 	const developer = readAgentPrompt("subagents", "developer");
 	const { normalizedBody } = developer;

--- a/tests/the-last-harness-experimental.test.mjs
+++ b/tests/the-last-harness-experimental.test.mjs
@@ -11,6 +11,7 @@ const RETIRED_RUN_TESTS_LAST_FEATURE = "run-tests-last";
 const LEGACY_UNKNOWN_FEATURE = "legacy-flag";
 const jiti = createJiti(import.meta.url);
 const {
+	CI_FAILURE_INVESTIGATION_FEATURE,
 	DELTA_FOLLOW_UP_REVIEWS_FEATURE,
 	TLH_CONTRARIAN_FEATURE,
 	buildPrimaryExperimentalPrompt,
@@ -52,18 +53,27 @@ function registeredExperimentalCommand() {
 	return command;
 }
 
-test("experimental command registers contrarian and delta follow-up review flags as default-off", async (t) => {
+test("experimental command registers contrarian, delta follow-up review, and architect-only ci failure investigation flags as default-off", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-experimental-test-", { test: t });
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const command = registeredExperimentalCommand();
 		assert.deepEqual(
 			(await command.getArgumentCompletions("enable ")).map((completion) => completion.value),
-			[`enable ${TLH_CONTRARIAN_FEATURE}`, `enable ${DELTA_FOLLOW_UP_REVIEWS_FEATURE}`],
+			[
+				`enable ${TLH_CONTRARIAN_FEATURE}`,
+				`enable ${DELTA_FOLLOW_UP_REVIEWS_FEATURE}`,
+				`enable ${CI_FAILURE_INVESTIGATION_FEATURE}`,
+			],
 		);
 		assert.deepEqual(
 			(await command.getArgumentCompletions("status ")).map((completion) => completion.value),
-			["status", `status ${TLH_CONTRARIAN_FEATURE}`, `status ${DELTA_FOLLOW_UP_REVIEWS_FEATURE}`],
+			[
+				"status",
+				`status ${TLH_CONTRARIAN_FEATURE}`,
+				`status ${DELTA_FOLLOW_UP_REVIEWS_FEATURE}`,
+				`status ${CI_FAILURE_INVESTIGATION_FEATURE}`,
+			],
 		);
 		assert.equal(await command.getArgumentCompletions("unknown"), null);
 
@@ -77,6 +87,9 @@ test("experimental command registers contrarian and delta follow-up review flags
 		assert.match(notifications.at(-1)?.message ?? "", /disabled \(default\)/);
 		assert.match(notifications.at(-1)?.message ?? "", /\/experimental enable contrarian/);
 		assert.match(notifications.at(-1)?.message ?? "", /\/experimental enable delta-follow-up-reviews/);
+		assert.match(notifications.at(-1)?.message ?? "", /ci-failure-investigation/);
+		assert.match(notifications.at(-1)?.message ?? "", /architect-only guidance/i);
+		assert.match(notifications.at(-1)?.message ?? "", /\/experimental enable ci-failure-investigation/);
 		assert.doesNotMatch(notifications.at(-1)?.message ?? "", /run-tests-last/);
 	});
 });
@@ -91,6 +104,23 @@ test("contrarian experimental prompt injection stays default-off and becomes pri
 	assert.match(buildPrimaryExperimentalPrompt({ name: "rush" }, enabledConfig) ?? "", /TLH experiment enables the `contrarian` minor agent for TLH Rush/);
 	assert.match(buildPrimaryExperimentalPrompt({ name: "product" }, enabledConfig) ?? "", /product directions, tradeoffs, assumptions, or ticket framing/);
 	assert.match(buildPrimaryExperimentalPrompt({ name: "bug-hunter" }, enabledConfig) ?? "", /stress-test bug hypotheses or review conclusions/);
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "developer" }, enabledConfig), undefined);
+});
+
+test("ci failure investigation prompt injection stays default-off and only enables architect read-only investigation guidance", () => {
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "architect" }, undefined), undefined);
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "rush" }, undefined), undefined);
+
+	const enabledConfig = { enabledFeatures: [CI_FAILURE_INVESTIGATION_FEATURE] };
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /## TLH Experimental Feature: ci-failure-investigation/);
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /overrides the default post-PR monitor-and-ask-only step/i);
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /You may do a read-only investigation before asking the user whether to proceed/i);
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /Do not edit files, commit, push, rerun jobs, change the PR/i);
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /edits, commits, pushes, reruns, PR changes, or other follow-up changes/i);
+	assert.match(buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "", /ask for explicit user approval/i);
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "rush" }, enabledConfig), undefined);
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "product" }, enabledConfig), undefined);
+	assert.equal(buildPrimaryExperimentalPrompt({ name: "bug-hunter" }, enabledConfig), undefined);
 	assert.equal(buildPrimaryExperimentalPrompt({ name: "developer" }, enabledConfig), undefined);
 });
 

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -401,7 +401,7 @@ test("extension wires TLH changelog command and release-notes rendering", () => 
 	assert.match(changelogSource, /pi\.sendMessage\(\{/);
 });
 
-test("extension keeps TLH experimental command wiring with delta-follow-up-reviews as the registered flag", () => {
+test("extension keeps TLH experimental command wiring with registered ci and review feature flags", () => {
 	const lockedWriteHelper = sourceSection(
 		profileStateSource,
 		"export function withLockedTlhSettingsWrite",
@@ -412,6 +412,7 @@ test("extension keeps TLH experimental command wiring with delta-follow-up-revie
 	assert.match(extensionSource, /from "\.\/the-last-harness\/experimental\.js"/);
 	assert.match(experimentalSource, /pi\.registerCommand\("experimental"/);
 	assert.match(experimentalSource, /delta-follow-up-reviews/);
+	assert.match(experimentalSource, /ci-failure-investigation/);
 	assert.doesNotMatch(experimentalSource, /run-tests-last/);
 	assert.match(
 		experimentalSource,

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -9,7 +9,9 @@ import { cleanupTempDir, createIsolatedProfileFixture, withEnv } from "./test-fi
 
 const jiti = createJiti(import.meta.url);
 const { TLH_DEFAULT_COMMIT_ATTRIBUTION } = await jiti.import("../extensions/the-last-harness/attribution.ts");
-const { DELTA_FOLLOW_UP_REVIEWS_FEATURE, TLH_CONTRARIAN_FEATURE } = await jiti.import("../extensions/the-last-harness/experimental.ts");
+const { CI_FAILURE_INVESTIGATION_FEATURE, DELTA_FOLLOW_UP_REVIEWS_FEATURE, TLH_CONTRARIAN_FEATURE } = await jiti.import(
+	"../extensions/the-last-harness/experimental.ts",
+);
 const { registerTlhPrimaryAgentRuntime } = await jiti.import("../extensions/the-last-harness/primary-agent-runtime.ts");
 
 function createPiHarness() {
@@ -367,6 +369,60 @@ test("before_agent_start gates delta follow-up review guidance behind isolated T
 		assert.match(enabledPrompt.systemPrompt, /default the follow-up `code-reviewer` request to the delta since the last reviewed checkpoint/i);
 		assert.match(enabledPrompt.systemPrompt, /prior findings.*git range or checkpoint.*changed-file list/i);
 		assert.match(enabledPrompt.systemPrompt, /targeted wider review or full re-review/i);
+	});
+});
+
+test("before_agent_start gates ci failure investigation guidance behind isolated TLH settings for architect only", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		const { beforeAgentStart } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata: [] });
+		const defaultPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, createToolCallContext([], undefined, { cwd: fixture.cwd }));
+		assert.doesNotMatch(defaultPrompt.systemPrompt, /## TLH Experimental Feature: ci-failure-investigation/);
+		assert.doesNotMatch(defaultPrompt.systemPrompt, /read-only investigation before asking the user whether to proceed/i);
+
+		for (const enabledFeatures of [true, [123]]) {
+			writeFileSync(
+				join(fixture.agent, "settings.json"),
+				`${JSON.stringify({ tlh: { experimental: { enabledFeatures } } }, null, 2)}\n`,
+			);
+			const malformedPrompt = await beforeAgentStart(
+				{ systemPrompt: "base prompt" },
+				createToolCallContext([], undefined, { cwd: fixture.cwd }),
+			);
+			assert.doesNotMatch(malformedPrompt.systemPrompt, /## TLH Experimental Feature: ci-failure-investigation/);
+			assert.doesNotMatch(malformedPrompt.systemPrompt, /read-only investigation before asking the user whether to proceed/i);
+		}
+
+		writeFileSync(
+			join(fixture.agent, "settings.json"),
+			`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [CI_FAILURE_INVESTIGATION_FEATURE] } } }, null, 2)}\n`,
+		);
+		const architectPrompt = await beforeAgentStart(
+			{ systemPrompt: "base prompt" },
+			createToolCallContext([], undefined, { cwd: fixture.cwd }),
+		);
+		assert.match(architectPrompt.systemPrompt, /## TLH Experimental Feature: ci-failure-investigation/);
+		assert.match(architectPrompt.systemPrompt, /This TLH experiment is enabled for the architect primary agent/i);
+		assert.match(architectPrompt.systemPrompt, /overrides the default post-PR monitor-and-ask-only step/i);
+		assert.match(architectPrompt.systemPrompt, /read-only investigation before asking the user whether to proceed/i);
+		assert.match(architectPrompt.systemPrompt, /Do not edit files, commit, push, rerun jobs, change the PR/i);
+		assert.match(architectPrompt.systemPrompt, /edits, commits, pushes, reruns, PR changes, or other follow-up changes/i);
+		assert.match(architectPrompt.systemPrompt, /ask for explicit user approval/i);
+
+		writeFileSync(
+			join(fixture.agent, "settings.json"),
+			`${JSON.stringify(
+				{ tlh: { primaryAgent: { selected: "rush" }, experimental: { enabledFeatures: [CI_FAILURE_INVESTIGATION_FEATURE] } } },
+				null,
+				2,
+			)}\n`,
+		);
+		const rushPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, createToolCallContext([], undefined, { cwd: fixture.cwd }));
+		assert.doesNotMatch(rushPrompt.systemPrompt, /## TLH Experimental Feature: ci-failure-investigation/);
+		assert.doesNotMatch(rushPrompt.systemPrompt, /This TLH experiment is enabled for TLH Rush/i);
+		assert.doesNotMatch(rushPrompt.systemPrompt, /read-only investigation before asking the user whether to proceed/i);
+		assert.doesNotMatch(rushPrompt.systemPrompt, /summarize the failure and likely cause, then ask the user whether to proceed/i);
 	});
 });
 

--- a/tests/tlh-ticket-docs-static.test.mjs
+++ b/tests/tlh-ticket-docs-static.test.mjs
@@ -119,14 +119,17 @@ test("annotate-git-diff docs use the renamed command and extension names", () =>
 	assert.match(commandsDoc, /`annotate-git-diff`/);
 });
 
-test("commands docs describe contrarian and delta-follow-up-reviews as default-off /experimental flags", () => {
+test("commands docs describe contrarian, delta-follow-up-reviews, and architect-only ci-failure-investigation as default-off /experimental flags", () => {
 	const commandsDoc = readRepoFile("docs/commands.md");
 
 	assert.match(commandsDoc, /`\/experimental`/);
 	assert.match(commandsDoc, /contrarian/);
 	assert.match(commandsDoc, /delta-follow-up-reviews/);
+	assert.match(commandsDoc, /ci-failure-investigation/);
+	assert.match(commandsDoc, /architect primary agent do read-only failed ci\/status-check investigation/i);
 	assert.match(commandsDoc, /\/experimental enable contrarian/);
 	assert.match(commandsDoc, /\/experimental disable contrarian/);
+	assert.match(commandsDoc, /before any edits, commits, pushes, reruns, pr changes, or other follow-up changes/i);
 	assert.match(commandsDoc, /disabled by default/i);
 	assert.match(commandsDoc, /stale `run-tests-last` values/i);
 	assert.doesNotMatch(commandsDoc, /contrarian-subagent/);


### PR DESCRIPTION
## Summary

- Add default TLH prompt guidance to monitor CI/status checks after opening a PR and ask before proceeding on failures.
- Add default-off `/experimental enable ci-failure-investigation` for architect-only read-only CI failure investigation after TLH opens a PR.
- Document the new experimental flag and cover default/experimental prompt behavior with tests.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
# Not run; no installer changes.
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `node --test tests/the-last-harness-experimental.test.mjs tests/the-last-harness-primary-agent-runtime.test.mjs tests/tlh-ticket-docs-static.test.mjs tests/agent-prompt-contracts.test.mjs` passed.
- `npm run validate` passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/tlh-ci-monitoring-guidance/install.sh | bash -s -- --ref tlh-ci-monitoring-guidance --track ref
```
