### PR TITLE
Add discovery tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "pi-package",
     "pi",
     "coding-agent",
-    "agent"
+    "agent",
+    "developer-tools",
+    "cli",
+    "terminal",
+    "typescript",
+    "llm",
+    "orchestration",
+    "tlh"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Add discovery-oriented package keywords for TLH metadata.
- GitHub repository topics were also updated directly to match the approved discovery set.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed.

Additional verification:

```sh
gh api repos/diegopetrucci/the-last-harness/topics --jq '.names'
```

Verified topics: `agent-orchestration`, `cli`, `coding-agent`, `developer-tools`, `llm`, `pi`, `pi-package`, `terminal`, `typescript`.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/metadata-discovery-tags/install.sh | bash -s -- --ref metadata-discovery-tags --track ref
```
