### PR TITLE
[codex] Update release and install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ Run the one-liner:
 curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/latest/download/install.sh | bash -s --
 ```
 
-On supported platforms (linux/darwin × x64/arm64), it installs [Gnosis](https://github.com/skorokithakis/gnosis) automatically. TLH currently pins the managed default to Gnosis `v0.5.3`; installer-owned `TLH_GNOSIS_VERSION` or helper `--gnosis-version` overrides can still point at another release (including `latest`) when needed. Installs on unsupported platforms hard-fail. TLH also requires `tk` ticket integration; if no valid configured/existing `tk` is found, TLH installs a managed copy at `~/.the-last-harness/agent/bin/tk`. If TLH cannot validate or install `tk`, install fails with an actionable error instead of creating an incomplete workflow. Once the installation is finished, start `tlh` by running… you guessed it, `tlh`.
+On supported platforms (linux/darwin × x64/arm64), it installs [Gnosis](https://github.com/skorokithakis/gnosis) automatically. TLH currently pins the managed default to Gnosis `v0.5.3`; installer-owned `TLH_GNOSIS_VERSION` and `TLH_GNOSIS_REPO` overrides can still point at another release or repository when needed. Installs on unsupported platforms hard-fail. TLH also requires `tk` ticket integration; if no valid configured/existing `tk` is found, TLH installs a managed copy at `~/.the-last-harness/agent/bin/tk`. If TLH cannot validate or install `tk`, install fails with an actionable error instead of creating an incomplete workflow. Once the installation is finished, start `tlh` by running… you guessed it, `tlh`.
 
 Note: if you already have `pi` installed, `tlh` does not replace it — you can keep both, as it uses its own isolated config in `~/.the-last-harness/` and never mutates normal `~/.pi/agent` settings.
 
@@ -21,7 +21,7 @@ The installer is split into a stage-0 Bash bootstrapper (`install.sh`) and a sta
 - Pinned to a release tag for future updates:
 
 ```sh
-curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.6.0/install.sh | bash -s -- --track pinned-tag
+curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.26.0/install.sh | bash -s -- --track pinned-tag
 ```
 - Any remote branch, eg `main`:
 
@@ -29,7 +29,7 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/main/install.sh | bash -s -- --ref main --track ref
 ```
 
-These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a header warning only for those installs. It appears above `Context:` and reads `Warning: running TLH from {name} track` (for example `Warning: running TLH from v0.6.0 track`, `Warning: running TLH from main track`, `Warning: running TLH from local track`, or `Warning: running TLH from unknown track`). Official latest-release installs skip that warning, though interactive starts may still show a quiet startup tip.
+These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a header warning only for those installs. It appears above `Context:` and reads `Warning: running TLH from {name} track` (for example `Warning: running TLH from v0.26.0 track`, `Warning: running TLH from main track`, `Warning: running TLH from local track`, or `Warning: running TLH from unknown track`). Official latest-release installs skip that warning, though interactive starts may still show a quiet startup tip.
 
 ## Installer options
 
@@ -50,7 +50,7 @@ These alternatives keep TLH isolated, but they are not the official latest stabl
 Example pinned-tag install:
 
 ```sh
-curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.6.0/install.sh | bash -s -- --track pinned-tag
+curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.26.0/install.sh | bash -s -- --track pinned-tag
 ```
 
 ## Update

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,7 +4,7 @@ TLH includes managed integrations for project memory and ticketed workflows. Gno
 
 ## Gnosis integration
 
-[Gnosis](https://github.com/skorokithakis/gnosis) is a small `gn` CLI for recording project decisions, constraints, rejected alternatives, and lessons that are not obvious from code alone. On supported platforms (linux/darwin × x64/arm64), TLH installs it automatically because `tlh` works better when agents can consult and update repo-local project memory. TLH currently pins the managed default to Gnosis `v0.5.3`, while installer-owned `TLH_GNOSIS_VERSION` and helper `--gnosis-version` overrides still let maintainers point at a different release or `latest` when needed. Installs and updates on unsupported platforms hard-fail.
+[Gnosis](https://github.com/skorokithakis/gnosis) is a small `gn` CLI for recording project decisions, constraints, rejected alternatives, and lessons that are not obvious from code alone. On supported platforms (linux/darwin × x64/arm64), TLH installs it automatically because `tlh` works better when agents can consult and update repo-local project memory. TLH currently pins the managed default to Gnosis `v0.5.3`, while installer-owned `TLH_GNOSIS_VERSION` and `TLH_GNOSIS_REPO` overrides still let maintainers point at a different release or repository when needed. Installs and updates on unsupported platforms hard-fail.
 
 When a valid Gnosis `gn` binary is present, TLH appends these instructions to the system prompt:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,7 +23,15 @@ npm version "$version" --no-git-tag-version
 git diff -- package.json
 ```
 
-Update `CHANGELOG.md` with a `## [$version] - YYYY-MM-DD` section, then run the aggregate validation script and release-notes check:
+Update `CHANGELOG.md` with a `## [$version] - YYYY-MM-DD` section.
+
+Before validation, update release-sensitive docs that include concrete versioned install guidance or runtime pins:
+
+- `docs/install.md`: pinned-tag install examples and the non-stable-track warning examples should use `v$version`.
+- `README.md` and `docs/install.md`: any pinned Pi runtime version, minimum Node.js version, managed Gnosis version, managed `tk` version, or bundled default-extension behavior should match the release metadata and installer constants.
+- `docs/releasing.md`: keep this checklist aligned when release validation adds or removes required documentation checks.
+
+Then run the aggregate validation script and release-notes check:
 
 ```sh
 npm install --no-package-lock --legacy-peer-deps

--- a/tests/check-startup-performance.test.mjs
+++ b/tests/check-startup-performance.test.mjs
@@ -177,7 +177,7 @@ test("check-startup-performance cleans up the active child process group and tem
 	const helperScriptPath = join(fixture.root, "term-trap-helper.sh");
 	writeExecutable(helperScriptPath, `#!/usr/bin/env bash
 set -euo pipefail
-trap 'printf "signal=%s\\n" "TERM" >"${helperSignalFile}"' TERM
+trap 'printf "signal=%s\\n" "TERM" >"${helperSignalFile}"; exit 0' TERM
 printf 'ready\n' >"${helperReadyFile}"
 while true; do
   sleep 0.05

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -68,6 +68,13 @@ function existingNestedExtensionEntrypoints(directoryName) {
 	);
 }
 
+function parseInlineJsonStringAssignment(source, assignmentName) {
+	const escapedAssignmentName = assignmentName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const assignment = source.match(new RegExp(`${escapedAssignmentName} = ("(?:\\\\.|[^"\\\\])*");`));
+	assert.ok(assignment, `${assignmentName} assignment must be present`);
+	return JSON.parse(assignment[1]);
+}
+
 test("package extension discovery exposes the TLH entrypoints", () => {
 	assert.deepEqual(packageJson.pi?.extensions, ["./extensions"]);
 	assert.deepEqual(existingNestedExtensionEntrypoints("the-last-harness"), []);
@@ -111,7 +118,9 @@ test("annotate-git-diff review HTML inlines Monaco assets without file:// URLs i
 	assert.match(html, /\.monaco-editor/, "editor.main.css content must be inlined");
 
 	// Monaco worker source is inlined as a non-empty bundled script.
-	assert.match(html, /window\.__reviewMonacoWorkerSource = "\(function\(\)\{/, "editor worker source must be inlined");
+	const workerSource = parseInlineJsonStringAssignment(html, "window.__reviewMonacoWorkerSource");
+	assert.ok(workerSource.length > 1000, "editor worker source must be inlined");
+	assert.match(workerSource, /monaco|worker|editor/i, "editor worker source must contain worker script content");
 
 	// No unreplaced template markers.
 	assert.doesNotMatch(html, /__INLINE_MONACO_EDITOR_JS__/);
@@ -119,10 +128,12 @@ test("annotate-git-diff review HTML inlines Monaco assets without file:// URLs i
 	assert.doesNotMatch(html, /__INLINE_MONACO_WORKER_SOURCE_JSON__/);
 	assert.doesNotMatch(html, /__INLINE_MONACO_BASIC_LANGUAGES_JS__/, "__INLINE_MONACO_BASIC_LANGUAGES_JS__ marker must be replaced");
 
-	// Monaco language bundles are inlined (representative sample).
-	assert.match(html, /define\("vs\/typescript-/, "TypeScript tokenizer bundle must be inlined");
-	assert.match(html, /define\("vs\/python-/, "Python tokenizer bundle must be inlined");
-	assert.match(html, /define\("vs\/go-/, "Go tokenizer bundle must be inlined");
+	// Monaco language bundles are inlined (representative sample). Monaco's build can
+	// change chunk names, so assert on stable contribution and language-registration content.
+	assert.match(html, /define\("vs\/basic-languages\/monaco\.contribution"/, "basic-language contribution must be inlined");
+	assert.match(html, /languages\.typescript=/, "TypeScript language contribution must be inlined");
+	assert.match(html, /id:"python"/, "Python tokenizer registration must be inlined");
+	assert.match(html, /id:"go"/, "Go tokenizer registration must be inlined");
 
 	// The asset config must not expose monacoVsBaseUrl.
 	assert.doesNotMatch(html, /monacoVsBaseUrl/);


### PR DESCRIPTION
## Summary

- Update pinned-tag install examples from the old v0.6.0 release to v0.26.0.
- Clarify that Gnosis install overrides use installer-owned environment variables, not the internal helper flag.
- Add a release-prep checklist item so versioned install examples and runtime/version docs are refreshed before releases.
- Keep the annotate-git-diff static test aligned with current packaged Monaco asset output so validation checks the real inlining invariant.

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/codex/tlh-update-docs-2026-06-26/install.sh | bash -s -- --ref codex/tlh-update-docs-2026-06-26 --track ref
```

## Validation

- `node --test tests/the-last-harness-extension-static.test.mjs`
- Markdown link sanity check across 95 markdown files
- `npm run validate`
