### PR TITLE
Migrate safe profile writer to TypeScript

### DIFF
--- a/scripts/lib/tlh-safe-profile-write.mjs
+++ b/scripts/lib/tlh-safe-profile-write.mjs
@@ -1,229 +1,212 @@
-import {
-	chmodSync,
-	existsSync,
-	lstatSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	renameSync,
-	rmdirSync,
-	unlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, renameSync, rmdirSync, unlinkSync, writeFileSync, } from "node:fs";
 import { basename, dirname, join } from "node:path";
-
-import {
-	assertProfilePathWithinAgent,
-	ensureSafeProfileDir,
-	realpathForCompare,
-	validateProfileRelativePath,
-	isSymlink,
-} from "./tlh-install-paths.mjs";
-
+import { assertProfilePathWithinAgent, ensureSafeProfileDir, realpathForCompare, validateProfileRelativePath, isSymlink, } from "./tlh-install-paths.mjs";
+function isErrnoException(error) {
+    return typeof error === "object" && error !== null && "code" in error;
+}
 function ensureSafeProfileRoot(config, label, options) {
-	if (isSymlink(config.agentDir)) {
-		throw new Error(`refusing to write ${label} through symlinked TLH profile path: ${config.agentDir}`);
-	}
-	const root = realpathForCompare(config.agentDir);
-	assertProfilePathWithinAgent(config, root, label, options);
-	if (existsSync(root) && !lstatSync(root).isDirectory()) {
-		throw new Error(`refusing to use non-directory TLH profile root for ${label}: ${config.agentDir}`);
-	}
-	if (!existsSync(root)) mkdirSync(root, { recursive: true });
-	return root;
+    if (isSymlink(config.agentDir)) {
+        throw new Error(`refusing to write ${label} through symlinked TLH profile path: ${config.agentDir}`);
+    }
+    const root = realpathForCompare(config.agentDir);
+    assertProfilePathWithinAgent(config, root, label, options);
+    if (existsSync(root) && !lstatSync(root).isDirectory()) {
+        throw new Error(`refusing to use non-directory TLH profile root for ${label}: ${config.agentDir}`);
+    }
+    if (!existsSync(root))
+        mkdirSync(root, { recursive: true });
+    return root;
 }
-
 function safeProfileWriteTarget(config, relativePath, label, options) {
-	validateProfileRelativePath(relativePath, label);
-	const base = basename(relativePath);
-	const parentRelative = dirname(relativePath);
-	const parent = parentRelative === "."
-		? ensureSafeProfileRoot(config, `${label} parent directory`, options)
-		: ensureSafeProfileDir(config, parentRelative, `${label} parent directory`, options);
-	const target = join(parent, base);
-	if (isSymlink(target)) {
-		throw new Error(`refusing to replace symlinked ${label}: ${target}`);
-	}
-	if (existsSync(target) && !lstatSync(target).isFile()) {
-		throw new Error(`refusing to replace non-file ${label}: ${target}`);
-	}
-	assertProfilePathWithinAgent(config, target, label, options);
-	return target;
+    validateProfileRelativePath(relativePath, label);
+    const base = basename(relativePath);
+    const parentRelative = dirname(relativePath);
+    const parent = parentRelative === "."
+        ? ensureSafeProfileRoot(config, `${label} parent directory`, options)
+        : ensureSafeProfileDir(config, parentRelative, `${label} parent directory`, options);
+    const target = join(parent, base);
+    if (isSymlink(target)) {
+        throw new Error(`refusing to replace symlinked ${label}: ${target}`);
+    }
+    if (existsSync(target) && !lstatSync(target).isFile()) {
+        throw new Error(`refusing to replace non-file ${label}: ${target}`);
+    }
+    assertProfilePathWithinAgent(config, target, label, options);
+    return target;
 }
-
 function writeOptionsFor(content, mode, encoding) {
-	const options = {};
-	if (mode !== undefined) options.mode = mode;
-	if (typeof content === "string") options.encoding = encoding || "utf8";
-	return options;
+    const options = {};
+    if (mode !== undefined)
+        options.mode = mode;
+    if (typeof content === "string")
+        options.encoding = encoding || "utf8";
+    return options;
 }
-
 function tempDirIdentity(tempDir, action = "clean up") {
-	let stats;
-	try {
-		stats = lstatSync(tempDir);
-	} catch (error) {
-		if (error?.code === "ENOENT") {
-			throw new Error(`refusing to ${action} missing temp directory: ${tempDir}`, { cause: error });
-		}
-		throw error;
-	}
-	if (!stats.isDirectory() || stats.isSymbolicLink()) {
-		throw new Error(`refusing to ${action} unexpected temp directory type: ${tempDir}`);
-	}
-	return { dev: stats.dev, ino: stats.ino };
+    let stats;
+    try {
+        stats = lstatSync(tempDir);
+    }
+    catch (error) {
+        if (isErrnoException(error) && error.code === "ENOENT") {
+            throw new Error(`refusing to ${action} missing temp directory: ${tempDir}`, { cause: error });
+        }
+        throw error;
+    }
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        throw new Error(`refusing to ${action} unexpected temp directory type: ${tempDir}`);
+    }
+    return { dev: stats.dev, ino: stats.ino };
 }
-
 function tempFileIdentity(tempTarget, action = "commit") {
-	let stats;
-	try {
-		stats = lstatSync(tempTarget);
-	} catch (error) {
-		if (error?.code === "ENOENT") {
-			throw new Error(`refusing to ${action} missing temp file: ${tempTarget}`, { cause: error });
-		}
-		throw error;
-	}
-	if (!stats.isFile() || stats.isSymbolicLink()) {
-		throw new Error(`refusing to ${action} unexpected temp file type: ${tempTarget}`);
-	}
-	return { dev: stats.dev, ino: stats.ino };
+    let stats;
+    try {
+        stats = lstatSync(tempTarget);
+    }
+    catch (error) {
+        if (isErrnoException(error) && error.code === "ENOENT") {
+            throw new Error(`refusing to ${action} missing temp file: ${tempTarget}`, { cause: error });
+        }
+        throw error;
+    }
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+        throw new Error(`refusing to ${action} unexpected temp file type: ${tempTarget}`);
+    }
+    return { dev: stats.dev, ino: stats.ino };
 }
-
 function assertTempArtifactIdentity(path, expectedIdentity, actualIdentity, label, action = "commit") {
-	if (actualIdentity.dev !== expectedIdentity.dev || actualIdentity.ino !== expectedIdentity.ino) {
-		throw new Error(`refusing to ${action} replaced ${label}: ${path}`);
-	}
+    if (actualIdentity.dev !== expectedIdentity.dev || actualIdentity.ino !== expectedIdentity.ino) {
+        throw new Error(`refusing to ${action} replaced ${label}: ${path}`);
+    }
 }
-
 function sameIdentity(actualIdentity, expectedIdentity) {
-	return actualIdentity.dev === expectedIdentity.dev && actualIdentity.ino === expectedIdentity.ino;
+    return actualIdentity.dev === expectedIdentity.dev && actualIdentity.ino === expectedIdentity.ino;
 }
-
 function captureCleanupAncestry(profileRoot, parentRelative) {
-	const ancestry = [];
-	let cursor = profileRoot;
-	ancestry.push({
-		path: cursor,
-		identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
-		realpath: realpathForCompare(cursor),
-	});
-	if (parentRelative === ".") return ancestry;
-	for (const component of parentRelative.split("/")) {
-		cursor = join(cursor, component);
-		ancestry.push({
-			path: cursor,
-			identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
-			realpath: realpathForCompare(cursor),
-		});
-	}
-	return ancestry;
+    const ancestry = [];
+    let cursor = profileRoot;
+    ancestry.push({
+        path: cursor,
+        identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
+        realpath: realpathForCompare(cursor),
+    });
+    if (parentRelative === ".")
+        return ancestry;
+    for (const component of parentRelative.split("/")) {
+        cursor = join(cursor, component);
+        ancestry.push({
+            path: cursor,
+            identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
+            realpath: realpathForCompare(cursor),
+        });
+    }
+    return ancestry;
 }
-
 function cleanupAncestryUnchanged(ancestry) {
-	for (const entry of ancestry) {
-		let stats;
-		try {
-			stats = lstatSync(entry.path);
-		} catch {
-			return false;
-		}
-		if (!stats.isDirectory() || stats.isSymbolicLink()) return false;
-		if (!sameIdentity(stats, entry.identity)) return false;
-		let currentRealpath;
-		try {
-			currentRealpath = realpathForCompare(entry.path);
-		} catch {
-			return false;
-		}
-		if (currentRealpath !== entry.realpath) return false;
-	}
-	return true;
+    for (const entry of ancestry) {
+        let stats;
+        try {
+            stats = lstatSync(entry.path);
+        }
+        catch {
+            return false;
+        }
+        if (!stats.isDirectory() || stats.isSymbolicLink())
+            return false;
+        if (!sameIdentity(stats, entry.identity))
+            return false;
+        let currentRealpath;
+        try {
+            currentRealpath = realpathForCompare(entry.path);
+        }
+        catch {
+            return false;
+        }
+        if (currentRealpath !== entry.realpath)
+            return false;
+    }
+    return true;
 }
-
 function cleanupTempDir(tempDir, expectedTempDirIdentity, tempTarget, expectedTempTargetIdentity, committed, cleanupAncestry) {
-	if (!cleanupAncestryUnchanged(cleanupAncestry)) return;
-
-	let tempDirStats;
-	try {
-		tempDirStats = lstatSync(tempDir);
-	} catch {
-		return;
-	}
-	if (!tempDirStats.isDirectory() || tempDirStats.isSymbolicLink()) return;
-	if (!sameIdentity(tempDirStats, expectedTempDirIdentity)) return;
-
-	if (!committed && expectedTempTargetIdentity) {
-		let tempTargetStats;
-		try {
-			tempTargetStats = lstatSync(tempTarget);
-		} catch {
-			return;
-		}
-		if (!tempTargetStats.isFile() || tempTargetStats.isSymbolicLink()) return;
-		if (!sameIdentity(tempTargetStats, expectedTempTargetIdentity)) return;
-		try {
-			unlinkSync(tempTarget);
-		} catch {
-			return;
-		}
-	}
-
-	let entries;
-	try {
-		entries = readdirSync(tempDir);
-	} catch {
-		return;
-	}
-	if (entries.length !== 0) return;
-	try {
-		rmdirSync(tempDir);
-	} catch {
-		// Best-effort cleanup only; leave the temp directory behind if anything changed.
-	}
+    if (!cleanupAncestryUnchanged(cleanupAncestry))
+        return;
+    let tempDirStats;
+    try {
+        tempDirStats = lstatSync(tempDir);
+    }
+    catch {
+        return;
+    }
+    if (!tempDirStats.isDirectory() || tempDirStats.isSymbolicLink())
+        return;
+    if (!sameIdentity(tempDirStats, expectedTempDirIdentity))
+        return;
+    if (!committed && expectedTempTargetIdentity) {
+        let tempTargetStats;
+        try {
+            tempTargetStats = lstatSync(tempTarget);
+        }
+        catch {
+            return;
+        }
+        if (!tempTargetStats.isFile() || tempTargetStats.isSymbolicLink())
+            return;
+        if (!sameIdentity(tempTargetStats, expectedTempTargetIdentity))
+            return;
+        try {
+            unlinkSync(tempTarget);
+        }
+        catch {
+            return;
+        }
+    }
+    let entries;
+    try {
+        entries = readdirSync(tempDir);
+    }
+    catch {
+        return;
+    }
+    if (entries.length !== 0)
+        return;
+    try {
+        rmdirSync(tempDir);
+    }
+    catch {
+        // Best-effort cleanup only; leave the temp directory behind if anything changed.
+    }
 }
-
 export function writeSafeProfileFile(config, relativePath, content, label = "TLH profile file", options = {}) {
-	const target = safeProfileWriteTarget(config, relativePath, label, options);
-	const resolvedMode = options.mode ?? (existsSync(target) ? (lstatSync(target).mode & 0o777) : undefined);
-	const parent = dirname(target);
-	const parentRelative = dirname(relativePath);
-	const cleanupAncestry = captureCleanupAncestry(realpathForCompare(config.agentDir), parentRelative);
-	const base = basename(target);
-	const tempDir = mkdtempSync(join(parent, `.${base}.tmp.`));
-	const expectedTempDirIdentity = tempDirIdentity(tempDir);
-	const tempTarget = join(tempDir, base);
-	let expectedTempTargetIdentity;
-	let committed = false;
-
-	try {
-		writeFileSync(tempTarget, content, writeOptionsFor(content, resolvedMode, options.encoding));
-		if (resolvedMode !== undefined) chmodSync(tempTarget, resolvedMode);
-		expectedTempTargetIdentity = tempFileIdentity(tempTarget);
-		if (typeof options.beforeCommit === "function") {
-			options.beforeCommit({ parent, target, tempDir, tempTarget });
-		}
-		const verifiedTarget = safeProfileWriteTarget(config, relativePath, label, options);
-		if (verifiedTarget !== target) {
-			throw new Error(`refusing to replace moved ${label}: ${target}`);
-		}
-		assertTempArtifactIdentity(
-			tempDir,
-			expectedTempDirIdentity,
-			tempDirIdentity(tempDir, "commit"),
-			"temp directory",
-		);
-		assertTempArtifactIdentity(
-			tempTarget,
-			expectedTempTargetIdentity,
-			tempFileIdentity(tempTarget),
-			"temp file",
-		);
-		renameSync(tempTarget, target);
-		committed = true;
-	} finally {
-		cleanupTempDir(tempDir, expectedTempDirIdentity, tempTarget, expectedTempTargetIdentity, committed, cleanupAncestry);
-	}
-
-	return target;
+    const target = safeProfileWriteTarget(config, relativePath, label, options);
+    const resolvedMode = options.mode ?? (existsSync(target) ? (lstatSync(target).mode & 0o777) : undefined);
+    const parent = dirname(target);
+    const parentRelative = dirname(relativePath);
+    const cleanupAncestry = captureCleanupAncestry(realpathForCompare(config.agentDir), parentRelative);
+    const base = basename(target);
+    const tempDir = mkdtempSync(join(parent, `.${base}.tmp.`));
+    const expectedTempDirIdentity = tempDirIdentity(tempDir);
+    const tempTarget = join(tempDir, base);
+    let expectedTempTargetIdentity;
+    let committed = false;
+    try {
+        writeFileSync(tempTarget, content, writeOptionsFor(content, resolvedMode, options.encoding));
+        if (resolvedMode !== undefined)
+            chmodSync(tempTarget, resolvedMode);
+        expectedTempTargetIdentity = tempFileIdentity(tempTarget);
+        if (typeof options.beforeCommit === "function") {
+            options.beforeCommit({ parent, target, tempDir, tempTarget });
+        }
+        const verifiedTarget = safeProfileWriteTarget(config, relativePath, label, options);
+        if (verifiedTarget !== target) {
+            throw new Error(`refusing to replace moved ${label}: ${target}`);
+        }
+        assertTempArtifactIdentity(tempDir, expectedTempDirIdentity, tempDirIdentity(tempDir, "commit"), "temp directory");
+        assertTempArtifactIdentity(tempTarget, expectedTempTargetIdentity, tempFileIdentity(tempTarget), "temp file");
+        renameSync(tempTarget, target);
+        committed = true;
+    }
+    finally {
+        cleanupTempDir(tempDir, expectedTempDirIdentity, tempTarget, expectedTempTargetIdentity, committed, cleanupAncestry);
+    }
+    return target;
 }

--- a/scripts/lib/tlh-safe-profile-write.mts
+++ b/scripts/lib/tlh-safe-profile-write.mts
@@ -1,0 +1,292 @@
+import {
+	chmodSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	renameSync,
+	rmdirSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+import type { InstallerPathConfig, InstallerPathOptions } from "./tlh-install-paths.mjs";
+import {
+	assertProfilePathWithinAgent,
+	ensureSafeProfileDir,
+	realpathForCompare,
+	validateProfileRelativePath,
+	isSymlink,
+} from "./tlh-install-paths.mjs";
+
+type ProfileWriteContent = string | NodeJS.ArrayBufferView;
+
+interface TempArtifactIdentity {
+	dev: number;
+	ino: number;
+}
+
+interface CleanupAncestryEntry {
+	path: string;
+	identity: TempArtifactIdentity;
+	realpath: string;
+}
+
+interface BeforeCommitContext {
+	parent: string;
+	target: string;
+	tempDir: string;
+	tempTarget: string;
+}
+
+export interface SafeProfileWriteOptions extends InstallerPathOptions {
+	mode?: number;
+	encoding?: BufferEncoding;
+	beforeCommit?: (context: BeforeCommitContext) => void;
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+	return typeof error === "object" && error !== null && "code" in error;
+}
+
+function ensureSafeProfileRoot(
+	config: InstallerPathConfig,
+	label: string,
+	options: InstallerPathOptions,
+): string {
+	if (isSymlink(config.agentDir)) {
+		throw new Error(`refusing to write ${label} through symlinked TLH profile path: ${config.agentDir}`);
+	}
+	const root = realpathForCompare(config.agentDir);
+	assertProfilePathWithinAgent(config, root, label, options);
+	if (existsSync(root) && !lstatSync(root).isDirectory()) {
+		throw new Error(`refusing to use non-directory TLH profile root for ${label}: ${config.agentDir}`);
+	}
+	if (!existsSync(root)) mkdirSync(root, { recursive: true });
+	return root;
+}
+
+function safeProfileWriteTarget(
+	config: InstallerPathConfig,
+	relativePath: string,
+	label: string,
+	options: InstallerPathOptions,
+): string {
+	validateProfileRelativePath(relativePath, label);
+	const base = basename(relativePath);
+	const parentRelative = dirname(relativePath);
+	const parent = parentRelative === "."
+		? ensureSafeProfileRoot(config, `${label} parent directory`, options)
+		: ensureSafeProfileDir(config, parentRelative, `${label} parent directory`, options);
+	const target = join(parent, base);
+	if (isSymlink(target)) {
+		throw new Error(`refusing to replace symlinked ${label}: ${target}`);
+	}
+	if (existsSync(target) && !lstatSync(target).isFile()) {
+		throw new Error(`refusing to replace non-file ${label}: ${target}`);
+	}
+	assertProfilePathWithinAgent(config, target, label, options);
+	return target;
+}
+
+function writeOptionsFor(
+	content: ProfileWriteContent,
+	mode: number | undefined,
+	encoding: BufferEncoding | undefined,
+): { mode?: number; encoding?: BufferEncoding } {
+	const options: { mode?: number; encoding?: BufferEncoding } = {};
+	if (mode !== undefined) options.mode = mode;
+	if (typeof content === "string") options.encoding = encoding || "utf8";
+	return options;
+}
+
+function tempDirIdentity(tempDir: string, action = "clean up"): TempArtifactIdentity {
+	let stats;
+	try {
+		stats = lstatSync(tempDir);
+	} catch (error) {
+		if (isErrnoException(error) && error.code === "ENOENT") {
+			throw new Error(`refusing to ${action} missing temp directory: ${tempDir}`, { cause: error });
+		}
+		throw error;
+	}
+	if (!stats.isDirectory() || stats.isSymbolicLink()) {
+		throw new Error(`refusing to ${action} unexpected temp directory type: ${tempDir}`);
+	}
+	return { dev: stats.dev, ino: stats.ino };
+}
+
+function tempFileIdentity(tempTarget: string, action = "commit"): TempArtifactIdentity {
+	let stats;
+	try {
+		stats = lstatSync(tempTarget);
+	} catch (error) {
+		if (isErrnoException(error) && error.code === "ENOENT") {
+			throw new Error(`refusing to ${action} missing temp file: ${tempTarget}`, { cause: error });
+		}
+		throw error;
+	}
+	if (!stats.isFile() || stats.isSymbolicLink()) {
+		throw new Error(`refusing to ${action} unexpected temp file type: ${tempTarget}`);
+	}
+	return { dev: stats.dev, ino: stats.ino };
+}
+
+function assertTempArtifactIdentity(
+	path: string,
+	expectedIdentity: TempArtifactIdentity,
+	actualIdentity: TempArtifactIdentity,
+	label: string,
+	action = "commit",
+): void {
+	if (actualIdentity.dev !== expectedIdentity.dev || actualIdentity.ino !== expectedIdentity.ino) {
+		throw new Error(`refusing to ${action} replaced ${label}: ${path}`);
+	}
+}
+
+function sameIdentity(actualIdentity: TempArtifactIdentity, expectedIdentity: TempArtifactIdentity): boolean {
+	return actualIdentity.dev === expectedIdentity.dev && actualIdentity.ino === expectedIdentity.ino;
+}
+
+function captureCleanupAncestry(profileRoot: string, parentRelative: string): CleanupAncestryEntry[] {
+	const ancestry: CleanupAncestryEntry[] = [];
+	let cursor = profileRoot;
+	ancestry.push({
+		path: cursor,
+		identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
+		realpath: realpathForCompare(cursor),
+	});
+	if (parentRelative === ".") return ancestry;
+	for (const component of parentRelative.split("/")) {
+		cursor = join(cursor, component);
+		ancestry.push({
+			path: cursor,
+			identity: tempDirIdentity(cursor, "verify cleanup ancestry for"),
+			realpath: realpathForCompare(cursor),
+		});
+	}
+	return ancestry;
+}
+
+function cleanupAncestryUnchanged(ancestry: readonly CleanupAncestryEntry[]): boolean {
+	for (const entry of ancestry) {
+		let stats;
+		try {
+			stats = lstatSync(entry.path);
+		} catch {
+			return false;
+		}
+		if (!stats.isDirectory() || stats.isSymbolicLink()) return false;
+		if (!sameIdentity(stats, entry.identity)) return false;
+		let currentRealpath;
+		try {
+			currentRealpath = realpathForCompare(entry.path);
+		} catch {
+			return false;
+		}
+		if (currentRealpath !== entry.realpath) return false;
+	}
+	return true;
+}
+
+function cleanupTempDir(
+	tempDir: string,
+	expectedTempDirIdentity: TempArtifactIdentity,
+	tempTarget: string,
+	expectedTempTargetIdentity: TempArtifactIdentity | undefined,
+	committed: boolean,
+	cleanupAncestry: readonly CleanupAncestryEntry[],
+): void {
+	if (!cleanupAncestryUnchanged(cleanupAncestry)) return;
+
+	let tempDirStats;
+	try {
+		tempDirStats = lstatSync(tempDir);
+	} catch {
+		return;
+	}
+	if (!tempDirStats.isDirectory() || tempDirStats.isSymbolicLink()) return;
+	if (!sameIdentity(tempDirStats, expectedTempDirIdentity)) return;
+
+	if (!committed && expectedTempTargetIdentity) {
+		let tempTargetStats;
+		try {
+			tempTargetStats = lstatSync(tempTarget);
+		} catch {
+			return;
+		}
+		if (!tempTargetStats.isFile() || tempTargetStats.isSymbolicLink()) return;
+		if (!sameIdentity(tempTargetStats, expectedTempTargetIdentity)) return;
+		try {
+			unlinkSync(tempTarget);
+		} catch {
+			return;
+		}
+	}
+
+	let entries;
+	try {
+		entries = readdirSync(tempDir);
+	} catch {
+		return;
+	}
+	if (entries.length !== 0) return;
+	try {
+		rmdirSync(tempDir);
+	} catch {
+		// Best-effort cleanup only; leave the temp directory behind if anything changed.
+	}
+}
+
+export function writeSafeProfileFile(
+	config: InstallerPathConfig,
+	relativePath: string,
+	content: ProfileWriteContent,
+	label = "TLH profile file",
+	options: SafeProfileWriteOptions = {},
+): string {
+	const target = safeProfileWriteTarget(config, relativePath, label, options);
+	const resolvedMode = options.mode ?? (existsSync(target) ? (lstatSync(target).mode & 0o777) : undefined);
+	const parent = dirname(target);
+	const parentRelative = dirname(relativePath);
+	const cleanupAncestry = captureCleanupAncestry(realpathForCompare(config.agentDir), parentRelative);
+	const base = basename(target);
+	const tempDir = mkdtempSync(join(parent, `.${base}.tmp.`));
+	const expectedTempDirIdentity = tempDirIdentity(tempDir);
+	const tempTarget = join(tempDir, base);
+	let expectedTempTargetIdentity: TempArtifactIdentity | undefined;
+	let committed = false;
+
+	try {
+		writeFileSync(tempTarget, content, writeOptionsFor(content, resolvedMode, options.encoding));
+		if (resolvedMode !== undefined) chmodSync(tempTarget, resolvedMode);
+		expectedTempTargetIdentity = tempFileIdentity(tempTarget);
+		if (typeof options.beforeCommit === "function") {
+			options.beforeCommit({ parent, target, tempDir, tempTarget });
+		}
+		const verifiedTarget = safeProfileWriteTarget(config, relativePath, label, options);
+		if (verifiedTarget !== target) {
+			throw new Error(`refusing to replace moved ${label}: ${target}`);
+		}
+		assertTempArtifactIdentity(
+			tempDir,
+			expectedTempDirIdentity,
+			tempDirIdentity(tempDir, "commit"),
+			"temp directory",
+		);
+		assertTempArtifactIdentity(
+			tempTarget,
+			expectedTempTargetIdentity,
+			tempFileIdentity(tempTarget),
+			"temp file",
+		);
+		renameSync(tempTarget, target);
+		committed = true;
+	} finally {
+		cleanupTempDir(tempDir, expectedTempDirIdentity, tempTarget, expectedTempTargetIdentity, committed, cleanupAncestry);
+	}
+
+	return target;
+}

--- a/tests/runtime-typescript-infra.test.mjs
+++ b/tests/runtime-typescript-infra.test.mjs
@@ -108,6 +108,7 @@ test("runtime TypeScript helper covers converted installer libraries", () => {
 		"scripts/lib/tlh-install-support-files",
 		"scripts/lib/tlh-install-support-manifest",
 		"scripts/lib/tlh-install-utils",
+		"scripts/lib/tlh-safe-profile-write",
 	];
 
 	for (const path of convertedLibraries) {


### PR DESCRIPTION
## Summary
- add `scripts/lib/tlh-safe-profile-write.mts` as the runtime TypeScript source
- regenerate the committed `.mjs` output
- include the helper in runtime TypeScript infra coverage

## Validation
- `npm run validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer, atomic profile file updates to reduce the risk of partial or corrupted writes.

* **Bug Fixes**
  * Improved handling when temporary files or folders are missing, with clearer failure messages and more reliable cleanup.
  * Strengthened safeguards to avoid writing outside the expected application directory.

* **Tests**
  * Expanded runtime coverage to include the new profile-writing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->