### PR TITLE
Migrate merge config CLIs to TypeScript

### DIFF
--- a/.tickets/tlha-0eo8.md
+++ b/.tickets/tlha-0eo8.md
@@ -1,0 +1,20 @@
+---
+id: tlha-0eo8
+status: closed
+deps: []
+links: []
+created: 2026-06-27T08:23:20Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlha-xn6b
+tags: [typescript, migration, installer]
+---
+# Migrate merge-keybindings CLI to runtime TypeScript
+
+Convert scripts/merge-keybindings.mjs to the runtime TypeScript source/emit pattern by adding scripts/merge-keybindings.mts as source of truth and regenerating the committed .mjs output. Keep isolated-profile keybinding merge behavior unchanged.
+
+## Acceptance Criteria
+
+scripts/merge-keybindings.mts exists and emits fresh scripts/merge-keybindings.mjs; runtime TypeScript infra tracks this top-level CLI; support manifests/install.sh continue referencing the generated .mjs path; focused validation passes: npm run typecheck:runtime, npm run check:runtime, node --test tests/keybindings-merge.test.mjs tests/runtime-typescript-infra.test.mjs, and relevant installer smoke/static checks.
+

--- a/.tickets/tlha-31ut.md
+++ b/.tickets/tlha-31ut.md
@@ -1,0 +1,20 @@
+---
+id: tlha-31ut
+status: open
+deps: [tlha-3f7f]
+links: []
+created: 2026-06-27T08:23:20Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlha-xn6b
+tags: [typescript, migration, installer, update]
+---
+# Migrate tlh-update CLI to runtime TypeScript
+
+Convert scripts/tlh-update.mjs to the runtime TypeScript source/emit pattern by adding scripts/tlh-update.mts as source of truth and regenerating the committed .mjs output. Preserve update-track, extension-only update, private runtime, and installer handoff behavior.
+
+## Acceptance Criteria
+
+scripts/tlh-update.mts exists and emits fresh scripts/tlh-update.mjs; runtime TypeScript infra tracks this top-level CLI; support manifests/install.sh continue referencing the generated .mjs path; focused validation passes: npm run typecheck:runtime, npm run check:runtime, update-focused tests in tests/install-stage1.test.mjs, tests/runtime-typescript-infra.test.mjs, and relevant installer smoke/static checks.
+

--- a/.tickets/tlha-3euk.md
+++ b/.tickets/tlha-3euk.md
@@ -1,0 +1,20 @@
+---
+id: tlha-3euk
+status: open
+deps: [tlha-31ut]
+links: []
+created: 2026-06-27T08:23:20Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlha-xn6b
+tags: [typescript, migration, installer]
+---
+# Migrate tlh-install CLI to runtime TypeScript
+
+Convert scripts/tlh-install.mjs to the runtime TypeScript source/emit pattern by adding scripts/tlh-install.mts as source of truth and regenerating the committed .mjs output. This is the final high-risk top-level CLI migration and must preserve stage-1 installer behavior and exported test helpers.
+
+## Acceptance Criteria
+
+scripts/tlh-install.mts exists and emits fresh scripts/tlh-install.mjs; runtime TypeScript infra tracks this top-level CLI; install.sh and support manifests remain aligned with the generated .mjs path; exported helpers used by tests remain available; focused validation passes: npm run typecheck:runtime, npm run check:runtime, node --test tests/install-stage1.test.mjs tests/install-libs.test.mjs tests/runtime-typescript-infra.test.mjs, bash scripts/check-installer-smoke.sh, and npm run validate before PR.
+

--- a/.tickets/tlha-3f7f.md
+++ b/.tickets/tlha-3f7f.md
@@ -1,0 +1,20 @@
+---
+id: tlha-3f7f
+status: open
+deps: [tlha-g7gi]
+links: []
+created: 2026-06-27T08:23:20Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlha-xn6b
+tags: [typescript, migration, installer, wrapper]
+---
+# Migrate tlh-wrapper CLI to runtime TypeScript
+
+Convert scripts/tlh-wrapper.mjs to the runtime TypeScript source/emit pattern by adding scripts/tlh-wrapper.mts as source of truth and regenerating the committed .mjs output. Preserve wrapper rendering, managed-wrapper detection, and helper subcommand routing.
+
+## Acceptance Criteria
+
+scripts/tlh-wrapper.mts exists and emits fresh scripts/tlh-wrapper.mjs; runtime TypeScript infra tracks this top-level CLI; support manifests/install.sh continue referencing the generated .mjs path; focused validation passes: npm run typecheck:runtime, npm run check:runtime, node --test tests/install-stage1.test.mjs tests/check-startup-performance.test.mjs tests/runtime-typescript-infra.test.mjs, plus wrapper-related smoke/static checks.
+

--- a/.tickets/tlha-akfh.md
+++ b/.tickets/tlha-akfh.md
@@ -1,0 +1,19 @@
+---
+id: tlha-akfh
+status: open
+deps: []
+links: []
+created: 2026-06-27T07:37:14Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+tags: [typescript, migration, extensions]
+---
+# Plan migration of remaining extension-side MJS helpers to TypeScript
+
+Future work: migrate remaining extension-side .mjs helpers where compatible with TLH extension loading, especially extensions/the-last-harness/footer-git.mjs and extensions/the-last-harness/subscription-usage.mjs; assess primary-agent/tool/safety shims separately before converting.
+
+## Acceptance Criteria
+
+A safe migration path is documented or implemented for the listed extension helpers; extension import/loading behavior is preserved; typecheck/lint and relevant extension tests pass; browser web/app.js files are intentionally out of scope unless a browser build story is added.
+

--- a/.tickets/tlha-g7gi.md
+++ b/.tickets/tlha-g7gi.md
@@ -1,0 +1,20 @@
+---
+id: tlha-g7gi
+status: closed
+deps: [tlha-0eo8]
+links: []
+created: 2026-06-27T08:23:20Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+parent: tlha-xn6b
+tags: [typescript, migration, installer]
+---
+# Migrate merge-settings CLI to runtime TypeScript
+
+Convert scripts/merge-settings.mjs to the runtime TypeScript source/emit pattern by adding scripts/merge-settings.mts as source of truth and regenerating the committed .mjs output. Preserve conservative isolated settings merge behavior.
+
+## Acceptance Criteria
+
+scripts/merge-settings.mts exists and emits fresh scripts/merge-settings.mjs; runtime TypeScript infra tracks this top-level CLI; support manifests/install.sh continue referencing the generated .mjs path; focused validation passes: npm run typecheck:runtime, npm run check:runtime, node --test tests/merge-settings.test.mjs tests/default-extensions.test.mjs tests/runtime-typescript-infra.test.mjs, and relevant installer smoke/static checks.
+

--- a/.tickets/tlha-xn6b.md
+++ b/.tickets/tlha-xn6b.md
@@ -1,0 +1,19 @@
+---
+id: tlha-xn6b
+status: open
+deps: [tlha-fcjg]
+links: []
+created: 2026-06-27T07:37:14Z
+type: task
+priority: 2
+assignee: Diego Petrucci
+tags: [typescript, migration, installer]
+---
+# Plan migration of top-level installer CLIs to TypeScript
+
+Future work: migrate top-level installer/runtime CLIs to the runtime TypeScript pattern where appropriate, including scripts/tlh-install.mjs, scripts/tlh-update.mjs, scripts/tlh-wrapper.mjs, scripts/merge-settings.mjs, and scripts/merge-keybindings.mjs.
+
+## Acceptance Criteria
+
+Migration plan or implementation covers the listed CLIs; generated .mjs outputs remain committed and fresh where .mts sources are introduced; install.sh and support-file manifests stay aligned; focused smoke tests for installer/update/settings paths pass.
+

--- a/scripts/merge-keybindings.mjs
+++ b/scripts/merge-keybindings.mjs
@@ -3,23 +3,12 @@ import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
-
-import {
-	assertNotInNormalPiConfig,
-	assignOptionValue,
-	backupPathWithTimestamp,
-	defaultTlhKeybindingsPath,
-	expandHomePath,
-	readJsonFile,
-	readRegularFileForBackup,
-} from "./lib/tlh-install-utils.mjs";
+import { assertNotInNormalPiConfig, backupPathWithTimestamp, defaultTlhKeybindingsPath, expandHomePath, readJsonFile, readOptionValue, readRegularFileForBackup, } from "./lib/tlh-install-utils.mjs";
 import { writeSafeProfileFile } from "./lib/tlh-safe-profile-write.mjs";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
 function usage() {
-	return `Usage: node scripts/merge-keybindings.mjs [defaults.json] [options]
+    return `Usage: node scripts/merge-keybindings.mjs [defaults.json] [options]
 
 Merge TLH default keybindings into the isolated TLH profile without clobbering user values.
 
@@ -31,173 +20,150 @@ Options:
   -h, --help              Show this help
 `;
 }
-
 function parseArgs(argv) {
-	const args = {
-		defaultsPath: undefined,
-		keybindingsPath: undefined,
-		dryRun: false,
-		quiet: false,
-		help: false,
-	};
-
-	for (let index = 0; index < argv.length; index += 1) {
-		const arg = argv[index];
-		if (arg === "--dry-run") {
-			args.dryRun = true;
-			continue;
-		}
-		if (arg === "--quiet") {
-			args.quiet = true;
-			continue;
-		}
-		if (arg === "-h" || arg === "--help") {
-			args.help = true;
-			continue;
-		}
-		const keybindingsIndex = assignOptionValue(args, "keybindingsPath", argv, index, "--keybindings");
-		if (keybindingsIndex !== undefined) {
-			index = keybindingsIndex;
-			continue;
-		}
-		const defaultsIndex = assignOptionValue(args, "defaultsPath", argv, index, "--defaults");
-		if (defaultsIndex !== undefined) {
-			index = defaultsIndex;
-			continue;
-		}
-		if (arg.startsWith("-")) {
-			throw new Error(`Unknown option: ${arg}`);
-		}
-		if (args.defaultsPath) {
-			throw new Error(`Unexpected extra argument: ${arg}`);
-		}
-		args.defaultsPath = arg;
-	}
-
-	return args;
+    const args = {
+        defaultsPath: undefined,
+        keybindingsPath: undefined,
+        dryRun: false,
+        quiet: false,
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === "--dry-run") {
+            args.dryRun = true;
+            continue;
+        }
+        if (arg === "--quiet") {
+            args.quiet = true;
+            continue;
+        }
+        if (arg === "-h" || arg === "--help") {
+            args.help = true;
+            continue;
+        }
+        const keybindingsMatch = readOptionValue(argv, index, "--keybindings");
+        if (keybindingsMatch) {
+            args.keybindingsPath = keybindingsMatch.value;
+            index = keybindingsMatch.nextIndex;
+            continue;
+        }
+        const defaultsMatch = readOptionValue(argv, index, "--defaults");
+        if (defaultsMatch) {
+            args.defaultsPath = defaultsMatch.value;
+            index = defaultsMatch.nextIndex;
+            continue;
+        }
+        if (arg.startsWith("-")) {
+            throw new Error(`Unknown option: ${arg}`);
+        }
+        if (args.defaultsPath) {
+            throw new Error(`Unexpected extra argument: ${arg}`);
+        }
+        args.defaultsPath = arg;
+    }
+    return args;
 }
-
 function defaultDefaultsPath() {
-	return join(resolve(__dirname, ".."), "config", "keybindings.defaults.json");
+    return join(resolve(__dirname, ".."), "config", "keybindings.defaults.json");
 }
-
 function isPlainObject(value) {
-	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
-
 function clone(value) {
-	return JSON.parse(JSON.stringify(value));
+    return JSON.parse(JSON.stringify(value));
 }
-
 const legacyKeybindingOwners = new Map([["app.thinking.cycle", ["cycleThinkingLevel"]]]);
-
 function hasExistingKeybindingOwner(keybindings, key) {
-	if (Object.hasOwn(keybindings, key)) return true;
-	return legacyKeybindingOwners.get(key)?.some((legacyKey) => Object.hasOwn(keybindings, legacyKey)) ?? false;
+    if (Object.hasOwn(keybindings, key))
+        return true;
+    return legacyKeybindingOwners.get(key)?.some((legacyKey) => Object.hasOwn(keybindings, legacyKey)) ?? false;
 }
-
 function mergeKeybindings(existing, defaults) {
-	if (!isPlainObject(existing)) {
-		throw new Error("Existing keybindings must be a JSON object");
-	}
-	if (!isPlainObject(defaults)) {
-		throw new Error("Default keybindings must be a JSON object");
-	}
-
-	const next = clone(existing);
-	const changes = [];
-	for (const [key, value] of Object.entries(defaults)) {
-		if (hasExistingKeybindingOwner(next, key)) continue;
-		next[key] = clone(value);
-		changes.push(`set ${key}`);
-	}
-
-	return { next, changes };
+    if (!isPlainObject(existing)) {
+        throw new Error("Existing keybindings must be a JSON object");
+    }
+    if (!isPlainObject(defaults)) {
+        throw new Error("Default keybindings must be a JSON object");
+    }
+    const next = clone(existing);
+    const changes = [];
+    for (const [key, value] of Object.entries(defaults)) {
+        if (hasExistingKeybindingOwner(next, key))
+            continue;
+        next[key] = clone(value);
+        changes.push(`set ${key}`);
+    }
+    return { next, changes };
 }
-
 function backupPathFor(keybindingsPath) {
-	return backupPathWithTimestamp(keybindingsPath);
+    return backupPathWithTimestamp(keybindingsPath);
 }
-
 function assertKeybindingsTarget(keybindingsPath) {
-	if (basename(resolve(keybindingsPath)) !== "keybindings.json") {
-		throw new Error(`Refusing to modify non-keybindings file: ${keybindingsPath}`);
-	}
-
-	assertNotInNormalPiConfig(
-		keybindingsPath,
-		`Refusing to modify normal Pi config from The Last Harness installer: ${keybindingsPath}`,
-	);
+    if (basename(resolve(keybindingsPath)) !== "keybindings.json") {
+        throw new Error(`Refusing to modify non-keybindings file: ${keybindingsPath}`);
+    }
+    assertNotInNormalPiConfig(keybindingsPath, `Refusing to modify normal Pi config from The Last Harness installer: ${keybindingsPath}`);
 }
-
 function writeExistingProfileBackup(keybindingsPath, backupPath) {
-	const { content, mode } = readRegularFileForBackup(keybindingsPath, "Pi keybindings");
-	writeSafeProfileFile(
-		{ agentDir: dirname(keybindingsPath) },
-		basename(backupPath),
-		content,
-		"Pi keybindings backup",
-		{ mode },
-	);
+    const { content, mode } = readRegularFileForBackup(keybindingsPath, "Pi keybindings");
+    writeSafeProfileFile({ agentDir: dirname(keybindingsPath) }, basename(backupPath), content, "Pi keybindings backup", { mode });
 }
-
 function writeKeybindings(keybindingsPath, value, { dryRun, existed }) {
-	const formatted = `${JSON.stringify(value, null, 2)}\n`;
-	if (dryRun) return undefined;
-
-	let backupPath;
-	if (existed) {
-		backupPath = backupPathFor(keybindingsPath);
-		writeExistingProfileBackup(keybindingsPath, backupPath);
-	}
-
-	writeSafeProfileFile({ agentDir: dirname(keybindingsPath) }, basename(keybindingsPath), formatted, "Pi keybindings");
-	return backupPath;
+    const formatted = `${JSON.stringify(value, null, 2)}\n`;
+    if (dryRun)
+        return undefined;
+    let backupPath;
+    if (existed) {
+        backupPath = backupPathFor(keybindingsPath);
+        writeExistingProfileBackup(keybindingsPath, backupPath);
+    }
+    writeSafeProfileFile({ agentDir: dirname(keybindingsPath) }, basename(keybindingsPath), formatted, "Pi keybindings");
+    return backupPath;
 }
-
 function log(args, message) {
-	if (!args.quiet) console.log(message);
+    if (!args.quiet)
+        console.log(message);
 }
-
 function main() {
-	const args = parseArgs(process.argv.slice(2));
-	if (args.help) {
-		console.log(usage());
-		return;
-	}
-
-	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()));
-	const keybindingsPath = resolve(expandHomePath(args.keybindingsPath || defaultTlhKeybindingsPath()));
-	assertKeybindingsTarget(keybindingsPath);
-	const existed = existsSync(keybindingsPath);
-	const existing = readJsonFile(keybindingsPath, { missingValue: {} });
-	const defaults = readJsonFile(defaultsPath);
-	const { next, changes } = mergeKeybindings(existing, defaults);
-
-	log(args, `Keybindings: ${keybindingsPath}`);
-	if (changes.length === 0) {
-		log(args, "No keybinding changes needed.");
-		return;
-	}
-
-	for (const change of changes) {
-		log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
-	}
-
-	if (args.dryRun) {
-		if (existed) log(args, "Would back up existing keybindings before writing.");
-		log(args, "Dry run only; no keybindings were changed.");
-		return;
-	}
-
-	const backupPath = writeKeybindings(keybindingsPath, next, { dryRun: args.dryRun, existed });
-	if (backupPath) log(args, `Backed up previous keybindings to: ${backupPath}`);
-	log(args, "Keybindings updated.");
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()) || defaultDefaultsPath());
+    const keybindingsPath = resolve(expandHomePath(args.keybindingsPath || defaultTlhKeybindingsPath()) || defaultTlhKeybindingsPath());
+    assertKeybindingsTarget(keybindingsPath);
+    const existed = existsSync(keybindingsPath);
+    const existing = readJsonFile(keybindingsPath, { missingValue: {} });
+    const defaults = readJsonFile(defaultsPath);
+    const { next, changes } = mergeKeybindings(existing, defaults);
+    log(args, `Keybindings: ${keybindingsPath}`);
+    if (changes.length === 0) {
+        log(args, "No keybinding changes needed.");
+        return;
+    }
+    for (const change of changes) {
+        log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
+    }
+    if (args.dryRun) {
+        if (existed)
+            log(args, "Would back up existing keybindings before writing.");
+        log(args, "Dry run only; no keybindings were changed.");
+        return;
+    }
+    const backupPath = writeKeybindings(keybindingsPath, next, { dryRun: args.dryRun, existed });
+    if (backupPath)
+        log(args, `Backed up previous keybindings to: ${backupPath}`);
+    log(args, "Keybindings updated.");
 }
-
+function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
+}
 try {
-	main();
-} catch (error) {
-	console.error(`merge-keybindings: ${error.message}`);
-	process.exit(1);
+    main();
+}
+catch (error) {
+    console.error(`merge-keybindings: ${errorMessage(error)}`);
+    process.exit(1);
 }

--- a/scripts/merge-keybindings.mts
+++ b/scripts/merge-keybindings.mts
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+import {
+	assertNotInNormalPiConfig,
+	backupPathWithTimestamp,
+	defaultTlhKeybindingsPath,
+	expandHomePath,
+	readJsonFile,
+	readOptionValue,
+	readRegularFileForBackup,
+} from "./lib/tlh-install-utils.mjs";
+import { writeSafeProfileFile } from "./lib/tlh-safe-profile-write.mjs";
+
+interface CliArgs {
+	defaultsPath?: string;
+	keybindingsPath?: string;
+	dryRun: boolean;
+	quiet: boolean;
+	help: boolean;
+}
+
+type KeybindingMap = Record<string, unknown>;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function usage(): string {
+	return `Usage: node scripts/merge-keybindings.mjs [defaults.json] [options]
+
+Merge TLH default keybindings into the isolated TLH profile without clobbering user values.
+
+Options:
+  --keybindings <path>    Keybindings file to update (default: ~/.the-last-harness/agent/keybindings.json, or PI_CODING_AGENT_DIR/keybindings.json)
+  --defaults <path>       Default keybindings file (default: config/keybindings.defaults.json next to this script)
+  --dry-run               Print intended changes without writing
+  --quiet                 Only print errors
+  -h, --help              Show this help
+`;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+	const args: CliArgs = {
+		defaultsPath: undefined,
+		keybindingsPath: undefined,
+		dryRun: false,
+		quiet: false,
+		help: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--dry-run") {
+			args.dryRun = true;
+			continue;
+		}
+		if (arg === "--quiet") {
+			args.quiet = true;
+			continue;
+		}
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+			continue;
+		}
+
+		const keybindingsMatch = readOptionValue(argv, index, "--keybindings");
+		if (keybindingsMatch) {
+			args.keybindingsPath = keybindingsMatch.value;
+			index = keybindingsMatch.nextIndex;
+			continue;
+		}
+
+		const defaultsMatch = readOptionValue(argv, index, "--defaults");
+		if (defaultsMatch) {
+			args.defaultsPath = defaultsMatch.value;
+			index = defaultsMatch.nextIndex;
+			continue;
+		}
+
+		if (arg.startsWith("-")) {
+			throw new Error(`Unknown option: ${arg}`);
+		}
+		if (args.defaultsPath) {
+			throw new Error(`Unexpected extra argument: ${arg}`);
+		}
+		args.defaultsPath = arg;
+	}
+
+	return args;
+}
+
+function defaultDefaultsPath(): string {
+	return join(resolve(__dirname, ".."), "config", "keybindings.defaults.json");
+}
+
+function isPlainObject(value: unknown): value is KeybindingMap {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function clone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const legacyKeybindingOwners = new Map<string, readonly string[]>([["app.thinking.cycle", ["cycleThinkingLevel"]]]);
+
+function hasExistingKeybindingOwner(keybindings: KeybindingMap, key: string): boolean {
+	if (Object.hasOwn(keybindings, key)) return true;
+	return legacyKeybindingOwners.get(key)?.some((legacyKey) => Object.hasOwn(keybindings, legacyKey)) ?? false;
+}
+
+function mergeKeybindings(existing: unknown, defaults: unknown): { next: KeybindingMap; changes: string[] } {
+	if (!isPlainObject(existing)) {
+		throw new Error("Existing keybindings must be a JSON object");
+	}
+	if (!isPlainObject(defaults)) {
+		throw new Error("Default keybindings must be a JSON object");
+	}
+
+	const next = clone(existing);
+	const changes: string[] = [];
+	for (const [key, value] of Object.entries(defaults)) {
+		if (hasExistingKeybindingOwner(next, key)) continue;
+		next[key] = clone(value);
+		changes.push(`set ${key}`);
+	}
+
+	return { next, changes };
+}
+
+function backupPathFor(keybindingsPath: string): string {
+	return backupPathWithTimestamp(keybindingsPath);
+}
+
+function assertKeybindingsTarget(keybindingsPath: string): void {
+	if (basename(resolve(keybindingsPath)) !== "keybindings.json") {
+		throw new Error(`Refusing to modify non-keybindings file: ${keybindingsPath}`);
+	}
+
+	assertNotInNormalPiConfig(
+		keybindingsPath,
+		`Refusing to modify normal Pi config from The Last Harness installer: ${keybindingsPath}`,
+	);
+}
+
+function writeExistingProfileBackup(keybindingsPath: string, backupPath: string): void {
+	const { content, mode } = readRegularFileForBackup(keybindingsPath, "Pi keybindings");
+	writeSafeProfileFile(
+		{ agentDir: dirname(keybindingsPath) },
+		basename(backupPath),
+		content,
+		"Pi keybindings backup",
+		{ mode },
+	);
+}
+
+function writeKeybindings(
+	keybindingsPath: string,
+	value: KeybindingMap,
+	{ dryRun, existed }: { dryRun: boolean; existed: boolean },
+): string | undefined {
+	const formatted = `${JSON.stringify(value, null, 2)}\n`;
+	if (dryRun) return undefined;
+
+	let backupPath: string | undefined;
+	if (existed) {
+		backupPath = backupPathFor(keybindingsPath);
+		writeExistingProfileBackup(keybindingsPath, backupPath);
+	}
+
+	writeSafeProfileFile({ agentDir: dirname(keybindingsPath) }, basename(keybindingsPath), formatted, "Pi keybindings");
+	return backupPath;
+}
+
+function log(args: CliArgs, message: string): void {
+	if (!args.quiet) console.log(message);
+}
+
+function main(): void {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help) {
+		console.log(usage());
+		return;
+	}
+
+	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()) || defaultDefaultsPath());
+	const keybindingsPath = resolve(
+		expandHomePath(args.keybindingsPath || defaultTlhKeybindingsPath()) || defaultTlhKeybindingsPath(),
+	);
+	assertKeybindingsTarget(keybindingsPath);
+	const existed = existsSync(keybindingsPath);
+	const existing = readJsonFile<KeybindingMap>(keybindingsPath, { missingValue: {} });
+	const defaults = readJsonFile<KeybindingMap>(defaultsPath);
+	const { next, changes } = mergeKeybindings(existing, defaults);
+
+	log(args, `Keybindings: ${keybindingsPath}`);
+	if (changes.length === 0) {
+		log(args, "No keybinding changes needed.");
+		return;
+	}
+
+	for (const change of changes) {
+		log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
+	}
+
+	if (args.dryRun) {
+		if (existed) log(args, "Would back up existing keybindings before writing.");
+		log(args, "Dry run only; no keybindings were changed.");
+		return;
+	}
+
+	const backupPath = writeKeybindings(keybindingsPath, next, { dryRun: args.dryRun, existed });
+	if (backupPath) log(args, `Backed up previous keybindings to: ${backupPath}`);
+	log(args, "Keybindings updated.");
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(`merge-keybindings: ${errorMessage(error)}`);
+	process.exit(1);
+}

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -3,41 +3,16 @@ import { existsSync } from "node:fs";
 import { basename, dirname, join, normalize, parse, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
-
-import {
-	criticalDefaultExtensionOptOutIds,
-	defaultExtensionPackageIdentities,
-	disabledDefaultExtensionIds,
-	managedDefaultExtensionPackageIdentities,
-	packageIdentity,
-	packageSourceOf,
-	readDefaultExtensionProvenance,
-	readDefaultExtensions,
-	RETIRED_TLH_DEFAULT_PACKAGE_SOURCES,
-	repairTargetedDefaultExtensionLoadOrder,
-	setDefaultExtensionProvenance,
-	withLegacyRetiredDefaultPackageIdentities,
-} from "./lib/default-extensions.mjs";
-import {
-	assertNotInNormalPiConfig,
-	assignOptionValue,
-	backupPathWithTimestamp,
-	defaultTlhSettingsPath,
-	expandHomePath,
-	readJsonFile,
-	readRegularFileForBackup,
-} from "./lib/tlh-install-utils.mjs";
+import { criticalDefaultExtensionOptOutIds, defaultExtensionPackageIdentities, disabledDefaultExtensionIds, managedDefaultExtensionPackageIdentities, packageIdentity, packageSourceOf, readDefaultExtensionProvenance, readDefaultExtensions, RETIRED_TLH_DEFAULT_PACKAGE_SOURCES, repairTargetedDefaultExtensionLoadOrder, setDefaultExtensionProvenance, withLegacyRetiredDefaultPackageIdentities, } from "./lib/default-extensions.mjs";
+import { assertNotInNormalPiConfig, assignOptionValue, backupPathWithTimestamp, defaultTlhSettingsPath, expandHomePath, readJsonFile, readRegularFileForBackup, } from "./lib/tlh-install-utils.mjs";
 import { writeSafeProfileFile } from "./lib/tlh-safe-profile-write.mjs";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
 const DEFAULT_PACKAGE_SOURCE = "git:github.com/diegopetrucci/the-last-harness";
 const TLH_CHANGELOG_SENTINEL = "9999.0.0";
 const HARNESS_PACKAGE_IDENTITY = packageIdentity(DEFAULT_PACKAGE_SOURCE);
-
 function usage() {
-	return `Usage: node scripts/merge-settings.mjs [defaults.json] [options]
+    return `Usage: node scripts/merge-settings.mjs [defaults.json] [options]
 
 Merge installer defaults into The Last Harness isolated Pi settings without clobbering user values.
 
@@ -51,616 +26,584 @@ Options:
   -h, --help               Show this help
 `;
 }
-
 function parseArgs(argv) {
-	const args = {
-		defaultsPath: undefined,
-		settingsPath: undefined,
-		packageSource: undefined,
-		defaultExtensionsPath: undefined,
-		dryRun: false,
-		force: false,
-		quiet: false,
-		help: false,
-	};
-
-	for (let i = 0; i < argv.length; i += 1) {
-		const arg = argv[i];
-		if (arg === "--dry-run") {
-			args.dryRun = true;
-			continue;
-		}
-		if (arg === "--force") {
-			args.force = true;
-			continue;
-		}
-		if (arg === "--quiet") {
-			args.quiet = true;
-			continue;
-		}
-		if (arg === "-h" || arg === "--help") {
-			args.help = true;
-			continue;
-		}
-		const settingsIndex = assignOptionValue(args, "settingsPath", argv, i, "--settings");
-		if (settingsIndex !== undefined) {
-			i = settingsIndex;
-			continue;
-		}
-		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, i, "--package-source");
-		if (packageSourceIndex !== undefined) {
-			i = packageSourceIndex;
-			continue;
-		}
-		const defaultExtensionsIndex = assignOptionValue(args, "defaultExtensionsPath", argv, i, "--default-extensions");
-		if (defaultExtensionsIndex !== undefined) {
-			i = defaultExtensionsIndex;
-			continue;
-		}
-		if (arg.startsWith("-")) {
-			throw new Error(`Unknown option: ${arg}`);
-		}
-		if (args.defaultsPath) {
-			throw new Error(`Unexpected extra argument: ${arg}`);
-		}
-		args.defaultsPath = arg;
-	}
-
-	return args;
+    const args = {
+        defaultsPath: undefined,
+        settingsPath: undefined,
+        packageSource: undefined,
+        defaultExtensionsPath: undefined,
+        dryRun: false,
+        force: false,
+        quiet: false,
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === "--dry-run") {
+            args.dryRun = true;
+            continue;
+        }
+        if (arg === "--force") {
+            args.force = true;
+            continue;
+        }
+        if (arg === "--quiet") {
+            args.quiet = true;
+            continue;
+        }
+        if (arg === "-h" || arg === "--help") {
+            args.help = true;
+            continue;
+        }
+        const settingsIndex = assignOptionValue(args, "settingsPath", argv, index, "--settings");
+        if (settingsIndex !== undefined) {
+            index = settingsIndex;
+            continue;
+        }
+        const packageSourceIndex = assignOptionValue(args, "packageSource", argv, index, "--package-source");
+        if (packageSourceIndex !== undefined) {
+            index = packageSourceIndex;
+            continue;
+        }
+        const defaultExtensionsIndex = assignOptionValue(args, "defaultExtensionsPath", argv, index, "--default-extensions");
+        if (defaultExtensionsIndex !== undefined) {
+            index = defaultExtensionsIndex;
+            continue;
+        }
+        if (arg.startsWith("-")) {
+            throw new Error(`Unknown option: ${arg}`);
+        }
+        if (args.defaultsPath) {
+            throw new Error(`Unexpected extra argument: ${arg}`);
+        }
+        args.defaultsPath = arg;
+    }
+    return args;
 }
-
 function defaultDefaultsPath() {
-	return join(resolve(__dirname, ".."), "config", "settings.defaults.json");
+    return join(resolve(__dirname, ".."), "config", "settings.defaults.json");
 }
-
 function defaultDefaultExtensionsPath() {
-	return join(resolve(__dirname, ".."), "config", "default-extensions.json");
+    return join(resolve(__dirname, ".."), "config", "default-extensions.json");
 }
-
 function isPlainObject(value) {
-	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
-
 function clone(value) {
-	return JSON.parse(JSON.stringify(value));
+    return JSON.parse(JSON.stringify(value));
 }
-
 function packageIdentityExists(packages, identity) {
-	return Boolean(identity) && packages.some((entry) => packageIdentity(entry) === identity);
+    return Boolean(identity) && packages.some((entry) => packageIdentity(entry) === identity);
 }
-
 function isPinnedNpmSource(source) {
-	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) !== source.trim();
+    return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) !== source.trim();
 }
-
 function isUnpinnedNpmSource(source) {
-	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) === source.trim();
+    return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) === source.trim();
 }
-
 function shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities = new Set() }) {
-	if (force || extension.critical === true) return true;
-	const identity = packageIdentity(extension.source);
-	if (!identity || packageIdentity(currentSource) !== identity) return false;
-	if (!isPinnedNpmSource(extension.source)) return false;
-	if (isUnpinnedNpmSource(currentSource)) return true;
-	return managedPackageIdentities.has(identity);
+    if (force || extension.critical === true)
+        return true;
+    const identity = packageIdentity(extension.source);
+    if (!identity || packageIdentity(currentSource) !== identity)
+        return false;
+    if (!isPinnedNpmSource(extension.source))
+        return false;
+    if (isUnpinnedNpmSource(currentSource))
+        return true;
+    return managedPackageIdentities.has(identity);
 }
-
 function shouldMigrateDefaultExtensionReplacements(extension, { force }) {
-	return force || extension.migrateReplacements === true;
+    return force || extension.migrateReplacements === true;
 }
-
 function shouldEnsureDefaultExtensionSource(existingPackages, extension, { force }) {
-	if (shouldMigrateDefaultExtensionReplacements(extension, { force })) return true;
-	if (packageIdentityExists(existingPackages, packageIdentity(extension.source))) return true;
-	return !extension.replaces.some((oldSource) => packageIdentityExists(existingPackages, packageIdentity(oldSource)));
+    if (shouldMigrateDefaultExtensionReplacements(extension, { force }))
+        return true;
+    if (packageIdentityExists(existingPackages, packageIdentity(extension.source)))
+        return true;
+    return !extension.replaces.some((oldSource) => packageIdentityExists(existingPackages, packageIdentity(oldSource)));
 }
-
 function prepareDefaults(defaults, packageSource, defaultExtensions, disabledIds, existingSettings, { force }) {
-	const next = clone(defaults);
-	next.lastChangelogVersion = TLH_CHANGELOG_SENTINEL;
-
-	// Strip the anthropic-auth warning suppression from the defaults clone when
-	// that extension is disabled, so the merge engine cannot re-introduce
-	// warnings.anthropicExtraUsage into an opted-out user's settings on update.
-	if (disabledIds.has("anthropic-auth")) {
-		if (isPlainObject(next.warnings) && next.warnings.anthropicExtraUsage !== undefined) {
-			delete next.warnings.anthropicExtraUsage;
-			if (Object.keys(next.warnings).length === 0) {
-				delete next.warnings;
-			}
-		}
-	}
-
-	const ensuredSource = packageSource || DEFAULT_PACKAGE_SOURCE;
-	const existingPackages = isPlainObject(existingSettings) && Array.isArray(existingSettings.packages) ? existingSettings.packages : [];
-	const ensuredPackages = [
-		ensuredSource,
-		...defaultExtensions
-			.filter((extension) => !disabledIds.has(extension.id))
-			.filter((extension) => shouldEnsureDefaultExtensionSource(existingPackages, extension, { force }))
-			.map((extension) => extension.source),
-	];
-	const ensuredIdentities = new Set(ensuredPackages.map(packageIdentity).filter(Boolean));
-	const disabledIdentities = new Set(
-		defaultExtensions.filter((extension) => disabledIds.has(extension.id)).flatMap(defaultExtensionPackageIdentities),
-	);
-	const packages = Array.isArray(next.packages) ? next.packages : [];
-	next.packages = [
-		...ensuredPackages,
-		...packages.filter((entry) => {
-			const identity = packageIdentity(entry);
-			return !ensuredIdentities.has(identity) && !disabledIdentities.has(identity);
-		}),
-	];
-	return next;
+    const next = clone(defaults);
+    next.lastChangelogVersion = TLH_CHANGELOG_SENTINEL;
+    // Strip the anthropic-auth warning suppression from the defaults clone when
+    // that extension is disabled, so the merge engine cannot re-introduce
+    // warnings.anthropicExtraUsage into an opted-out user's settings on update.
+    if (disabledIds.has("anthropic-auth")) {
+        const warnings = isPlainObject(next.warnings) ? next.warnings : undefined;
+        if (warnings?.anthropicExtraUsage !== undefined) {
+            delete warnings.anthropicExtraUsage;
+            if (Object.keys(warnings).length === 0) {
+                delete next.warnings;
+            }
+        }
+    }
+    const ensuredSource = packageSource || DEFAULT_PACKAGE_SOURCE;
+    const existingPackages = isPlainObject(existingSettings) && Array.isArray(existingSettings.packages) ? existingSettings.packages : [];
+    const ensuredPackages = [
+        ensuredSource,
+        ...defaultExtensions
+            .filter((extension) => !disabledIds.has(extension.id))
+            .filter((extension) => shouldEnsureDefaultExtensionSource(existingPackages, extension, { force }))
+            .map((extension) => extension.source),
+    ];
+    const ensuredIdentities = new Set(ensuredPackages.map(packageIdentity).filter((value) => Boolean(value)));
+    const disabledIdentities = new Set(defaultExtensions.filter((extension) => disabledIds.has(extension.id)).flatMap(defaultExtensionPackageIdentities));
+    const packages = Array.isArray(next.packages) ? next.packages : [];
+    next.packages = [
+        ...ensuredPackages,
+        ...packages.filter((entry) => {
+            const identity = packageIdentity(entry);
+            return !ensuredIdentities.has(identity || "") && !disabledIdentities.has(identity || "");
+        }),
+    ];
+    return next;
 }
-
 function removePackageByIdentity(settings, identity) {
-	if (!identity || !Array.isArray(settings.packages)) return undefined;
-	const index = settings.packages.findIndex((entry) => packageIdentity(entry) === identity);
-	if (index === -1) return undefined;
-	const [removed] = settings.packages.splice(index, 1);
-	return packageSourceOf(removed) || identity;
+    if (!identity || !Array.isArray(settings.packages))
+        return undefined;
+    const index = settings.packages.findIndex((entry) => packageIdentity(entry) === identity);
+    if (index === -1)
+        return undefined;
+    const [removed] = settings.packages.splice(index, 1);
+    return packageSourceOf(removed) || identity;
 }
-
 function removeDuplicatePackagesByIdentity(settings, identity) {
-	if (!identity || !Array.isArray(settings.packages)) return [];
-	const removedSources = [];
-	let seen = false;
-	for (let index = 0; index < settings.packages.length;) {
-		if (packageIdentity(settings.packages[index]) !== identity) {
-			index += 1;
-			continue;
-		}
-		if (!seen) {
-			seen = true;
-			index += 1;
-			continue;
-		}
-		const [removed] = settings.packages.splice(index, 1);
-		removedSources.push(packageSourceOf(removed) || identity);
-	}
-	return removedSources;
+    if (!identity || !Array.isArray(settings.packages))
+        return [];
+    const removedSources = [];
+    let seen = false;
+    for (let index = 0; index < settings.packages.length;) {
+        if (packageIdentity(settings.packages[index]) !== identity) {
+            index += 1;
+            continue;
+        }
+        if (!seen) {
+            seen = true;
+            index += 1;
+            continue;
+        }
+        const [removed] = settings.packages.splice(index, 1);
+        removedSources.push(packageSourceOf(removed) || identity);
+    }
+    return removedSources;
 }
-
 function applyHarnessPackageDedupes(settings, ensuredSource, changes) {
-	if (!Array.isArray(settings.packages)) return;
-	for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
-		changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
-	}
+    if (!Array.isArray(settings.packages))
+        return;
+    for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
+        changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
+    }
 }
-
 function applyReplacedDefaultExtensions(settings, defaultExtensions, disabledIds, changes, { force }) {
-	if (!Array.isArray(settings.packages)) return;
-
-	for (const extension of defaultExtensions) {
-		if (!shouldMigrateDefaultExtensionReplacements(extension, { force })) continue;
-		if (disabledIds.has(extension.id)) continue;
-		const newIdentity = packageIdentity(extension.source);
-		for (const oldSource of extension.replaces) {
-			const oldIdentity = packageIdentity(oldSource);
-			if (!oldIdentity || oldIdentity === newIdentity) continue;
-			let removedSource;
-			while ((removedSource = removePackageByIdentity(settings, oldIdentity))) {
-				changes.push(`remove replaced default extension package: ${removedSource} -> ${extension.source}`);
-			}
-		}
-	}
+    if (!Array.isArray(settings.packages))
+        return;
+    for (const extension of defaultExtensions) {
+        if (!shouldMigrateDefaultExtensionReplacements(extension, { force }))
+            continue;
+        if (disabledIds.has(extension.id))
+            continue;
+        const newIdentity = packageIdentity(extension.source);
+        for (const oldSource of extension.replaces) {
+            const oldIdentity = packageIdentity(oldSource);
+            if (!oldIdentity || oldIdentity === newIdentity)
+                continue;
+            let removedSource;
+            while ((removedSource = removePackageByIdentity(settings, oldIdentity))) {
+                changes.push(`remove replaced default extension package: ${removedSource} -> ${extension.source}`);
+            }
+        }
+    }
 }
-
-function applyDefaultExtensionPackageDedupes(settings, defaultExtensions, disabledIds, changes, { force, sourceUpdatedIdentities = new Set() }) {
-	if (!Array.isArray(settings.packages)) return;
-
-	for (const extension of defaultExtensions) {
-		const identity = packageIdentity(extension.source);
-		if (!shouldMigrateDefaultExtensionReplacements(extension, { force }) && !sourceUpdatedIdentities.has(identity)) continue;
-		if (disabledIds.has(extension.id)) continue;
-		const removedSources = removeDuplicatePackagesByIdentity(settings, identity);
-		for (const removedSource of removedSources) {
-			changes.push(`remove duplicate default extension package: ${removedSource} (same identity as ${extension.source})`);
-		}
-	}
+function applyDefaultExtensionPackageDedupes(settings, defaultExtensions, disabledIds, changes, { force, sourceUpdatedIdentities = new Set(), }) {
+    if (!Array.isArray(settings.packages))
+        return;
+    for (const extension of defaultExtensions) {
+        const identity = packageIdentity(extension.source);
+        if (!shouldMigrateDefaultExtensionReplacements(extension, { force }) && !sourceUpdatedIdentities.has(identity || ""))
+            continue;
+        if (disabledIds.has(extension.id))
+            continue;
+        const removedSources = removeDuplicatePackagesByIdentity(settings, identity);
+        for (const removedSource of removedSources) {
+            changes.push(`remove duplicate default extension package: ${removedSource} (same identity as ${extension.source})`);
+        }
+    }
 }
-
-function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disabledIds, changes, { force, managedPackageIdentities = new Set() }) {
-	const updatedIdentities = new Set();
-	if (!Array.isArray(settings.packages)) return updatedIdentities;
-
-	for (const extension of defaultExtensions) {
-		if (disabledIds.has(extension.id)) continue;
-		const identity = packageIdentity(extension.source);
-		if (!identity) continue;
-		const index = settings.packages.findIndex((entry) => packageIdentity(entry) === identity);
-		if (index === -1) continue;
-
-		const current = settings.packages[index];
-		const currentSource = packageSourceOf(current);
-		if (!currentSource) continue;
-		if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities })) continue;
-
-		const sourceNeedsUpdate = currentSource !== extension.source;
-		const removesCriticalExtensionFilter = extension.critical === true
-			&& isPlainObject(current)
-			&& Object.hasOwn(current, "extensions");
-		if (!sourceNeedsUpdate && !removesCriticalExtensionFilter) continue;
-
-		if (isPlainObject(current)) {
-			const next = { ...clone(current), source: extension.source };
-			if (removesCriticalExtensionFilter) delete next.extensions;
-			settings.packages[index] = Object.keys(next).length === 1 && typeof next.source === "string"
-				? next.source
-				: next;
-		} else {
-			settings.packages[index] = extension.source;
-		}
-		if (sourceNeedsUpdate) {
-			changes.push(`update default extension package source: ${currentSource} -> ${extension.source}`);
-		}
-		if (removesCriticalExtensionFilter) {
-			changes.push(`remove critical default extension package filter: ${extension.id}`);
-		}
-		updatedIdentities.add(identity);
-	}
-
-	return updatedIdentities;
+function applyDefaultExtensionSourceUpdates(settings, defaultExtensions, disabledIds, changes, { force, managedPackageIdentities = new Set(), }) {
+    const updatedIdentities = new Set();
+    if (!Array.isArray(settings.packages))
+        return updatedIdentities;
+    for (const extension of defaultExtensions) {
+        if (disabledIds.has(extension.id))
+            continue;
+        const identity = packageIdentity(extension.source);
+        if (!identity)
+            continue;
+        const index = settings.packages.findIndex((entry) => packageIdentity(entry) === identity);
+        if (index === -1)
+            continue;
+        const current = settings.packages[index];
+        const currentSource = packageSourceOf(current);
+        if (!currentSource)
+            continue;
+        if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities }))
+            continue;
+        const sourceNeedsUpdate = currentSource !== extension.source;
+        const removesCriticalExtensionFilter = extension.critical === true
+            && isPlainObject(current)
+            && Object.hasOwn(current, "extensions");
+        if (!sourceNeedsUpdate && !removesCriticalExtensionFilter)
+            continue;
+        if (isPlainObject(current)) {
+            const next = { ...clone(current), source: extension.source };
+            if (removesCriticalExtensionFilter)
+                delete next.extensions;
+            settings.packages[index] = Object.keys(next).length === 1 && typeof next.source === "string"
+                ? next.source
+                : next;
+        }
+        else {
+            settings.packages[index] = extension.source;
+        }
+        if (sourceNeedsUpdate) {
+            changes.push(`update default extension package source: ${currentSource} -> ${extension.source}`);
+        }
+        if (removesCriticalExtensionFilter) {
+            changes.push(`remove critical default extension package filter: ${extension.id}`);
+        }
+        updatedIdentities.add(identity);
+    }
+    return updatedIdentities;
 }
-
 function applyDisabledDefaultExtensions(settings, defaultExtensions, disabledIds, changes) {
-	if (disabledIds.size === 0 || !Array.isArray(settings.packages)) return;
-
-	for (const extension of defaultExtensions) {
-		if (!disabledIds.has(extension.id)) continue;
-		const removedSources = [];
-		for (const identity of defaultExtensionPackageIdentities(extension)) {
-			let removedSource;
-			while ((removedSource = removePackageByIdentity(settings, identity))) {
-				removedSources.push(removedSource);
-			}
-		}
-		if (removedSources.length === 0) continue;
-
-		changes.push(`remove disabled default extension package: ${extension.id}`);
-	}
+    if (disabledIds.size === 0 || !Array.isArray(settings.packages))
+        return;
+    for (const extension of defaultExtensions) {
+        if (!disabledIds.has(extension.id))
+            continue;
+        const removedSources = [];
+        for (const identity of defaultExtensionPackageIdentities(extension)) {
+            let removedSource;
+            while ((removedSource = removePackageByIdentity(settings, identity))) {
+                removedSources.push(removedSource);
+            }
+        }
+        if (removedSources.length === 0)
+            continue;
+        changes.push(`remove disabled default extension package: ${extension.id}`);
+    }
 }
-
 function applyRetiredTlhDefaultPackageCleanup(settings, changes, managedPackageIdentities) {
-	if (!Array.isArray(settings.packages)) return;
-
-	for (const source of RETIRED_TLH_DEFAULT_PACKAGE_SOURCES) {
-		const identity = packageIdentity(source);
-		if (!identity || !managedPackageIdentities.has(identity)) continue;
-		let removedSource;
-		while ((removedSource = removePackageByIdentity(settings, identity))) {
-			changes.push(`remove retired TLH default package: ${removedSource}`);
-		}
-		managedPackageIdentities.delete(identity);
-	}
+    if (!Array.isArray(settings.packages))
+        return;
+    for (const source of RETIRED_TLH_DEFAULT_PACKAGE_SOURCES) {
+        const identity = packageIdentity(source);
+        if (!identity || !managedPackageIdentities.has(identity))
+            continue;
+        let removedSource;
+        while ((removedSource = removePackageByIdentity(settings, identity))) {
+            changes.push(`remove retired TLH default package: ${removedSource}`);
+        }
+        managedPackageIdentities.delete(identity);
+    }
 }
-
 function applyDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds, changes) {
-	const loadOrderRepair = repairTargetedDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds);
-	if (!loadOrderRepair) return;
-	changes.push(
-		`reorder targeted default extension packages for load order: ${loadOrderRepair.previous.join(", ")} -> ${loadOrderRepair.next.join(", ")}`,
-	);
+    const loadOrderRepair = repairTargetedDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds);
+    if (!loadOrderRepair)
+        return;
+    changes.push(`reorder targeted default extension packages for load order: ${loadOrderRepair.previous.join(", ")} -> ${loadOrderRepair.next.join(", ")}`);
 }
-
 // Sources of retired default extensions that TLH now removes unconditionally
 // from isolated settings because they should no longer stay installed after
 // install/update reruns.
 const FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES = Object.freeze([
-	"npm:@diegopetrucci/pi-context-cap",
-	"npm:@diegopetrucci/pi-permission-gate",
-	"npm:@diegopetrucci/pi-confirm-destructive",
-	"npm:@diegopetrucci/pi-oracle",
+    "npm:@diegopetrucci/pi-context-cap",
+    "npm:@diegopetrucci/pi-permission-gate",
+    "npm:@diegopetrucci/pi-confirm-destructive",
+    "npm:@diegopetrucci/pi-oracle",
 ]);
-
 function purgeForceRemovedRetiredDefaultExtensionPackages(settings, changes) {
-	if (!Array.isArray(settings.packages)) return;
-	for (const source of FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES) {
-		const identity = packageIdentity(source);
-		if (!identity) continue;
-		while (removePackageByIdentity(settings, identity)) {
-			changes.push(`force-remove retired default extension package: ${source}`);
-		}
-	}
+    if (!Array.isArray(settings.packages))
+        return;
+    for (const source of FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES) {
+        const identity = packageIdentity(source);
+        if (!identity)
+            continue;
+        while (removePackageByIdentity(settings, identity)) {
+            changes.push(`force-remove retired default extension package: ${source}`);
+        }
+    }
 }
-
 function pruneContextCapDisabledDefaultExtension(settings, changes) {
-	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
-	const values = settings.tlh.disabledDefaultExtensions;
-	if (!Array.isArray(values)) return;
-	const nextValues = values.filter((value) => !(typeof value === "string" && value.trim() === "context-cap"));
-	if (nextValues.length === values.length) return;
-	settings.tlh.disabledDefaultExtensions = nextValues;
-	changes.push("remove stale context-cap opt-out from tlh.disabledDefaultExtensions");
+    if (!isPlainObject(settings) || !isPlainObject(settings.tlh))
+        return;
+    const values = settings.tlh.disabledDefaultExtensions;
+    if (!Array.isArray(values))
+        return;
+    const nextValues = values.filter((value) => !(typeof value === "string" && value.trim() === "context-cap"));
+    if (nextValues.length === values.length)
+        return;
+    settings.tlh.disabledDefaultExtensions = nextValues;
+    changes.push("remove stale context-cap opt-out from tlh.disabledDefaultExtensions");
 }
-
 function pruneOracleDisabledDefaultExtension(settings, changes) {
-	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
-	const values = settings.tlh.disabledDefaultExtensions;
-	if (!Array.isArray(values)) return;
-	const nextValues = values.filter((value) => !(typeof value === "string" && value.trim() === "oracle"));
-	if (nextValues.length === values.length) return;
-	settings.tlh.disabledDefaultExtensions = nextValues;
-	changes.push("remove stale oracle opt-out from tlh.disabledDefaultExtensions");
+    if (!isPlainObject(settings) || !isPlainObject(settings.tlh))
+        return;
+    const values = settings.tlh.disabledDefaultExtensions;
+    if (!Array.isArray(values))
+        return;
+    const nextValues = values.filter((value) => !(typeof value === "string" && value.trim() === "oracle"));
+    if (nextValues.length === values.length)
+        return;
+    settings.tlh.disabledDefaultExtensions = nextValues;
+    changes.push("remove stale oracle opt-out from tlh.disabledDefaultExtensions");
 }
-
 function scrubGnosisSettings(settings, changes) {
-	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
-	if (!Object.hasOwn(settings.tlh, "gnosis")) return;
-	delete settings.tlh.gnosis;
-	changes.push("remove tlh.gnosis (one-time cleanup)");
+    if (!isPlainObject(settings) || !isPlainObject(settings.tlh))
+        return;
+    if (!Object.hasOwn(settings.tlh, "gnosis"))
+        return;
+    delete settings.tlh.gnosis;
+    changes.push("remove tlh.gnosis (one-time cleanup)");
 }
-
 function removeCriticalDisabledDefaultExtensionOptOuts(settings, defaultExtensions, changes) {
-	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
-	const values = settings.tlh.disabledDefaultExtensions;
-	if (!Array.isArray(values)) return;
-
-	const criticalIds = criticalDefaultExtensionOptOutIds(defaultExtensions);
-	if (criticalIds.size === 0) return;
-
-	const nextValues = values.filter((value) => !(typeof value === "string" && criticalIds.has(value.trim())));
-	if (nextValues.length === values.length) return;
-
-	settings.tlh.disabledDefaultExtensions = nextValues;
-	changes.push("remove invalid critical default extension opt-out");
+    if (!isPlainObject(settings) || !isPlainObject(settings.tlh))
+        return;
+    const values = settings.tlh.disabledDefaultExtensions;
+    if (!Array.isArray(values))
+        return;
+    const criticalIds = criticalDefaultExtensionOptOutIds(defaultExtensions);
+    if (criticalIds.size === 0)
+        return;
+    const nextValues = values.filter((value) => !(typeof value === "string" && criticalIds.has(value.trim())));
+    if (nextValues.length === values.length)
+        return;
+    settings.tlh.disabledDefaultExtensions = nextValues;
+    changes.push("remove invalid critical default extension opt-out");
 }
-
 function sameIdentitySets(left, right) {
-	if (left.size !== right.size) return false;
-	for (const value of left) {
-		if (!right.has(value)) return false;
-	}
-	return true;
+    if (left.size !== right.size)
+        return false;
+    for (const value of left) {
+        if (!right.has(value))
+            return false;
+    }
+    return true;
 }
-
 function syncDefaultExtensionProvenance(settings, defaultExtensions, disabledIds, changes) {
-	const previous = readDefaultExtensionProvenance(settings);
-	const previousRaw = isPlainObject(settings) && isPlainObject(settings.tlh) && Object.hasOwn(settings.tlh, "defaultExtensionProvenance")
-		? JSON.stringify(settings.tlh.defaultExtensionProvenance)
-		: undefined;
-	const nextManagedIdentities = managedDefaultExtensionPackageIdentities(settings, defaultExtensions, disabledIds);
-	if (!setDefaultExtensionProvenance(settings, nextManagedIdentities)) return;
-	const nextRaw = JSON.stringify(settings.tlh.defaultExtensionProvenance);
-	if (previousRaw !== nextRaw || !previous.exists || !sameIdentitySets(previous.managedPackageIdentities, nextManagedIdentities)) {
-		changes.push("update TLH default extension provenance metadata");
-	}
+    const previous = readDefaultExtensionProvenance(settings);
+    const tlh = isPlainObject(settings) && isPlainObject(settings.tlh) ? settings.tlh : undefined;
+    const previousRaw = tlh && Object.hasOwn(tlh, "defaultExtensionProvenance")
+        ? JSON.stringify(tlh.defaultExtensionProvenance)
+        : undefined;
+    const nextManagedIdentities = managedDefaultExtensionPackageIdentities(settings, defaultExtensions, disabledIds);
+    if (!setDefaultExtensionProvenance(settings, nextManagedIdentities))
+        return;
+    const nextTlh = isPlainObject(settings.tlh) ? settings.tlh : undefined;
+    const nextRaw = JSON.stringify(nextTlh?.defaultExtensionProvenance);
+    if (previousRaw !== nextRaw || !previous.exists || !sameIdentitySets(previous.managedPackageIdentities, nextManagedIdentities)) {
+        changes.push("update TLH default extension provenance metadata");
+    }
 }
-
 function mergeSettings(existing, defaults, { force }) {
-	if (!isPlainObject(existing)) {
-		throw new Error("Existing settings must be a JSON object");
-	}
-	if (!isPlainObject(defaults)) {
-		throw new Error("Default settings must be a JSON object");
-	}
-
-	const next = clone(existing);
-	const changes = [];
-	mergeObject(next, defaults, changes, { force, path: [] });
-	return { next, changes };
+    if (!isPlainObject(existing)) {
+        throw new Error("Existing settings must be a JSON object");
+    }
+    if (!isPlainObject(defaults)) {
+        throw new Error("Default settings must be a JSON object");
+    }
+    const next = clone(existing);
+    const changes = [];
+    mergeObject(next, defaults, changes, { force, path: [] });
+    return { next, changes };
 }
-
 function isPersistentTelemetryOptOut(path, currentValue, defaultValue) {
-	// Telemetry opt-outs are user-owned and must survive installer reruns and forced updates.
-	return path.join(".") === "tlh.telemetry.enabled" && currentValue === false && defaultValue === true;
+    // Telemetry opt-outs are user-owned and must survive installer reruns and forced updates.
+    return path.join(".") === "tlh.telemetry.enabled" && currentValue === false && defaultValue === true;
 }
-
 function isInstallerOwnedSetting(path) {
-	return path.join(".") === "lastChangelogVersion";
+    return path.join(".") === "lastChangelogVersion";
 }
-
 function mergeObject(target, defaults, changes, options) {
-	for (const [key, value] of Object.entries(defaults)) {
-		const path = [...options.path, key];
-		const label = path.join(".");
-
-		if (key === "packages" && options.path.length === 0) {
-			mergePackages(target, value, changes);
-			continue;
-		}
-
-		if (target[key] === undefined) {
-			target[key] = clone(value);
-			changes.push(`set ${label}`);
-			continue;
-		}
-
-		if (Array.isArray(value) && Array.isArray(target[key])) {
-			mergeArray(target[key], value, changes, { label, path });
-			continue;
-		}
-
-		if (isPlainObject(value) && isPlainObject(target[key])) {
-			mergeObject(target[key], value, changes, { ...options, path });
-			continue;
-		}
-
-		if (isPersistentTelemetryOptOut(path, target[key], value)) {
-			continue;
-		}
-
-		if ((options.force || isInstallerOwnedSetting(path)) && JSON.stringify(target[key]) !== JSON.stringify(value)) {
-			target[key] = clone(value);
-			changes.push(`overwrite ${label}`);
-		}
-	}
+    for (const [key, value] of Object.entries(defaults)) {
+        const path = [...options.path, key];
+        const label = path.join(".");
+        if (key === "packages" && options.path.length === 0) {
+            mergePackages(target, value, changes);
+            continue;
+        }
+        if (target[key] === undefined) {
+            target[key] = clone(value);
+            changes.push(`set ${label}`);
+            continue;
+        }
+        if (Array.isArray(value) && Array.isArray(target[key])) {
+            mergeArray(target[key], value, changes, { label, path });
+            continue;
+        }
+        if (isPlainObject(value) && isPlainObject(target[key])) {
+            mergeObject(target[key], value, changes, { ...options, path });
+            continue;
+        }
+        if (isPersistentTelemetryOptOut(path, target[key], value)) {
+            continue;
+        }
+        if ((options.force || isInstallerOwnedSetting(path)) && JSON.stringify(target[key]) !== JSON.stringify(value)) {
+            target[key] = clone(value);
+            changes.push(`overwrite ${label}`);
+        }
+    }
 }
-
 function mergePackages(target, packageDefaults, changes) {
-	if (!Array.isArray(packageDefaults)) {
-		throw new Error("Default settings field 'packages' must be an array");
-	}
-	if (target.packages === undefined) {
-		target.packages = [];
-	}
-	if (!Array.isArray(target.packages)) {
-		throw new Error("Existing settings field 'packages' must be an array if present");
-	}
-
-	const seen = new Map();
-	target.packages.forEach((entry, index) => {
-		const identity = packageIdentity(entry);
-		if (identity && !seen.has(identity)) seen.set(identity, index);
-	});
-
-	for (const entry of packageDefaults) {
-		const source = packageSourceOf(entry);
-		const identity = packageIdentity(entry);
-		if (!source || !identity) {
-			throw new Error(`Invalid package entry in defaults: ${JSON.stringify(entry)}`);
-		}
-		if (seen.has(identity)) {
-			const existingIndex = seen.get(identity);
-			const existingSource = packageSourceOf(target.packages[existingIndex]);
-			if (identity === HARNESS_PACKAGE_IDENTITY && existingSource !== source) {
-				target.packages[existingIndex] = clone(entry);
-				changes.push(`replace packages: ${existingSource} -> ${source}`);
-			}
-			continue;
-		}
-		target.packages.push(clone(entry));
-		seen.set(identity, target.packages.length - 1);
-		changes.push(`append packages: ${source}`);
-	}
+    if (!Array.isArray(packageDefaults)) {
+        throw new Error("Default settings field 'packages' must be an array");
+    }
+    if (target.packages === undefined) {
+        target.packages = [];
+    }
+    if (!Array.isArray(target.packages)) {
+        throw new Error("Existing settings field 'packages' must be an array if present");
+    }
+    const seen = new Map();
+    target.packages.forEach((entry, index) => {
+        const identity = packageIdentity(entry);
+        if (identity && !seen.has(identity))
+            seen.set(identity, index);
+    });
+    for (const entry of packageDefaults) {
+        const source = packageSourceOf(entry);
+        const identity = packageIdentity(entry);
+        if (!source || !identity) {
+            throw new Error(`Invalid package entry in defaults: ${JSON.stringify(entry)}`);
+        }
+        if (seen.has(identity)) {
+            const existingIndex = seen.get(identity);
+            const existingSource = packageSourceOf(target.packages[existingIndex]);
+            if (identity === HARNESS_PACKAGE_IDENTITY && existingSource !== source) {
+                target.packages[existingIndex] = clone(entry);
+                changes.push(`replace packages: ${existingSource} -> ${source}`);
+            }
+            continue;
+        }
+        target.packages.push(clone(entry));
+        seen.set(identity, target.packages.length - 1);
+        changes.push(`append packages: ${source}`);
+    }
 }
-
 function normalizeAgentDirPath(value) {
-	const normalized = normalize(value);
-	const root = parse(normalized).root;
-	let stripped = normalized;
-	while (stripped.length > root.length && stripped.endsWith(sep)) {
-		stripped = stripped.slice(0, -sep.length);
-	}
-	return stripped;
+    const normalized = normalize(value);
+    const root = parse(normalized).root;
+    let stripped = normalized;
+    while (stripped.length > root.length && stripped.endsWith(sep)) {
+        stripped = stripped.slice(0, -sep.length);
+    }
+    return stripped;
 }
-
 function arrayMergeKey(item, path) {
-	if (path.join(".") === "subagents.agentDirs" && typeof item === "string") {
-		return `path:${normalizeAgentDirPath(item)}`;
-	}
-	return `json:${JSON.stringify(item)}`;
+    if (path.join(".") === "subagents.agentDirs" && typeof item === "string") {
+        return `path:${normalizeAgentDirPath(item)}`;
+    }
+    return `json:${JSON.stringify(item)}`;
 }
-
 function mergeArray(targetArray, defaultArray, changes, { label, path }) {
-	const seen = new Set(targetArray.map((item) => arrayMergeKey(item, path)));
-	for (const item of defaultArray) {
-		const key = arrayMergeKey(item, path);
-		if (seen.has(key)) continue;
-		targetArray.push(clone(item));
-		seen.add(key);
-		changes.push(`append ${label}`);
-	}
+    const seen = new Set(targetArray.map((item) => arrayMergeKey(item, path)));
+    for (const item of defaultArray) {
+        const key = arrayMergeKey(item, path);
+        if (seen.has(key))
+            continue;
+        targetArray.push(clone(item));
+        seen.add(key);
+        changes.push(`append ${label}`);
+    }
 }
-
 function backupPathFor(settingsPath) {
-	return backupPathWithTimestamp(settingsPath);
+    return backupPathWithTimestamp(settingsPath);
 }
-
 function assertNotNormalPiSettings(settingsPath) {
-	assertNotInNormalPiConfig(
-		settingsPath,
-		`Refusing to modify normal Pi config from The Last Harness installer: ${settingsPath}`,
-	);
+    assertNotInNormalPiConfig(settingsPath, `Refusing to modify normal Pi config from The Last Harness installer: ${settingsPath}`);
 }
-
 function writeExistingProfileBackup(settingsPath, backupPath) {
-	const { content, mode } = readRegularFileForBackup(settingsPath, "Pi settings");
-	writeSafeProfileFile(
-		{ agentDir: dirname(settingsPath) },
-		basename(backupPath),
-		content,
-		"Pi settings backup",
-		{ mode },
-	);
+    const { content, mode } = readRegularFileForBackup(settingsPath, "Pi settings");
+    writeSafeProfileFile({ agentDir: dirname(settingsPath) }, basename(backupPath), content, "Pi settings backup", { mode });
 }
-
 function writeSettings(settingsPath, value, { dryRun, existed }) {
-	const formatted = `${JSON.stringify(value, null, 2)}\n`;
-	if (dryRun) return undefined;
-
-	let backupPath;
-	if (existed) {
-		backupPath = backupPathFor(settingsPath);
-		writeExistingProfileBackup(settingsPath, backupPath);
-	}
-
-	writeSafeProfileFile({ agentDir: dirname(settingsPath) }, basename(settingsPath), formatted, "Pi settings");
-	return backupPath;
+    const formatted = `${JSON.stringify(value, null, 2)}\n`;
+    if (dryRun)
+        return undefined;
+    let backupPath;
+    if (existed) {
+        backupPath = backupPathFor(settingsPath);
+        writeExistingProfileBackup(settingsPath, backupPath);
+    }
+    writeSafeProfileFile({ agentDir: dirname(settingsPath) }, basename(settingsPath), formatted, "Pi settings");
+    return backupPath;
 }
-
 function log(args, message) {
-	if (!args.quiet) console.log(message);
+    if (!args.quiet)
+        console.log(message);
 }
-
 function main() {
-	const args = parseArgs(process.argv.slice(2));
-	if (args.help) {
-		console.log(usage());
-		return;
-	}
-
-	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()));
-	const defaultExtensionsPath = resolve(expandHomePath(args.defaultExtensionsPath || defaultDefaultExtensionsPath()));
-	const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath()));
-	assertNotNormalPiSettings(settingsPath);
-	const existed = existsSync(settingsPath);
-	const existing = readJsonFile(settingsPath, { missingValue: {} });
-	const rawDefaults = readJsonFile(defaultsPath);
-	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath, { allowMissing: true });
-	const disabledIds = disabledDefaultExtensionIds(existing, defaultExtensions);
-	const ensuredHarnessSource = args.packageSource || DEFAULT_PACKAGE_SOURCE;
-	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
-	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
-	applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
-	const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
-	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
-		force: args.force,
-		managedPackageIdentities: managedDefaultExtensionProvenance,
-	});
-	applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
-	applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });
-	applyDisabledDefaultExtensions(next, defaultExtensions, disabledIds, changes);
-	applyRetiredTlhDefaultPackageCleanup(
-		next,
-		changes,
-		withLegacyRetiredDefaultPackageIdentities(next, readDefaultExtensionProvenance(next).managedPackageIdentities),
-	);
-	applyDefaultExtensionLoadOrder(next, defaultExtensions, disabledIds, changes);
-	removeCriticalDisabledDefaultExtensionOptOuts(next, defaultExtensions, changes);
-	scrubGnosisSettings(next, changes);
-	purgeForceRemovedRetiredDefaultExtensionPackages(next, changes);
-	pruneContextCapDisabledDefaultExtension(next, changes);
-	pruneOracleDisabledDefaultExtension(next, changes);
-	syncDefaultExtensionProvenance(next, defaultExtensions, disabledIds, changes);
-
-	log(args, `Pi settings: ${settingsPath}`);
-	if (changes.length === 0) {
-		log(args, "No settings changes needed.");
-		return;
-	}
-
-	for (const change of changes) {
-		log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
-	}
-
-	if (args.dryRun) {
-		if (existed) log(args, `Would back up existing settings before writing.`);
-		log(args, "Dry run only; no settings were changed.");
-		return;
-	}
-
-	const backupPath = writeSettings(settingsPath, next, { dryRun: args.dryRun, existed });
-	if (backupPath) log(args, `Backed up previous settings to: ${backupPath}`);
-	log(args, "Settings updated.");
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+        console.log(usage());
+        return;
+    }
+    const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()) || defaultDefaultsPath());
+    const defaultExtensionsPath = resolve(expandHomePath(args.defaultExtensionsPath || defaultDefaultExtensionsPath()) || defaultDefaultExtensionsPath());
+    const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath()) || defaultTlhSettingsPath());
+    assertNotNormalPiSettings(settingsPath);
+    const existed = existsSync(settingsPath);
+    const existing = readJsonFile(settingsPath, { missingValue: {} });
+    const rawDefaults = readJsonFile(defaultsPath);
+    const defaultExtensions = readDefaultExtensions(defaultExtensionsPath, { allowMissing: true });
+    const disabledIds = disabledDefaultExtensionIds(existing, defaultExtensions);
+    const ensuredHarnessSource = args.packageSource || DEFAULT_PACKAGE_SOURCE;
+    const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
+    const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
+    applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
+    const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
+    const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
+        force: args.force,
+        managedPackageIdentities: managedDefaultExtensionProvenance,
+    });
+    applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
+    applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });
+    applyDisabledDefaultExtensions(next, defaultExtensions, disabledIds, changes);
+    applyRetiredTlhDefaultPackageCleanup(next, changes, withLegacyRetiredDefaultPackageIdentities(next, readDefaultExtensionProvenance(next).managedPackageIdentities));
+    applyDefaultExtensionLoadOrder(next, defaultExtensions, disabledIds, changes);
+    removeCriticalDisabledDefaultExtensionOptOuts(next, defaultExtensions, changes);
+    scrubGnosisSettings(next, changes);
+    purgeForceRemovedRetiredDefaultExtensionPackages(next, changes);
+    pruneContextCapDisabledDefaultExtension(next, changes);
+    pruneOracleDisabledDefaultExtension(next, changes);
+    syncDefaultExtensionProvenance(next, defaultExtensions, disabledIds, changes);
+    log(args, `Pi settings: ${settingsPath}`);
+    if (changes.length === 0) {
+        log(args, "No settings changes needed.");
+        return;
+    }
+    for (const change of changes) {
+        log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
+    }
+    if (args.dryRun) {
+        if (existed)
+            log(args, "Would back up existing settings before writing.");
+        log(args, "Dry run only; no settings were changed.");
+        return;
+    }
+    const backupPath = writeSettings(settingsPath, next, { dryRun: args.dryRun, existed });
+    if (backupPath)
+        log(args, `Backed up previous settings to: ${backupPath}`);
+    log(args, "Settings updated.");
 }
-
+function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
+}
 try {
-	main();
-} catch (error) {
-	console.error(`merge-settings: ${error.message}`);
-	process.exit(1);
+    main();
+}
+catch (error) {
+    console.error(`merge-settings: ${errorMessage(error)}`);
+    process.exit(1);
 }

--- a/scripts/merge-settings.mts
+++ b/scripts/merge-settings.mts
@@ -1,0 +1,761 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { basename, dirname, join, normalize, parse, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+import {
+	criticalDefaultExtensionOptOutIds,
+	defaultExtensionPackageIdentities,
+	disabledDefaultExtensionIds,
+	managedDefaultExtensionPackageIdentities,
+	packageIdentity,
+	packageSourceOf,
+	readDefaultExtensionProvenance,
+	readDefaultExtensions,
+	RETIRED_TLH_DEFAULT_PACKAGE_SOURCES,
+	repairTargetedDefaultExtensionLoadOrder,
+	setDefaultExtensionProvenance,
+	withLegacyRetiredDefaultPackageIdentities,
+} from "./lib/default-extensions.mjs";
+import type { DefaultExtensionEntry } from "./lib/default-extensions.mjs";
+import {
+	assertNotInNormalPiConfig,
+	assignOptionValue,
+	backupPathWithTimestamp,
+	defaultTlhSettingsPath,
+	expandHomePath,
+	readJsonFile,
+	readRegularFileForBackup,
+} from "./lib/tlh-install-utils.mjs";
+import { writeSafeProfileFile } from "./lib/tlh-safe-profile-write.mjs";
+
+interface CliArgs extends Record<string, unknown> {
+	defaultsPath?: string;
+	settingsPath?: string;
+	packageSource?: string;
+	defaultExtensionsPath?: string;
+	dryRun: boolean;
+	force: boolean;
+	quiet: boolean;
+	help: boolean;
+}
+
+type JsonObject = Record<string, unknown>;
+
+interface MergeOptions {
+	force: boolean;
+	path: string[];
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DEFAULT_PACKAGE_SOURCE = "git:github.com/diegopetrucci/the-last-harness";
+const TLH_CHANGELOG_SENTINEL = "9999.0.0";
+const HARNESS_PACKAGE_IDENTITY = packageIdentity(DEFAULT_PACKAGE_SOURCE);
+
+function usage(): string {
+	return `Usage: node scripts/merge-settings.mjs [defaults.json] [options]
+
+Merge installer defaults into The Last Harness isolated Pi settings without clobbering user values.
+
+Options:
+  --settings <path>        Settings file to update (default: ~/.the-last-harness/agent/settings.json, or PI_CODING_AGENT_DIR/settings.json)
+  --package-source <src>   Package source to ensure in settings.packages
+  --default-extensions <p> Default extension manifest to enable unless opted out
+  --dry-run                Print intended changes without writing
+  --force                  Overwrite scalar values from defaults
+  --quiet                  Only print errors
+  -h, --help               Show this help
+`;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+	const args: CliArgs = {
+		defaultsPath: undefined,
+		settingsPath: undefined,
+		packageSource: undefined,
+		defaultExtensionsPath: undefined,
+		dryRun: false,
+		force: false,
+		quiet: false,
+		help: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--dry-run") {
+			args.dryRun = true;
+			continue;
+		}
+		if (arg === "--force") {
+			args.force = true;
+			continue;
+		}
+		if (arg === "--quiet") {
+			args.quiet = true;
+			continue;
+		}
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+			continue;
+		}
+		const settingsIndex = assignOptionValue(args, "settingsPath", argv, index, "--settings");
+		if (settingsIndex !== undefined) {
+			index = settingsIndex;
+			continue;
+		}
+		const packageSourceIndex = assignOptionValue(args, "packageSource", argv, index, "--package-source");
+		if (packageSourceIndex !== undefined) {
+			index = packageSourceIndex;
+			continue;
+		}
+		const defaultExtensionsIndex = assignOptionValue(args, "defaultExtensionsPath", argv, index, "--default-extensions");
+		if (defaultExtensionsIndex !== undefined) {
+			index = defaultExtensionsIndex;
+			continue;
+		}
+		if (arg.startsWith("-")) {
+			throw new Error(`Unknown option: ${arg}`);
+		}
+		if (args.defaultsPath) {
+			throw new Error(`Unexpected extra argument: ${arg}`);
+		}
+		args.defaultsPath = arg;
+	}
+
+	return args;
+}
+
+function defaultDefaultsPath(): string {
+	return join(resolve(__dirname, ".."), "config", "settings.defaults.json");
+}
+
+function defaultDefaultExtensionsPath(): string {
+	return join(resolve(__dirname, ".."), "config", "default-extensions.json");
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function clone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function packageIdentityExists(packages: readonly unknown[], identity: string | undefined): boolean {
+	return Boolean(identity) && packages.some((entry) => packageIdentity(entry) === identity);
+}
+
+function isPinnedNpmSource(source: unknown): boolean {
+	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) !== source.trim();
+}
+
+function isUnpinnedNpmSource(source: unknown): boolean {
+	return typeof source === "string" && source.trim().startsWith("npm:") && packageIdentity(source) === source.trim();
+}
+
+function shouldMigrateManagedDefaultExtensionSource(
+	currentSource: unknown,
+	extension: DefaultExtensionEntry,
+	{ force, managedPackageIdentities = new Set<string>() }: { force: boolean; managedPackageIdentities?: Set<string> },
+): boolean {
+	if (force || extension.critical === true) return true;
+	const identity = packageIdentity(extension.source);
+	if (!identity || packageIdentity(currentSource) !== identity) return false;
+	if (!isPinnedNpmSource(extension.source)) return false;
+	if (isUnpinnedNpmSource(currentSource)) return true;
+	return managedPackageIdentities.has(identity);
+}
+
+function shouldMigrateDefaultExtensionReplacements(extension: DefaultExtensionEntry, { force }: { force: boolean }): boolean {
+	return force || extension.migrateReplacements === true;
+}
+
+function shouldEnsureDefaultExtensionSource(
+	existingPackages: readonly unknown[],
+	extension: DefaultExtensionEntry,
+	{ force }: { force: boolean },
+): boolean {
+	if (shouldMigrateDefaultExtensionReplacements(extension, { force })) return true;
+	if (packageIdentityExists(existingPackages, packageIdentity(extension.source))) return true;
+	return !extension.replaces.some((oldSource) => packageIdentityExists(existingPackages, packageIdentity(oldSource)));
+}
+
+function prepareDefaults(
+	defaults: JsonObject,
+	packageSource: string | undefined,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	existingSettings: unknown,
+	{ force }: { force: boolean },
+): JsonObject {
+	const next = clone(defaults);
+	next.lastChangelogVersion = TLH_CHANGELOG_SENTINEL;
+
+	// Strip the anthropic-auth warning suppression from the defaults clone when
+	// that extension is disabled, so the merge engine cannot re-introduce
+	// warnings.anthropicExtraUsage into an opted-out user's settings on update.
+	if (disabledIds.has("anthropic-auth")) {
+		const warnings = isPlainObject(next.warnings) ? next.warnings : undefined;
+		if (warnings?.anthropicExtraUsage !== undefined) {
+			delete warnings.anthropicExtraUsage;
+			if (Object.keys(warnings).length === 0) {
+				delete next.warnings;
+			}
+		}
+	}
+
+	const ensuredSource = packageSource || DEFAULT_PACKAGE_SOURCE;
+	const existingPackages = isPlainObject(existingSettings) && Array.isArray(existingSettings.packages) ? existingSettings.packages : [];
+	const ensuredPackages = [
+		ensuredSource,
+		...defaultExtensions
+			.filter((extension) => !disabledIds.has(extension.id))
+			.filter((extension) => shouldEnsureDefaultExtensionSource(existingPackages, extension, { force }))
+			.map((extension) => extension.source),
+	];
+	const ensuredIdentities = new Set(ensuredPackages.map(packageIdentity).filter((value): value is string => Boolean(value)));
+	const disabledIdentities = new Set(
+		defaultExtensions.filter((extension) => disabledIds.has(extension.id)).flatMap(defaultExtensionPackageIdentities),
+	);
+	const packages = Array.isArray(next.packages) ? next.packages : [];
+	next.packages = [
+		...ensuredPackages,
+		...packages.filter((entry) => {
+			const identity = packageIdentity(entry);
+			return !ensuredIdentities.has(identity || "") && !disabledIdentities.has(identity || "");
+		}),
+	];
+	return next;
+}
+
+function removePackageByIdentity(settings: JsonObject, identity: string | undefined): string | undefined {
+	if (!identity || !Array.isArray(settings.packages)) return undefined;
+	const index = settings.packages.findIndex((entry: unknown) => packageIdentity(entry) === identity);
+	if (index === -1) return undefined;
+	const [removed] = settings.packages.splice(index, 1);
+	return packageSourceOf(removed) || identity;
+}
+
+function removeDuplicatePackagesByIdentity(settings: JsonObject, identity: string | undefined): string[] {
+	if (!identity || !Array.isArray(settings.packages)) return [];
+	const removedSources: string[] = [];
+	let seen = false;
+	for (let index = 0; index < settings.packages.length;) {
+		if (packageIdentity(settings.packages[index]) !== identity) {
+			index += 1;
+			continue;
+		}
+		if (!seen) {
+			seen = true;
+			index += 1;
+			continue;
+		}
+		const [removed] = settings.packages.splice(index, 1);
+		removedSources.push(packageSourceOf(removed) || identity);
+	}
+	return removedSources;
+}
+
+function applyHarnessPackageDedupes(settings: JsonObject, ensuredSource: string, changes: string[]): void {
+	if (!Array.isArray(settings.packages)) return;
+	for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
+		changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
+	}
+}
+
+function applyReplacedDefaultExtensions(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+	{ force }: { force: boolean },
+): void {
+	if (!Array.isArray(settings.packages)) return;
+
+	for (const extension of defaultExtensions) {
+		if (!shouldMigrateDefaultExtensionReplacements(extension, { force })) continue;
+		if (disabledIds.has(extension.id)) continue;
+		const newIdentity = packageIdentity(extension.source);
+		for (const oldSource of extension.replaces) {
+			const oldIdentity = packageIdentity(oldSource);
+			if (!oldIdentity || oldIdentity === newIdentity) continue;
+			let removedSource: string | undefined;
+			while ((removedSource = removePackageByIdentity(settings, oldIdentity))) {
+				changes.push(`remove replaced default extension package: ${removedSource} -> ${extension.source}`);
+			}
+		}
+	}
+}
+
+function applyDefaultExtensionPackageDedupes(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+	{
+		force,
+		sourceUpdatedIdentities = new Set<string>(),
+	}: { force: boolean; sourceUpdatedIdentities?: Set<string> },
+): void {
+	if (!Array.isArray(settings.packages)) return;
+
+	for (const extension of defaultExtensions) {
+		const identity = packageIdentity(extension.source);
+		if (!shouldMigrateDefaultExtensionReplacements(extension, { force }) && !sourceUpdatedIdentities.has(identity || "")) continue;
+		if (disabledIds.has(extension.id)) continue;
+		const removedSources = removeDuplicatePackagesByIdentity(settings, identity);
+		for (const removedSource of removedSources) {
+			changes.push(`remove duplicate default extension package: ${removedSource} (same identity as ${extension.source})`);
+		}
+	}
+}
+
+function applyDefaultExtensionSourceUpdates(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+	{
+		force,
+		managedPackageIdentities = new Set<string>(),
+	}: { force: boolean; managedPackageIdentities?: Set<string> },
+): Set<string> {
+	const updatedIdentities = new Set<string>();
+	if (!Array.isArray(settings.packages)) return updatedIdentities;
+
+	for (const extension of defaultExtensions) {
+		if (disabledIds.has(extension.id)) continue;
+		const identity = packageIdentity(extension.source);
+		if (!identity) continue;
+		const index = settings.packages.findIndex((entry: unknown) => packageIdentity(entry) === identity);
+		if (index === -1) continue;
+
+		const current = settings.packages[index];
+		const currentSource = packageSourceOf(current);
+		if (!currentSource) continue;
+		if (!shouldMigrateManagedDefaultExtensionSource(currentSource, extension, { force, managedPackageIdentities })) continue;
+
+		const sourceNeedsUpdate = currentSource !== extension.source;
+		const removesCriticalExtensionFilter = extension.critical === true
+			&& isPlainObject(current)
+			&& Object.hasOwn(current, "extensions");
+		if (!sourceNeedsUpdate && !removesCriticalExtensionFilter) continue;
+
+		if (isPlainObject(current)) {
+			const next: JsonObject = { ...clone(current), source: extension.source };
+			if (removesCriticalExtensionFilter) delete next.extensions;
+			settings.packages[index] = Object.keys(next).length === 1 && typeof next.source === "string"
+				? next.source
+				: next;
+		} else {
+			settings.packages[index] = extension.source;
+		}
+		if (sourceNeedsUpdate) {
+			changes.push(`update default extension package source: ${currentSource} -> ${extension.source}`);
+		}
+		if (removesCriticalExtensionFilter) {
+			changes.push(`remove critical default extension package filter: ${extension.id}`);
+		}
+		updatedIdentities.add(identity);
+	}
+
+	return updatedIdentities;
+}
+
+function applyDisabledDefaultExtensions(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+): void {
+	if (disabledIds.size === 0 || !Array.isArray(settings.packages)) return;
+
+	for (const extension of defaultExtensions) {
+		if (!disabledIds.has(extension.id)) continue;
+		const removedSources: string[] = [];
+		for (const identity of defaultExtensionPackageIdentities(extension)) {
+			let removedSource: string | undefined;
+			while ((removedSource = removePackageByIdentity(settings, identity))) {
+				removedSources.push(removedSource);
+			}
+		}
+		if (removedSources.length === 0) continue;
+
+		changes.push(`remove disabled default extension package: ${extension.id}`);
+	}
+}
+
+function applyRetiredTlhDefaultPackageCleanup(settings: JsonObject, changes: string[], managedPackageIdentities: Set<string>): void {
+	if (!Array.isArray(settings.packages)) return;
+
+	for (const source of RETIRED_TLH_DEFAULT_PACKAGE_SOURCES) {
+		const identity = packageIdentity(source);
+		if (!identity || !managedPackageIdentities.has(identity)) continue;
+		let removedSource: string | undefined;
+		while ((removedSource = removePackageByIdentity(settings, identity))) {
+			changes.push(`remove retired TLH default package: ${removedSource}`);
+		}
+		managedPackageIdentities.delete(identity);
+	}
+}
+
+function applyDefaultExtensionLoadOrder(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+): void {
+	const loadOrderRepair = repairTargetedDefaultExtensionLoadOrder(settings, defaultExtensions, disabledIds);
+	if (!loadOrderRepair) return;
+	changes.push(
+		`reorder targeted default extension packages for load order: ${loadOrderRepair.previous.join(", ")} -> ${loadOrderRepair.next.join(", ")}`,
+	);
+}
+
+// Sources of retired default extensions that TLH now removes unconditionally
+// from isolated settings because they should no longer stay installed after
+// install/update reruns.
+const FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES = Object.freeze([
+	"npm:@diegopetrucci/pi-context-cap",
+	"npm:@diegopetrucci/pi-permission-gate",
+	"npm:@diegopetrucci/pi-confirm-destructive",
+	"npm:@diegopetrucci/pi-oracle",
+]);
+
+function purgeForceRemovedRetiredDefaultExtensionPackages(settings: JsonObject, changes: string[]): void {
+	if (!Array.isArray(settings.packages)) return;
+	for (const source of FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES) {
+		const identity = packageIdentity(source);
+		if (!identity) continue;
+		while (removePackageByIdentity(settings, identity)) {
+			changes.push(`force-remove retired default extension package: ${source}`);
+		}
+	}
+}
+
+function pruneContextCapDisabledDefaultExtension(settings: JsonObject, changes: string[]): void {
+	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
+	const values = settings.tlh.disabledDefaultExtensions;
+	if (!Array.isArray(values)) return;
+	const nextValues = values.filter((value: unknown) => !(typeof value === "string" && value.trim() === "context-cap"));
+	if (nextValues.length === values.length) return;
+	settings.tlh.disabledDefaultExtensions = nextValues;
+	changes.push("remove stale context-cap opt-out from tlh.disabledDefaultExtensions");
+}
+
+function pruneOracleDisabledDefaultExtension(settings: JsonObject, changes: string[]): void {
+	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
+	const values = settings.tlh.disabledDefaultExtensions;
+	if (!Array.isArray(values)) return;
+	const nextValues = values.filter((value: unknown) => !(typeof value === "string" && value.trim() === "oracle"));
+	if (nextValues.length === values.length) return;
+	settings.tlh.disabledDefaultExtensions = nextValues;
+	changes.push("remove stale oracle opt-out from tlh.disabledDefaultExtensions");
+}
+
+function scrubGnosisSettings(settings: JsonObject, changes: string[]): void {
+	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
+	if (!Object.hasOwn(settings.tlh, "gnosis")) return;
+	delete settings.tlh.gnosis;
+	changes.push("remove tlh.gnosis (one-time cleanup)");
+}
+
+function removeCriticalDisabledDefaultExtensionOptOuts(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	changes: string[],
+): void {
+	if (!isPlainObject(settings) || !isPlainObject(settings.tlh)) return;
+	const values = settings.tlh.disabledDefaultExtensions;
+	if (!Array.isArray(values)) return;
+
+	const criticalIds = criticalDefaultExtensionOptOutIds(defaultExtensions);
+	if (criticalIds.size === 0) return;
+
+	const nextValues = values.filter((value: unknown) => !(typeof value === "string" && criticalIds.has(value.trim())));
+	if (nextValues.length === values.length) return;
+
+	settings.tlh.disabledDefaultExtensions = nextValues;
+	changes.push("remove invalid critical default extension opt-out");
+}
+
+function sameIdentitySets(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+	if (left.size !== right.size) return false;
+	for (const value of left) {
+		if (!right.has(value)) return false;
+	}
+	return true;
+}
+
+function syncDefaultExtensionProvenance(
+	settings: JsonObject,
+	defaultExtensions: readonly DefaultExtensionEntry[],
+	disabledIds: Set<string>,
+	changes: string[],
+): void {
+	const previous = readDefaultExtensionProvenance(settings);
+	const tlh = isPlainObject(settings) && isPlainObject(settings.tlh) ? settings.tlh : undefined;
+	const previousRaw = tlh && Object.hasOwn(tlh, "defaultExtensionProvenance")
+		? JSON.stringify(tlh.defaultExtensionProvenance)
+		: undefined;
+	const nextManagedIdentities = managedDefaultExtensionPackageIdentities(settings, defaultExtensions, disabledIds);
+	if (!setDefaultExtensionProvenance(settings, nextManagedIdentities)) return;
+	const nextTlh = isPlainObject(settings.tlh) ? settings.tlh : undefined;
+	const nextRaw = JSON.stringify(nextTlh?.defaultExtensionProvenance);
+	if (previousRaw !== nextRaw || !previous.exists || !sameIdentitySets(previous.managedPackageIdentities, nextManagedIdentities)) {
+		changes.push("update TLH default extension provenance metadata");
+	}
+}
+
+function mergeSettings(existing: unknown, defaults: unknown, { force }: { force: boolean }): { next: JsonObject; changes: string[] } {
+	if (!isPlainObject(existing)) {
+		throw new Error("Existing settings must be a JSON object");
+	}
+	if (!isPlainObject(defaults)) {
+		throw new Error("Default settings must be a JSON object");
+	}
+
+	const next = clone(existing);
+	const changes: string[] = [];
+	mergeObject(next, defaults, changes, { force, path: [] });
+	return { next, changes };
+}
+
+function isPersistentTelemetryOptOut(path: readonly string[], currentValue: unknown, defaultValue: unknown): boolean {
+	// Telemetry opt-outs are user-owned and must survive installer reruns and forced updates.
+	return path.join(".") === "tlh.telemetry.enabled" && currentValue === false && defaultValue === true;
+}
+
+function isInstallerOwnedSetting(path: readonly string[]): boolean {
+	return path.join(".") === "lastChangelogVersion";
+}
+
+function mergeObject(target: JsonObject, defaults: JsonObject, changes: string[], options: MergeOptions): void {
+	for (const [key, value] of Object.entries(defaults)) {
+		const path = [...options.path, key];
+		const label = path.join(".");
+
+		if (key === "packages" && options.path.length === 0) {
+			mergePackages(target, value, changes);
+			continue;
+		}
+
+		if (target[key] === undefined) {
+			target[key] = clone(value);
+			changes.push(`set ${label}`);
+			continue;
+		}
+
+		if (Array.isArray(value) && Array.isArray(target[key])) {
+			mergeArray(target[key], value, changes, { label, path });
+			continue;
+		}
+
+		if (isPlainObject(value) && isPlainObject(target[key])) {
+			mergeObject(target[key], value, changes, { ...options, path });
+			continue;
+		}
+
+		if (isPersistentTelemetryOptOut(path, target[key], value)) {
+			continue;
+		}
+
+		if ((options.force || isInstallerOwnedSetting(path)) && JSON.stringify(target[key]) !== JSON.stringify(value)) {
+			target[key] = clone(value);
+			changes.push(`overwrite ${label}`);
+		}
+	}
+}
+
+function mergePackages(target: JsonObject, packageDefaults: unknown, changes: string[]): void {
+	if (!Array.isArray(packageDefaults)) {
+		throw new Error("Default settings field 'packages' must be an array");
+	}
+	if (target.packages === undefined) {
+		target.packages = [];
+	}
+	if (!Array.isArray(target.packages)) {
+		throw new Error("Existing settings field 'packages' must be an array if present");
+	}
+
+	const seen = new Map<string, number>();
+	target.packages.forEach((entry: unknown, index: number) => {
+		const identity = packageIdentity(entry);
+		if (identity && !seen.has(identity)) seen.set(identity, index);
+	});
+
+	for (const entry of packageDefaults) {
+		const source = packageSourceOf(entry);
+		const identity = packageIdentity(entry);
+		if (!source || !identity) {
+			throw new Error(`Invalid package entry in defaults: ${JSON.stringify(entry)}`);
+		}
+		if (seen.has(identity)) {
+			const existingIndex = seen.get(identity) as number;
+			const existingSource = packageSourceOf(target.packages[existingIndex]);
+			if (identity === HARNESS_PACKAGE_IDENTITY && existingSource !== source) {
+				target.packages[existingIndex] = clone(entry);
+				changes.push(`replace packages: ${existingSource} -> ${source}`);
+			}
+			continue;
+		}
+		target.packages.push(clone(entry));
+		seen.set(identity, target.packages.length - 1);
+		changes.push(`append packages: ${source}`);
+	}
+}
+
+function normalizeAgentDirPath(value: string): string {
+	const normalized = normalize(value);
+	const root = parse(normalized).root;
+	let stripped = normalized;
+	while (stripped.length > root.length && stripped.endsWith(sep)) {
+		stripped = stripped.slice(0, -sep.length);
+	}
+	return stripped;
+}
+
+function arrayMergeKey(item: unknown, path: readonly string[]): string {
+	if (path.join(".") === "subagents.agentDirs" && typeof item === "string") {
+		return `path:${normalizeAgentDirPath(item)}`;
+	}
+	return `json:${JSON.stringify(item)}`;
+}
+
+function mergeArray(
+	targetArray: unknown[],
+	defaultArray: readonly unknown[],
+	changes: string[],
+	{ label, path }: { label: string; path: readonly string[] },
+): void {
+	const seen = new Set(targetArray.map((item) => arrayMergeKey(item, path)));
+	for (const item of defaultArray) {
+		const key = arrayMergeKey(item, path);
+		if (seen.has(key)) continue;
+		targetArray.push(clone(item));
+		seen.add(key);
+		changes.push(`append ${label}`);
+	}
+}
+
+function backupPathFor(settingsPath: string): string {
+	return backupPathWithTimestamp(settingsPath);
+}
+
+function assertNotNormalPiSettings(settingsPath: string): void {
+	assertNotInNormalPiConfig(
+		settingsPath,
+		`Refusing to modify normal Pi config from The Last Harness installer: ${settingsPath}`,
+	);
+}
+
+function writeExistingProfileBackup(settingsPath: string, backupPath: string): void {
+	const { content, mode } = readRegularFileForBackup(settingsPath, "Pi settings");
+	writeSafeProfileFile(
+		{ agentDir: dirname(settingsPath) },
+		basename(backupPath),
+		content,
+		"Pi settings backup",
+		{ mode },
+	);
+}
+
+function writeSettings(
+	settingsPath: string,
+	value: JsonObject,
+	{ dryRun, existed }: { dryRun: boolean; existed: boolean },
+): string | undefined {
+	const formatted = `${JSON.stringify(value, null, 2)}\n`;
+	if (dryRun) return undefined;
+
+	let backupPath: string | undefined;
+	if (existed) {
+		backupPath = backupPathFor(settingsPath);
+		writeExistingProfileBackup(settingsPath, backupPath);
+	}
+
+	writeSafeProfileFile({ agentDir: dirname(settingsPath) }, basename(settingsPath), formatted, "Pi settings");
+	return backupPath;
+}
+
+function log(args: CliArgs, message: string): void {
+	if (!args.quiet) console.log(message);
+}
+
+function main(): void {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help) {
+		console.log(usage());
+		return;
+	}
+
+	const defaultsPath = resolve(expandHomePath(args.defaultsPath || defaultDefaultsPath()) || defaultDefaultsPath());
+	const defaultExtensionsPath = resolve(
+		expandHomePath(args.defaultExtensionsPath || defaultDefaultExtensionsPath()) || defaultDefaultExtensionsPath(),
+	);
+	const settingsPath = resolve(expandHomePath(args.settingsPath || defaultTlhSettingsPath()) || defaultTlhSettingsPath());
+	assertNotNormalPiSettings(settingsPath);
+	const existed = existsSync(settingsPath);
+	const existing = readJsonFile<JsonObject>(settingsPath, { missingValue: {} });
+	const rawDefaults = readJsonFile<JsonObject>(defaultsPath);
+	const defaultExtensions = readDefaultExtensions(defaultExtensionsPath, { allowMissing: true });
+	const disabledIds = disabledDefaultExtensionIds(existing, defaultExtensions);
+	const ensuredHarnessSource = args.packageSource || DEFAULT_PACKAGE_SOURCE;
+	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
+	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
+	applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
+	const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
+	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
+		force: args.force,
+		managedPackageIdentities: managedDefaultExtensionProvenance,
+	});
+	applyReplacedDefaultExtensions(next, defaultExtensions, disabledIds, changes, { force: args.force });
+	applyDefaultExtensionPackageDedupes(next, defaultExtensions, disabledIds, changes, { force: args.force, sourceUpdatedIdentities });
+	applyDisabledDefaultExtensions(next, defaultExtensions, disabledIds, changes);
+	applyRetiredTlhDefaultPackageCleanup(
+		next,
+		changes,
+		withLegacyRetiredDefaultPackageIdentities(next, readDefaultExtensionProvenance(next).managedPackageIdentities),
+	);
+	applyDefaultExtensionLoadOrder(next, defaultExtensions, disabledIds, changes);
+	removeCriticalDisabledDefaultExtensionOptOuts(next, defaultExtensions, changes);
+	scrubGnosisSettings(next, changes);
+	purgeForceRemovedRetiredDefaultExtensionPackages(next, changes);
+	pruneContextCapDisabledDefaultExtension(next, changes);
+	pruneOracleDisabledDefaultExtension(next, changes);
+	syncDefaultExtensionProvenance(next, defaultExtensions, disabledIds, changes);
+
+	log(args, `Pi settings: ${settingsPath}`);
+	if (changes.length === 0) {
+		log(args, "No settings changes needed.");
+		return;
+	}
+
+	for (const change of changes) {
+		log(args, `${args.dryRun ? "Would" : "Will"} ${change}`);
+	}
+
+	if (args.dryRun) {
+		if (existed) log(args, "Would back up existing settings before writing.");
+		log(args, "Dry run only; no settings were changed.");
+		return;
+	}
+
+	const backupPath = writeSettings(settingsPath, next, { dryRun: args.dryRun, existed });
+	if (backupPath) log(args, `Backed up previous settings to: ${backupPath}`);
+	log(args, "Settings updated.");
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(`merge-settings: ${errorMessage(error)}`);
+	process.exit(1);
+}

--- a/tests/runtime-typescript-infra.test.mjs
+++ b/tests/runtime-typescript-infra.test.mjs
@@ -117,6 +117,15 @@ test("runtime TypeScript helper covers converted installer libraries", () => {
 	}
 });
 
+test("runtime TypeScript helper tracks converted top-level CLIs", () => {
+	const convertedCliScripts = ["scripts/merge-keybindings", "scripts/merge-settings"];
+
+	for (const path of convertedCliScripts) {
+		assert.equal(existsSync(join(repoRoot, `${path}.mts`)), true, `${path}.mts should exist`);
+		assert.equal(existsSync(join(repoRoot, `${path}.mjs`)), true, `${path}.mjs should exist`);
+	}
+});
+
 test("runtime TypeScript helper builds, checks, and typechecks temporary fixtures", () => {
 	const fixture = createRuntimeFixture('export function greet(name: string) {\n\treturn `hello ${name}`;\n}\n');
 


### PR DESCRIPTION
## Summary
- add runtime TypeScript sources for `merge-keybindings` and `merge-settings`
- regenerate their committed `.mjs` CLI outputs
- track converted top-level CLIs in runtime TypeScript infra tests
- add ticket files for the remaining top-level CLI migration sequence

## Install this branch
```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/typescript-merge-config-clis/install.sh | bash -s -- --ref typescript-merge-config-clis --track ref
```

## Validation
- `npm run validate`
