### PR TITLE
Grant write permissions to Claude review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

Claude Code review *was* triggering on PRs but never posted anything back. On PR #199 the `Claude Code Review` run completed successfully (`is_error: false`, 10 turns, ~\$3.63 spent) but reported `permission_denials_count: 35` and `No buffered inline comments` — and the PR received zero Claude reviews/comments.

Root cause: both workflows scoped `GITHUB_TOKEN` to `pull-requests: read` / `issues: read`. The action uses `GITHUB_TOKEN` to post reviews and comments, so every write attempt was denied. The job still exited green because the Claude run itself succeeded; only the posting silently failed.

## Fix

Bump `pull-requests` and `issues` to `write` in:
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude.yml`

`id-token: write` and (in `claude.yml`) `actions: read` are unchanged.

## Verification

- YAML validates for both files.
- Once merged, opening/syncing a PR should produce a posted Claude review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)