### PR TITLE
Migrate extension helpers to TypeScript

### DIFF
--- a/.tickets/tlha-akfh.md
+++ b/.tickets/tlha-akfh.md
@@ -1,6 +1,6 @@
 ---
 id: tlha-akfh
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-27T07:37:14Z

--- a/.tickets/tlha-xn6b.md
+++ b/.tickets/tlha-xn6b.md
@@ -1,7 +1,7 @@
 ---
 id: tlha-xn6b
-status: open
-deps: [tlha-fcjg]
+status: closed
+deps: []
 links: []
 created: 2026-06-27T07:37:14Z
 type: task

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -20,7 +20,7 @@ import { installTlhPackageUpdateNotificationOverride } from "./the-last-harness/
 import { registerTlhPrimaryAgentRuntime } from "./the-last-harness/primary-agent-runtime.js";
 import { collectStartupResources } from "./the-last-harness/resources.js";
 import { getTlhStartupTip } from "./the-last-harness/startup-tip.js";
-import { createTlhSubscriptionUsageService } from "./the-last-harness/subscription-usage.mjs";
+import { createTlhSubscriptionUsageService } from "./the-last-harness/subscription-usage.js";
 import { registerTokensCommand } from "./the-last-harness/tokens.js";
 import { getTlhUsageLimitsConfig, registerUsageCommand, shouldShowTlhUsageWeekly } from "./the-last-harness/usage-limits.js";
 import { getTlhHeaderUpdate, maybeNotifyAvailableTlhUpdate } from "./the-last-harness/update-check.js";

--- a/extensions/the-last-harness/footer-first-line.ts
+++ b/extensions/the-last-harness/footer-first-line.ts
@@ -1,5 +1,5 @@
 import type { GitStatusSnapshot, PullRequestSnapshot } from "./footer-git-cache.js";
-import { formatTlhGitFooterSegments } from "./footer-git.mjs";
+import { formatTlhGitFooterSegments } from "./footer-git.js";
 
 /** Bullet divider used between segments on the TLH footer's first line. */
 export const FOOTER_FIRST_LINE_SEPARATOR = " • ";

--- a/extensions/the-last-harness/footer-git-cache.ts
+++ b/extensions/the-last-harness/footer-git-cache.ts
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process";
-import { parseGitStatusPorcelainV2 } from "./footer-git.mjs";
+import { parseGitStatusPorcelainV2 } from "./footer-git.js";
 
 /**
- * Snapshot shape used by `formatTlhGitFooterSegments` in `./footer-git.mjs`.
+ * Snapshot shape used by `formatTlhGitFooterSegments` in `./footer-git.js`.
  * Kept structurally compatible with the return value of `parseGitStatusPorcelainV2`.
  */
 export type GitStatusSnapshot = {

--- a/extensions/the-last-harness/footer-git.ts
+++ b/extensions/the-last-harness/footer-git.ts
@@ -1,7 +1,27 @@
 const BRANCH_HEAD_PREFIX = "# branch.head ";
 const BRANCH_AB_PREFIX = "# branch.ab ";
 
-function createEmptyGitStatus() {
+export type GitStatusSnapshot = {
+	branch?: string;
+	staged: number;
+	unstaged: number;
+	untracked: number;
+	conflict: number;
+	ahead: number;
+	behind: number;
+};
+
+export type PullRequestSnapshot = {
+	number?: number | string;
+	state?: string;
+	isDraft?: boolean;
+	url?: string;
+	title?: string;
+};
+
+type DisplayGitStatusSnapshot = Partial<GitStatusSnapshot> | null | undefined;
+
+function createEmptyGitStatus(): GitStatusSnapshot {
 	return {
 		branch: undefined,
 		staged: 0,
@@ -13,11 +33,11 @@ function createEmptyGitStatus() {
 	};
 }
 
-function positiveCount(value) {
-	return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+function positiveCount(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
 
-function addTrackedStatusCounts(status, xy) {
+function addTrackedStatusCounts(status: GitStatusSnapshot, xy: string): void {
 	if (xy.length !== 2) {
 		return;
 	}
@@ -29,7 +49,7 @@ function addTrackedStatusCounts(status, xy) {
 	}
 }
 
-function parseBranchAheadBehind(line, status) {
+function parseBranchAheadBehind(line: string, status: GitStatusSnapshot): void {
 	const match = /^# branch\.ab \+(\d+) -(\d+)$/.exec(line);
 	if (!match) {
 		return;
@@ -38,12 +58,12 @@ function parseBranchAheadBehind(line, status) {
 	status.behind = Number.parseInt(match[2], 10);
 }
 
-function normalizeBranchHead(value) {
+function normalizeBranchHead(value: string): string {
 	const branch = value.trim();
 	return branch === "(detached)" ? "detached" : branch;
 }
 
-export function parseGitStatusPorcelainV2(output) {
+export function parseGitStatusPorcelainV2(output: unknown): GitStatusSnapshot {
 	const status = createEmptyGitStatus();
 	if (typeof output !== "string") {
 		return status;
@@ -83,13 +103,13 @@ export function parseGitStatusPorcelainV2(output) {
 	return status;
 }
 
-export function formatGitStatusFooterSegment(status) {
+export function formatGitStatusFooterSegment(status: DisplayGitStatusSnapshot): string | undefined {
 	if (!status) {
 		return undefined;
 	}
 
-	const parts = [];
-	const indicators = [
+	const parts: string[] = [];
+	const indicators: ReadonlyArray<readonly [string, number]> = [
 		["!", positiveCount(status.conflict)],
 		["+", positiveCount(status.staged)],
 		["~", positiveCount(status.unstaged)],
@@ -107,9 +127,9 @@ export function formatGitStatusFooterSegment(status) {
 	return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
-export function formatPullRequestFooterSegment(pullRequest) {
+export function formatPullRequestFooterSegment(pullRequest: PullRequestSnapshot | null | undefined): string | undefined {
 	const value = pullRequest?.number;
-	if (Number.isSafeInteger(value) && value > 0) {
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
 		return `PR #${value}`;
 	}
 	if (typeof value === "string") {
@@ -121,8 +141,11 @@ export function formatPullRequestFooterSegment(pullRequest) {
 	return undefined;
 }
 
-export function formatTlhGitFooterSegments(status, pullRequest) {
-	const segments = [];
+export function formatTlhGitFooterSegments(
+	status: DisplayGitStatusSnapshot,
+	pullRequest?: PullRequestSnapshot | null,
+): string[] {
+	const segments: string[] = [];
 	const branch = typeof status?.branch === "string" ? status.branch.trim() : "";
 	if (branch) {
 		segments.push(branch);

--- a/extensions/the-last-harness/subscription-usage.ts
+++ b/extensions/the-last-harness/subscription-usage.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import type { TlhSubscriptionUsageProvider, TlhSubscriptionUsageSnapshot, TlhSubscriptionUsageWindow } from "./types.js";
+
 export const TLH_SUBSCRIPTION_USAGE_OPENAI_CODEX_URL = "https://chatgpt.com/backend-api/wham/usage";
 export const TLH_SUBSCRIPTION_USAGE_ANTHROPIC_URL = "https://api.anthropic.com/api/oauth/usage";
 export const TLH_SUBSCRIPTION_USAGE_ANTHROPIC_BETA = "oauth-2025-04-20";
@@ -7,16 +9,75 @@ export const TLH_SUBSCRIPTION_USAGE_CACHE_TTL_MS = 60_000;
 export const TLH_SUBSCRIPTION_USAGE_MIN_FETCH_INTERVAL_MS = 60_000;
 export const TLH_SUBSCRIPTION_USAGE_TIMEOUT_MS = 3_000;
 
-const SUPPORTED_PROVIDERS = new Set(["openai-codex", "anthropic"]);
-const ACCOUNT_ID_KEYS = ["accountId", "account_id", "chatgptAccountId", "chatgpt_account_id"];
-const USAGE_PERCENT_KEYS = ["used_percent", "usedPercent", "utilization"];
-const WINDOW_DURATION_SECONDS_KEYS = ["limit_window_seconds", "limitWindowSeconds"];
+const SUPPORTED_PROVIDERS = new Set<TlhSubscriptionUsageProvider>(["openai-codex", "anthropic"]);
+const ACCOUNT_ID_KEYS = ["accountId", "account_id", "chatgptAccountId", "chatgpt_account_id"] as const;
+const USAGE_PERCENT_KEYS = ["used_percent", "usedPercent", "utilization"] as const;
+const WINDOW_DURATION_SECONDS_KEYS = ["limit_window_seconds", "limitWindowSeconds"] as const;
 
-function asObject(value) {
-	return value && typeof value === "object" && !Array.isArray(value) ? value : undefined;
+type JsonRecord = Record<string, unknown>;
+type TlhSubscriptionUsageFetch = typeof globalThis.fetch;
+type ResponseLike = {
+	ok?: boolean;
+	json?: (() => Promise<unknown>) | (() => unknown);
+};
+type TlhSubscriptionUsageTarget = {
+	provider?: unknown;
+	accessToken?: unknown;
+	accountId?: string;
+};
+type TlhSubscriptionUsageFetchOptions = {
+	fetch?: TlhSubscriptionUsageFetch;
+	nowMs?: number;
+	timeoutMs?: number;
+};
+type TlhSubscriptionUsageContext = {
+	model?: { provider?: unknown };
+	modelRegistry?: TlhSubscriptionUsageModelRegistry;
+};
+type TlhSubscriptionUsageModelRegistry = {
+	isUsingOAuth?(model: unknown): boolean;
+	getApiKeyForProvider?(provider: string): Promise<unknown> | unknown;
+	authStorage?: unknown;
+};
+type EligibleProviderContext = {
+	status: "eligible";
+	model: TlhSubscriptionUsageContext["model"];
+	provider: TlhSubscriptionUsageProvider;
+	modelRegistry: TlhSubscriptionUsageModelRegistry;
+	credential: JsonRecord;
+};
+type ResolvedProviderContext =
+	| EligibleProviderContext
+	| { status: "unsupported"; provider: unknown }
+	| { status: "ineligible"; provider: TlhSubscriptionUsageProvider }
+	| { status: "transient-unavailable"; provider: TlhSubscriptionUsageProvider };
+type CredentialResult =
+	| { status: "ok"; credential: JsonRecord | undefined }
+	| { status: "transient-unavailable" };
+type CredentialCacheTarget = {
+	provider: TlhSubscriptionUsageProvider;
+	accountId?: string;
+	cacheKey: string;
+};
+type ResolvedTargetResult =
+	| { status: "resolved"; target: CredentialCacheTarget & { accessToken: string } }
+	| { status: "transient-unavailable" }
+	| { status: "ineligible" }
+	| { status: "mismatch" };
+
+export type TlhSubscriptionUsageServiceOptions = {
+	fetch?: TlhSubscriptionUsageFetch;
+	now?: () => number;
+	cacheTtlMs?: number;
+	minFetchIntervalMs?: number;
+	timeoutMs?: number;
+};
+
+function asObject(value: unknown): JsonRecord | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : undefined;
 }
 
-function finiteNumber(value) {
+function finiteNumber(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isFinite(value)) {
 		return value;
 	}
@@ -27,12 +88,12 @@ function finiteNumber(value) {
 	return undefined;
 }
 
-function positiveNumber(value) {
+function positiveNumber(value: unknown): number | undefined {
 	const parsed = finiteNumber(value);
 	return parsed !== undefined && parsed >= 0 ? parsed : undefined;
 }
 
-function pickNumber(source, keys) {
+function pickNumber(source: JsonRecord | undefined, keys: readonly string[]): number | undefined {
 	for (const key of keys) {
 		const value = positiveNumber(source?.[key]);
 		if (value !== undefined) {
@@ -42,7 +103,7 @@ function pickNumber(source, keys) {
 	return undefined;
 }
 
-function pickFiniteNumber(source, keys) {
+function pickFiniteNumber(source: JsonRecord | undefined, keys: readonly string[]): number | undefined {
 	for (const key of keys) {
 		const value = finiteNumber(source?.[key]);
 		if (value !== undefined) {
@@ -52,7 +113,7 @@ function pickFiniteNumber(source, keys) {
 	return undefined;
 }
 
-function pickString(source, keys) {
+function pickString(source: JsonRecord | undefined, keys: readonly string[]): string | undefined {
 	for (const key of keys) {
 		const value = source?.[key];
 		if (typeof value === "string" && value.trim()) {
@@ -65,25 +126,25 @@ function pickString(source, keys) {
 // Stable, one-way fingerprint of a bearer access token. Used in cache keys
 // only when no account id is available; raw bearer material is never stored in
 // usage service state or returned in snapshots.
-function accessTokenFingerprint(accessToken) {
+function accessTokenFingerprint(accessToken: unknown): string | undefined {
 	if (typeof accessToken !== "string" || !accessToken) {
 		return undefined;
 	}
 	return createHash("sha256").update(accessToken).digest("hex");
 }
 
-function clampPercent(value) {
+function clampPercent(value: number): number {
 	return Math.max(0, Math.min(100, Math.round(value * 10) / 10));
 }
 
-function normalizeCount(value) {
+function normalizeCount(value: number | undefined): number | undefined {
 	if (value === undefined) {
 		return undefined;
 	}
 	return Math.round(value * 1000) / 1000;
 }
 
-function normalizeIsoTime(value) {
+function normalizeIsoTime(value: unknown): string | undefined {
 	if (typeof value === "string" && value.trim()) {
 		const ms = Date.parse(value);
 		return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
@@ -96,17 +157,24 @@ function normalizeIsoTime(value) {
 	return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
 }
 
-function resetAtFromRelativeSeconds(source, nowMs) {
-	const seconds = pickNumber(source, ["seconds_until_reset", "reset_seconds", "resetAfterSeconds", "reset_after_seconds", "resetsInSeconds", "resets_in_seconds"]);
+function resetAtFromRelativeSeconds(source: JsonRecord, nowMs: number): string | undefined {
+	const seconds = pickNumber(source, [
+		"seconds_until_reset",
+		"reset_seconds",
+		"resetAfterSeconds",
+		"reset_after_seconds",
+		"resetsInSeconds",
+		"resets_in_seconds",
+	]);
 	return seconds !== undefined ? new Date(nowMs + seconds * 1000).toISOString() : undefined;
 }
 
-function normalizeWindowDurationMs(source) {
+function normalizeWindowDurationMs(source: JsonRecord): number | undefined {
 	const seconds = pickNumber(source, WINDOW_DURATION_SECONDS_KEYS);
 	return seconds !== undefined ? Math.round(seconds * 1000) : undefined;
 }
 
-function normalizeResetTime(source, nowMs) {
+function normalizeResetTime(source: JsonRecord, nowMs: number): string | undefined {
 	return (
 		normalizeIsoTime(source.reset_at) ??
 		normalizeIsoTime(source.resetAt) ??
@@ -120,7 +188,12 @@ function normalizeResetTime(source, nowMs) {
 	);
 }
 
-function normalizeUsageWindow(source, key, label, nowMs) {
+function normalizeUsageWindow(
+	source: unknown,
+	key: string,
+	label: string,
+	nowMs: number,
+): TlhSubscriptionUsageWindow | undefined {
 	const window = asObject(source);
 	if (!window) {
 		return undefined;
@@ -184,7 +257,7 @@ function normalizeUsageWindow(source, key, label, nowMs) {
 		limit = used + remaining;
 	}
 
-	const normalized = { key, label };
+	const normalized: TlhSubscriptionUsageWindow = { key, label };
 	const normalizedUsed = normalizeCount(used);
 	const normalizedLimit = normalizeCount(limit);
 	const normalizedRemaining = normalizeCount(remaining);
@@ -212,22 +285,30 @@ function normalizeUsageWindow(source, key, label, nowMs) {
 	return Object.keys(normalized).length > 2 ? normalized : undefined;
 }
 
-function createSnapshot(provider, session, weekly, fetchedAt) {
+function createSnapshot(
+	provider: TlhSubscriptionUsageProvider,
+	session: TlhSubscriptionUsageWindow | undefined,
+	weekly: TlhSubscriptionUsageWindow | undefined,
+	fetchedAt: number,
+): TlhSubscriptionUsageSnapshot | undefined {
 	if (!session) {
 		return undefined;
 	}
-	const windows = { session };
+	const windows: TlhSubscriptionUsageSnapshot["windows"] = { session };
 	if (weekly) {
 		windows.weekly = weekly;
 	}
 	return { provider, fetchedAt, windows };
 }
 
-export function isSupportedTlhSubscriptionUsageProvider(provider) {
-	return SUPPORTED_PROVIDERS.has(provider);
+export function isSupportedTlhSubscriptionUsageProvider(provider: unknown): provider is TlhSubscriptionUsageProvider {
+	return typeof provider === "string" && SUPPORTED_PROVIDERS.has(provider as TlhSubscriptionUsageProvider);
 }
 
-export function normalizeOpenAICodexUsage(data, options = {}) {
+export function normalizeOpenAICodexUsage(
+	data: unknown,
+	options: { nowMs?: number } = {},
+): TlhSubscriptionUsageSnapshot | undefined {
 	const nowMs = options.nowMs ?? Date.now();
 	const root = asObject(data);
 	const rateLimit = asObject(root?.rate_limit);
@@ -236,7 +317,10 @@ export function normalizeOpenAICodexUsage(data, options = {}) {
 	return createSnapshot("openai-codex", session, weekly, nowMs);
 }
 
-export function normalizeAnthropicUsage(data, options = {}) {
+export function normalizeAnthropicUsage(
+	data: unknown,
+	options: { nowMs?: number } = {},
+): TlhSubscriptionUsageSnapshot | undefined {
 	const nowMs = options.nowMs ?? Date.now();
 	const root = asObject(data);
 	const session = normalizeUsageWindow(root?.five_hour, "five_hour", "session", nowMs);
@@ -244,26 +328,34 @@ export function normalizeAnthropicUsage(data, options = {}) {
 	return createSnapshot("anthropic", session, weekly, nowMs);
 }
 
-function timeoutSignal(timeoutMs) {
+function timeoutSignal(timeoutMs: number): AbortSignal | undefined {
 	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || typeof AbortSignal === "undefined" || typeof AbortSignal.timeout !== "function") {
 		return undefined;
 	}
 	return AbortSignal.timeout(timeoutMs);
 }
 
-async function responseJson(response) {
-	if (!response?.ok || typeof response.json !== "function") {
+async function responseJson(response: ResponseLike | null | undefined): Promise<unknown | undefined> {
+	if (response?.ok !== true || typeof response.json !== "function") {
 		return undefined;
 	}
 	return response.json();
 }
 
-function oauthCredentialFromRegistry(modelRegistry, provider) {
-	const credential = modelRegistry?.authStorage?.get?.(provider);
-	return asObject(credential)?.type === "oauth" ? credential : undefined;
+function oauthCredentialFromRegistry(
+	modelRegistry: TlhSubscriptionUsageModelRegistry | undefined,
+	provider: TlhSubscriptionUsageProvider,
+): JsonRecord | undefined {
+	const authStorage = modelRegistry?.authStorage as { get?: (provider: string) => unknown } | undefined;
+	const credential = authStorage?.get?.(provider);
+	const stored = asObject(credential);
+	return stored?.type === "oauth" ? stored : undefined;
 }
 
-function readOauthCredentialFromRegistry(modelRegistry, provider) {
+function readOauthCredentialFromRegistry(
+	modelRegistry: TlhSubscriptionUsageModelRegistry | undefined,
+	provider: TlhSubscriptionUsageProvider,
+): CredentialResult {
 	try {
 		return { status: "ok", credential: oauthCredentialFromRegistry(modelRegistry, provider) };
 	} catch {
@@ -271,7 +363,7 @@ function readOauthCredentialFromRegistry(modelRegistry, provider) {
 	}
 }
 
-function oauthAccessTokenFromCredential(credential) {
+function oauthAccessTokenFromCredential(credential: unknown): string | undefined {
 	const stored = asObject(credential);
 	if (stored?.type !== "oauth") {
 		return undefined;
@@ -280,7 +372,7 @@ function oauthAccessTokenFromCredential(credential) {
 	return access || undefined;
 }
 
-function accountIdFromCredential(credential) {
+function accountIdFromCredential(credential: unknown): string | undefined {
 	const stored = asObject(credential);
 	if (!stored) {
 		return undefined;
@@ -288,25 +380,29 @@ function accountIdFromCredential(credential) {
 	return pickString(stored, ACCOUNT_ID_KEYS);
 }
 
-function subscriptionUsageCacheKey(provider, identity) {
+function subscriptionUsageCacheKey(provider: TlhSubscriptionUsageProvider, identity: string): string {
 	return `${provider}\t${identity}`;
 }
 
-function cacheKeyMatchesProvider(cacheKey, provider) {
-	return typeof cacheKey === "string" && cacheKey.startsWith(`${provider}\t`);
+function cacheKeyMatchesProvider(cacheKey: string, provider: TlhSubscriptionUsageProvider): boolean {
+	return cacheKey.startsWith(`${provider}\t`);
 }
 
-function hasRuntimeCredentialOverride(modelRegistry, provider) {
+function hasRuntimeCredentialOverride(
+	modelRegistry: TlhSubscriptionUsageModelRegistry | undefined,
+	provider: TlhSubscriptionUsageProvider,
+): boolean {
 	try {
-		const runtimeOverrides = modelRegistry?.authStorage?.runtimeOverrides;
+		const authStorage = modelRegistry?.authStorage as { runtimeOverrides?: unknown } | undefined;
+		const runtimeOverrides = authStorage?.runtimeOverrides;
 		return runtimeOverrides instanceof Map && runtimeOverrides.has(provider);
 	} catch {
 		return false;
 	}
 }
 
-function openAiHeaders(accessToken, accountId) {
-	const headers = {
+function openAiHeaders(accessToken: string, accountId: string | undefined): Record<string, string> {
+	const headers: Record<string, string> = {
 		Accept: "application/json",
 		Authorization: `Bearer ${accessToken}`,
 	};
@@ -316,7 +412,7 @@ function openAiHeaders(accessToken, accountId) {
 	return headers;
 }
 
-function anthropicHeaders(accessToken) {
+function anthropicHeaders(accessToken: string): Record<string, string> {
 	return {
 		Accept: "application/json",
 		Authorization: `Bearer ${accessToken}`,
@@ -324,7 +420,10 @@ function anthropicHeaders(accessToken) {
 	};
 }
 
-export async function fetchTlhSubscriptionUsage(target, options = {}) {
+export async function fetchTlhSubscriptionUsage(
+	target: TlhSubscriptionUsageTarget,
+	options: TlhSubscriptionUsageFetchOptions = {},
+): Promise<TlhSubscriptionUsageSnapshot | undefined> {
 	const provider = target?.provider;
 	const accessToken = typeof target?.accessToken === "string" ? target.accessToken.trim() : "";
 	const fetchImpl = options.fetch ?? globalThis.fetch;
@@ -336,19 +435,19 @@ export async function fetchTlhSubscriptionUsage(target, options = {}) {
 	const signal = timeoutSignal(options.timeoutMs ?? TLH_SUBSCRIPTION_USAGE_TIMEOUT_MS);
 	try {
 		if (provider === "openai-codex") {
-			const response = await fetchImpl(TLH_SUBSCRIPTION_USAGE_OPENAI_CODEX_URL, {
+			const response = (await fetchImpl(TLH_SUBSCRIPTION_USAGE_OPENAI_CODEX_URL, {
 				method: "GET",
 				headers: openAiHeaders(accessToken, target.accountId),
 				signal,
-			});
+			})) as ResponseLike;
 			return normalizeOpenAICodexUsage(await responseJson(response), { nowMs });
 		}
 		if (provider === "anthropic") {
-			const response = await fetchImpl(TLH_SUBSCRIPTION_USAGE_ANTHROPIC_URL, {
+			const response = (await fetchImpl(TLH_SUBSCRIPTION_USAGE_ANTHROPIC_URL, {
 				method: "GET",
 				headers: anthropicHeaders(accessToken),
 				signal,
-			});
+			})) as ResponseLike;
 			return normalizeAnthropicUsage(await responseJson(response), { nowMs });
 		}
 	} catch {
@@ -357,7 +456,7 @@ export async function fetchTlhSubscriptionUsage(target, options = {}) {
 	return undefined;
 }
 
-function resolveTlhSubscriptionUsageProviderContext(ctx) {
+function resolveTlhSubscriptionUsageProviderContext(ctx: TlhSubscriptionUsageContext | undefined): ResolvedProviderContext {
 	const model = ctx?.model;
 	const provider = model?.provider;
 	const modelRegistry = ctx?.modelRegistry;
@@ -386,12 +485,15 @@ function resolveTlhSubscriptionUsageProviderContext(ctx) {
 	return { status: "eligible", model, provider, modelRegistry, credential: credentialResult.credential };
 }
 
-function resolveTlhSubscriptionUsageProvider(ctx) {
+function resolveTlhSubscriptionUsageProvider(ctx: TlhSubscriptionUsageContext | undefined): EligibleProviderContext | undefined {
 	const resolved = resolveTlhSubscriptionUsageProviderContext(ctx);
 	return resolved.status === "eligible" ? resolved : undefined;
 }
 
-function credentialCacheTarget(provider, credential) {
+function credentialCacheTarget(
+	provider: TlhSubscriptionUsageProvider,
+	credential: unknown,
+): CredentialCacheTarget | undefined {
 	const accountId = accountIdFromCredential(credential);
 	if (accountId) {
 		return {
@@ -412,7 +514,9 @@ function credentialCacheTarget(provider, credential) {
 	};
 }
 
-function resolveTlhSubscriptionUsageDisplayTarget(ctx) {
+function resolveTlhSubscriptionUsageDisplayTarget(
+	ctx: TlhSubscriptionUsageContext | undefined,
+): CredentialCacheTarget | undefined {
 	const resolved = resolveTlhSubscriptionUsageProvider(ctx);
 	if (!resolved || hasRuntimeCredentialOverride(resolved.modelRegistry, resolved.provider)) {
 		return undefined;
@@ -421,9 +525,9 @@ function resolveTlhSubscriptionUsageDisplayTarget(ctx) {
 	return credentialCacheTarget(resolved.provider, resolved.credential);
 }
 
-async function resolveTlhSubscriptionUsageTarget(resolved) {
+async function resolveTlhSubscriptionUsageTarget(resolved: EligibleProviderContext): Promise<ResolvedTargetResult> {
 	const { provider, modelRegistry } = resolved;
-	let accessToken;
+	let accessToken: unknown;
 	try {
 		accessToken = await modelRegistry.getApiKeyForProvider?.(provider);
 	} catch {
@@ -467,7 +571,18 @@ async function resolveTlhSubscriptionUsageTarget(resolved) {
 }
 
 export class TlhSubscriptionUsageService {
-	constructor(options = {}) {
+	fetch: TlhSubscriptionUsageFetch | undefined;
+	now: () => number;
+	cacheTtlMs: number;
+	minFetchIntervalMs: number;
+	timeoutMs: number;
+	snapshots: Map<string, TlhSubscriptionUsageSnapshot>;
+	lastAttempts: Map<string, number>;
+	inFlight: Map<string, Promise<TlhSubscriptionUsageSnapshot | undefined>>;
+	activeCacheKeys: Map<TlhSubscriptionUsageProvider, string>;
+	ineligibleCacheKeys: Map<TlhSubscriptionUsageProvider, string>;
+
+	constructor(options: TlhSubscriptionUsageServiceOptions = {}) {
 		this.fetch = options.fetch;
 		this.now = typeof options.now === "function" ? options.now : () => Date.now();
 		this.cacheTtlMs = options.cacheTtlMs ?? TLH_SUBSCRIPTION_USAGE_CACHE_TTL_MS;
@@ -480,11 +595,11 @@ export class TlhSubscriptionUsageService {
 		this.ineligibleCacheKeys = new Map();
 	}
 
-	snapshotForCacheKey(provider, cacheKey) {
+	snapshotForCacheKey(provider: TlhSubscriptionUsageProvider, cacheKey: string): TlhSubscriptionUsageSnapshot | undefined {
 		return this.activeCacheKeys.get(provider) === cacheKey ? this.snapshots.get(cacheKey) : undefined;
 	}
 
-	getSnapshot(provider) {
+	getSnapshot(provider?: string): TlhSubscriptionUsageSnapshot | undefined {
 		if (provider !== undefined && !isSupportedTlhSubscriptionUsageProvider(provider)) {
 			return undefined;
 		}
@@ -494,11 +609,11 @@ export class TlhSubscriptionUsageService {
 		}
 		return Array.from(this.activeCacheKeys.entries())
 			.map(([snapshotProvider, cacheKey]) => this.snapshotForCacheKey(snapshotProvider, cacheKey))
-			.filter(Boolean)
+			.filter((snapshot): snapshot is TlhSubscriptionUsageSnapshot => Boolean(snapshot))
 			.sort((a, b) => b.fetchedAt - a.fetchedAt)[0];
 	}
 
-	getSnapshotForContext(ctx) {
+	getSnapshotForContext(ctx: TlhSubscriptionUsageContext | undefined): TlhSubscriptionUsageSnapshot | undefined {
 		const target = resolveTlhSubscriptionUsageDisplayTarget(ctx);
 		if (!target) {
 			return undefined;
@@ -506,7 +621,7 @@ export class TlhSubscriptionUsageService {
 		return this.snapshotForCacheKey(target.provider, target.cacheKey);
 	}
 
-	isEligible(target) {
+	isEligible(target: string | TlhSubscriptionUsageContext | undefined): boolean {
 		if (typeof target === "string") {
 			return isSupportedTlhSubscriptionUsageProvider(target) && this.activeCacheKeys.has(target);
 		}
@@ -514,7 +629,7 @@ export class TlhSubscriptionUsageService {
 		return Boolean(displayTarget && this.ineligibleCacheKeys.get(displayTarget.provider) !== displayTarget.cacheKey);
 	}
 
-	clearProvider(provider) {
+	clearProvider(provider: string): void {
 		if (!isSupportedTlhSubscriptionUsageProvider(provider)) {
 			return;
 		}
@@ -537,14 +652,14 @@ export class TlhSubscriptionUsageService {
 		this.ineligibleCacheKeys.delete(provider);
 	}
 
-	activateTarget(provider, cacheKey) {
+	activateTarget(provider: TlhSubscriptionUsageProvider, cacheKey: string): void {
 		if (this.activeCacheKeys.get(provider) !== cacheKey) {
 			this.clearProvider(provider);
 			this.activeCacheKeys.set(provider, cacheKey);
 		}
 	}
 
-	clear() {
+	clear(): void {
 		this.snapshots.clear();
 		this.lastAttempts.clear();
 		this.inFlight.clear();
@@ -552,7 +667,10 @@ export class TlhSubscriptionUsageService {
 		this.ineligibleCacheKeys.clear();
 	}
 
-	async refresh(ctx, options = {}) {
+	async refresh(
+		ctx: TlhSubscriptionUsageContext | undefined,
+		options: { force?: boolean } = {},
+	): Promise<TlhSubscriptionUsageSnapshot | undefined> {
 		const provider = ctx?.model?.provider;
 		if (!isSupportedTlhSubscriptionUsageProvider(provider)) {
 			return undefined;
@@ -616,7 +734,7 @@ export class TlhSubscriptionUsageService {
 		}
 
 		this.lastAttempts.set(cacheKey, nowMs);
-		const pending = (async () => {
+		const pending: Promise<TlhSubscriptionUsageSnapshot | undefined> = (async () => {
 			const snapshot = await fetchTlhSubscriptionUsage(target, {
 				fetch: this.fetch,
 				nowMs,
@@ -641,6 +759,8 @@ export class TlhSubscriptionUsageService {
 	}
 }
 
-export function createTlhSubscriptionUsageService(options = {}) {
+export function createTlhSubscriptionUsageService(
+	options: TlhSubscriptionUsageServiceOptions = {},
+): TlhSubscriptionUsageService {
 	return new TlhSubscriptionUsageService(options);
 }

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -18,6 +18,8 @@ const annotateGitDiffHtmlSource = readFileSync(new URL("../extensions/annotate-g
 const attributionSource = readFileSync(new URL("../extensions/the-last-harness/attribution.ts", import.meta.url), "utf8");
 const changelogSource = readFileSync(new URL("../extensions/the-last-harness/changelog.ts", import.meta.url), "utf8");
 const experimentalSource = readFileSync(new URL("../extensions/the-last-harness/experimental.ts", import.meta.url), "utf8");
+const footerFirstLineSource = readFileSync(new URL("../extensions/the-last-harness/footer-first-line.ts", import.meta.url), "utf8");
+const footerGitCacheSource = readFileSync(new URL("../extensions/the-last-harness/footer-git-cache.ts", import.meta.url), "utf8");
 const primaryRuntimeSource = readFileSync(new URL("../extensions/the-last-harness/primary-agent-runtime.ts", import.meta.url), "utf8");
 const effortSource = readFileSync(new URL("../extensions/the-last-harness/effort.ts", import.meta.url), "utf8");
 const promptsSource = readFileSync(new URL("../extensions/the-last-harness/prompts.ts", import.meta.url), "utf8");
@@ -400,8 +402,12 @@ test("extension imports extracted shared helpers from nested TypeScript modules"
 	assert.match(extensionSource, /from "\.\/the-last-harness\/package-update-notice\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/primary-agent-runtime\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/resources\.js"/);
-	assert.match(extensionSource, /from "\.\/the-last-harness\/subscription-usage\.mjs"/);
+	assert.match(extensionSource, /from "\.\/the-last-harness\/subscription-usage\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/types\.js"/);
+	assert.match(footerFirstLineSource, /from "\.\/footer-git\.js"/);
+	assert.match(footerGitCacheSource, /from "\.\/footer-git\.js"/);
+	assert.doesNotMatch(footerFirstLineSource, /from "\.\/footer-git\.mjs"/);
+	assert.doesNotMatch(footerGitCacheSource, /from "\.\/footer-git\.mjs"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/tokens\.js"/);
 	assert.match(extensionSource, /from "\.\/the-last-harness\/usage-limits\.js"/);
 	assert.match(primaryRuntimeSource, /from "\.\/constants\.js"/);

--- a/tests/the-last-harness-footer-git-cache.test.mjs
+++ b/tests/the-last-harness-footer-git-cache.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { FooterGitCache } from "../extensions/the-last-harness/footer-git-cache.ts";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { FooterGitCache } = await jiti.import("../extensions/the-last-harness/footer-git-cache.ts");
 
 const HASH = "1234567890abcdef1234567890abcdef12345678";
 

--- a/tests/the-last-harness-footer-git.test.mjs
+++ b/tests/the-last-harness-footer-git.test.mjs
@@ -6,7 +6,7 @@ import {
 	formatPullRequestFooterSegment,
 	formatTlhGitFooterSegments,
 	parseGitStatusPorcelainV2,
-} from "../extensions/the-last-harness/footer-git.mjs";
+} from "../extensions/the-last-harness/footer-git.ts";
 
 const HASH = "1234567890abcdef1234567890abcdef12345678";
 

--- a/tests/the-last-harness-footer-render.test.mjs
+++ b/tests/the-last-harness-footer-render.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { composeTlhFooterFirstLine } from "../extensions/the-last-harness/footer-first-line.ts";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { composeTlhFooterFirstLine } = await jiti.import("../extensions/the-last-harness/footer-first-line.ts");
 
 const CWD = "~/repo";
 

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createJiti } from "jiti";
 
-import { createTlhSubscriptionUsageService } from "../extensions/the-last-harness/subscription-usage.mjs";
+import { createTlhSubscriptionUsageService } from "../extensions/the-last-harness/subscription-usage.ts";
 import { DEFAULT_PRIMARY_AGENT } from "../extensions/the-last-harness-primary-agent.mjs";
 
 const jiti = createJiti(import.meta.url);

--- a/tests/the-last-harness-subscription-usage.test.mjs
+++ b/tests/the-last-harness-subscription-usage.test.mjs
@@ -10,7 +10,7 @@ import {
 	fetchTlhSubscriptionUsage,
 	normalizeAnthropicUsage,
 	normalizeOpenAICodexUsage,
-} from "../extensions/the-last-harness/subscription-usage.mjs";
+} from "../extensions/the-last-harness/subscription-usage.ts";
 
 const NOW_MS = Date.parse("2026-05-19T19:00:00Z");
 const RESET_AT = "2026-05-19T20:00:00.000Z";


### PR DESCRIPTION
## Summary

- Convert the remaining extension-side helper modules for ticket `tlha-akfh` from `.mjs` to TypeScript modules.
- Update extension imports, tests, and static assertions from `footer-git.mjs` / `subscription-usage.mjs` to the established `.js` TypeScript-module specifier pattern.
- Close the completed top-level migration parent ticket `tlha-xn6b` and remove its stale dangling dependency.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `npm run validate` passed.
- Focused developer validation passed:
  - `npm run typecheck`
  - `node --test tests/the-last-harness-footer-git.test.mjs tests/the-last-harness-subscription-usage.test.mjs tests/the-last-harness-footer-usage.test.mjs tests/the-last-harness-extension-static.test.mjs`
  - `npm run lint`
  - `node --test tests/the-last-harness-footer-git-cache.test.mjs tests/the-last-harness-footer-render.test.mjs`
- TLH `code-reviewer` final pass found no actionable issues after removing the stale parent-ticket dependency.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/typescript-extension-helpers/install.sh | bash -s -- --ref typescript-extension-helpers --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading harness-related features, helping footer content and subscription usage data display more reliably.
  * Tightened handling of Git status and pull request footer details to reduce formatting issues.

* **Improvements**
  * Updated validation and typing around usage snapshots and footer generation for more consistent behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->