### PR TITLE
Add five new startup tips

### DIFF
--- a/extensions/the-last-harness/startup-tip.ts
+++ b/extensions/the-last-harness/startup-tip.ts
@@ -13,6 +13,11 @@ export const TLH_STARTUP_TIPS = [
 	"Prefix a shell command with ! to send its output into the chat, or !! to run it without adding the output to the model context.",
 	"Run /tlh-changelog to review what’s new in this TLH build.",
 	"At any point, you can ask the oracle for a second opinion.",
+	"Run /tokens to generate a local, sanitized token-spend report for the current session.",
+	"Ask the contrarian to stress-test a plan or decision by steelmanning the strongest opposing case.",
+	"Ask TLH to research the web — the architect can delegate to web-scout for Exa-backed search and fetch.",
+	"Enable ci-failure-investigation via /experimental to let TLH investigate failed CI read-only after opening a PR, before asking how to proceed.",
+	"After opening a PR, TLH monitors CI/status checks and reports failures before asking whether to proceed.",
 ] as const;
 
 export function selectTlhStartupTip(random: () => number = Math.random): string | undefined {

--- a/extensions/the-last-harness/startup-tip.ts
+++ b/extensions/the-last-harness/startup-tip.ts
@@ -13,11 +13,11 @@ export const TLH_STARTUP_TIPS = [
 	"Prefix a shell command with ! to send its output into the chat, or !! to run it without adding the output to the model context.",
 	"Run /tlh-changelog to review what’s new in this TLH build.",
 	"At any point, you can ask the oracle for a second opinion.",
-	"Run /tokens to generate a local, sanitized token-spend report for the current session.",
+	"Run `/tokens` to know what's eating up your subscription limit.",
 	"Ask the contrarian to stress-test a plan or decision by steelmanning the strongest opposing case.",
-	"Ask TLH to research the web — the architect can delegate to web-scout for Exa-backed search and fetch.",
-	"Enable ci-failure-investigation via /experimental to let TLH investigate failed CI read-only after opening a PR, before asking how to proceed.",
-	"After opening a PR, TLH monitors CI/status checks and reports failures before asking whether to proceed.",
+	"TLH can search the web, just ask it to.",
+	"With `/experimental enable ci-failure-investigation` TLH auto-investigates failed CI checks, so you don't have to.",
+	"After opening a PR, TLH automatically monitors CI and reports failures.",
 ] as const;
 
 export function selectTlhStartupTip(random: () => number = Math.random): string | undefined {

--- a/tests/the-last-harness-startup-tip.test.mjs
+++ b/tests/the-last-harness-startup-tip.test.mjs
@@ -61,4 +61,19 @@ test("TLH startup tips cover key TLH affordances with concise user-facing phrasi
 	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("/tlh-changelog")), "expected a /tlh-changelog startup tip");
 	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("oracle")), "expected an oracle startup tip");
 	assert.equal(TLH_STARTUP_TIPS.some((tip) => tip.includes("footer data")), false, "expected startup tips to avoid awkward footer-data phrasing");
+
+	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("/tokens")), "expected a /tokens startup tip");
+	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("contrarian")), "expected a contrarian startup tip");
+	assert.ok(
+		TLH_STARTUP_TIPS.some((tip) => tip.includes("web-scout") && tip.includes("research the web")),
+		"expected a web research/web-scout startup tip",
+	);
+	assert.ok(
+		TLH_STARTUP_TIPS.some((tip) => tip.includes("ci-failure-investigation")),
+		"expected a ci-failure-investigation startup tip",
+	);
+	assert.ok(
+		TLH_STARTUP_TIPS.some((tip) => tip.includes("monitors CI/status checks")),
+		"expected a PR CI monitoring startup tip",
+	);
 });

--- a/tests/the-last-harness-startup-tip.test.mjs
+++ b/tests/the-last-harness-startup-tip.test.mjs
@@ -64,16 +64,18 @@ test("TLH startup tips cover key TLH affordances with concise user-facing phrasi
 
 	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("/tokens")), "expected a /tokens startup tip");
 	assert.ok(TLH_STARTUP_TIPS.some((tip) => tip.includes("contrarian")), "expected a contrarian startup tip");
-	assert.ok(
-		TLH_STARTUP_TIPS.some((tip) => tip.includes("web-scout") && tip.includes("research the web")),
-		"expected a web research/web-scout startup tip",
-	);
+	const webSearchTip = TLH_STARTUP_TIPS.find((tip) => /search the web/i.test(tip));
+	assert.ok(webSearchTip, "expected a web search startup tip");
+	assert.match(webSearchTip, /just ask/i, "expected the web search startup tip to keep concise ask-based wording");
+
 	assert.ok(
 		TLH_STARTUP_TIPS.some((tip) => tip.includes("ci-failure-investigation")),
 		"expected a ci-failure-investigation startup tip",
 	);
-	assert.ok(
-		TLH_STARTUP_TIPS.some((tip) => tip.includes("monitors CI/status checks")),
-		"expected a PR CI monitoring startup tip",
-	);
+
+	const prCiTip = TLH_STARTUP_TIPS.find((tip) => /PR/i.test(tip) && /CI/i.test(tip));
+	assert.ok(prCiTip, "expected a PR CI monitoring startup tip");
+	assert.match(prCiTip, /monitor/i, "expected the PR CI startup tip to mention monitoring");
+	assert.match(prCiTip, /report/i, "expected the PR CI startup tip to mention reporting");
+	assert.match(prCiTip, /fail/i, "expected the PR CI startup tip to mention failures");
 });


### PR DESCRIPTION
## Summary

Adds five new hand-curated launch tips to `TLH_STARTUP_TIPS`, surfacing affordances that weren't yet discoverable at startup:

1. `/tokens` — local, sanitized token-spend report
2. asking the `contrarian` subagent to stress-test a plan
3. web research via the `web-scout` subagent (Exa-backed)
4. the opt-in `ci-failure-investigation` experimental flag
5. default post-PR CI/status-check monitoring

Tips are appended (no existing tips removed or reordered), and `tests/the-last-harness-startup-tip.test.mjs` is extended with matching assertions. Launch-tip behavior is unchanged (at most one quiet tip per process launch).

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

All stages passed: package version checks, typecheck, runtime checks, installer smoke checks, all test files (no failures), ESLint, settings dry-run merge, and `npm pack --dry-run`.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer/profile surface touched; extension content only)
- [x] Relevant tests or smoke checks pass
- [ ] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — intentionally omitted; these are minor launch-scoped discovery hints
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/add-startup-tips/install.sh | bash -s -- --ref add-startup-tips --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more startup tips to help surface useful workflows, including token-spend reporting, stress-testing ideas, web research, CI failure investigation, and monitoring PR checks.
* **Tests**
  * Expanded coverage to verify the updated tip list includes the new guidance and expected wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->