### PR TITLE
Surface Claude review output for diagnosis

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,5 +39,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Diagnostics: surface the real model output/error and always leave a
+          # visible comment instead of failing silently when no inline comments buffer.
+          show_full_output: true
+          track_progress: true
+          use_sticky_comment: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Why

The `Claude Code Review` workflow reports green on every PR but no `claude[bot]` review has ever landed (verified across #62, #76, #130, #195, #207–#211 — all zero). Two failure modes in the run logs:

1. **Instant failures** — some runs init the model then immediately error: `is_error:true, num_turns:1, total_cost_usd:0, ~330ms`. Signature of the OAuth subscription token hitting usage/rate limits under burst load.
2. **Silent success** — the one fully clean run (`28300036448`, 8 turns, $1.87) ended with `post-buffered-inline-comments.ts → "No buffered inline comments"` and posted nothing. With `use_sticky_comment:false` / `track_progress:false` there's no summary comment either, so even a successful review is invisible.

The real error text is currently suppressed (`show_full_output:false`), so #1 can't be confirmed without enabling output.

## Change

Diagnostic-only, no logic change:
- `show_full_output: true` — expose the literal model output/error.
- `track_progress: true` — post + update a tracking comment so the review is visible.
- `use_sticky_comment: true` — post the final result as a real PR comment instead of relying on empty inline buffering.

## Note

`pull_request` workflows run from the **base branch**, so this must land on `main` before it takes effect; then re-trigger a review on an open PR to capture the diagnostic run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)