### PR TITLE
Pin pi-subagents to reviewed delta (main-track test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
+- Pinned the bundled main-track `pi-subagents` default extension to reviewed upstream-main commit `fa1db3fb525ef97234be6b7df43ba1d5b4d17b45` so TLH main/ref users can test that delta without a TLH release.
 - Promoted `contrarian` from an experimental opt-in to a bundled default minor subagent. README and command docs now describe it as a sparing adversarial stress-test path rather than a `/experimental` enable/disable toggle.
 - The `librarian` subagent now performs read-only GitHub repository research directly via the `gh` CLI and `git` through `bash`, without a separately managed extension package. **Prerequisite:** `gh` must be installed and authenticated (`gh auth login` / `gh auth status`). Without it, librarian reports what it could not verify rather than silently failing.
 - Migrated TLH away from the old bundled `pi-rtk` fork to a managed pinned native RTK integration. TLH now installs `rtk-ai/rtk` `v0.42.4` at `~/.the-last-harness/agent/bin/rtk`, hard-fails install/update if that managed binary cannot be installed and validated, and uses `RTK_DISABLED=1` or `tlh.rtk.disabled` instead of the old default-extension opt-out flow.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -66,7 +66,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13",
+    "source": "git:github.com/diegopetrucci/pi-subagents@fa1db3fb525ef97234be6b7df43ba1d5b4d17b45",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1063,7 +1063,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@fa1db3fb525ef97234be6b7df43ba1d5b4d17b45");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary

Pin TLH main/ref bundled `pi-subagents` to the reviewed upstream-main delta commit so main-track users can test it without creating a TLH release.

Local ticket: `tlh-t9x2`

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Not run; this is a scoped main-track pin-only change.

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
```

Not run; no installer logic changed.

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

N/A.

_Paste the relevant output or a summary here:_

```sh
node --test tests/default-extensions.test.mjs
```

Passed: 40 tests, 0 failures.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

This intentionally pins to immutable commit `fa1db3fb525ef97234be6b7df43ba1d5b4d17b45` rather than a release tag so TLH main/ref users can test the reviewed `pi-subagents` upstream-main delta outside the TLH release track.

The pinned delta includes the clean upstream-main-based TLH fork branch plus the reviewed pause-all fixes for disk-only top-level and nested async subagent runs.

**Link to merged fork PR:**

Review-only / do-not-merge fork PR: https://github.com/diegopetrucci/pi-subagents/pull/27

**Before → after pin:**

`git:github.com/diegopetrucci/pi-subagents@tlh-v0.26.0-13` → `git:github.com/diegopetrucci/pi-subagents@fa1db3fb525ef97234be6b7df43ba1d5b4d17b45`

**`npm run validate` result:**

Not run; scoped focused validation passed:

```sh
node --test tests/default-extensions.test.mjs
# 40 pass / 0 fail
```

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/pin-pi-subagents-fa1db3f-main-test/install.sh | bash -s -- --ref pin-pi-subagents-fa1db3f-main-test --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The bundled default extension has been pinned to a specific reviewed upstream version, making main/ref builds more predictable for testing and comparison.
  * Release notes now call out this pinned baseline so users can see which bundled extension state they’re running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->