### PR TITLE
Pin pi-subagents to a7e76d2 (async UI fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
-- Updated the bundled main-track `pi-subagents` default extension pin to reviewed upstream-main commit `ebc58962421338d9278fa10bd41d2cd857b1e62b` so TLH main/ref users can test the issue #29 profile-settings preservation fix without a TLH release.
+- Updated the bundled main-track `pi-subagents` default extension pin to reviewed upstream-main commit `a7e76d212dfa788c59538e44afddad326c074b86` so TLH main/ref users can test the issue #30 async-start chat result body suppression fix while keeping the live widget, without a TLH release.
 - Promoted `contrarian` from an experimental opt-in to a bundled default minor subagent. README and command docs now describe it as a sparing adversarial stress-test path rather than a `/experimental` enable/disable toggle.
 - The `librarian` subagent now performs read-only GitHub repository research directly via the `gh` CLI and `git` through `bash`, without a separately managed extension package. **Prerequisite:** `gh` must be installed and authenticated (`gh auth login` / `gh auth status`). Without it, librarian reports what it could not verify rather than silently failing.
 - Migrated TLH away from the old bundled `pi-rtk` fork to a managed pinned native RTK integration. TLH now installs `rtk-ai/rtk` `v0.42.4` at `~/.the-last-harness/agent/bin/rtk`, hard-fails install/update if that managed binary cannot be installed and validated, and uses `RTK_DISABLED=1` or `tlh.rtk.disabled` instead of the old default-extension opt-out flow.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -66,7 +66,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@ebc58962421338d9278fa10bd41d2cd857b1e62b",
+    "source": "git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1073,7 +1073,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@ebc58962421338d9278fa10bd41d2cd857b1e62b");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary

Update the main/ref-track bundled `pi-subagents` pin to `a7e76d212dfa788c59538e44afddad326c074b86`, which includes the issue #30 render-only fix that hides verbose async-start result bodies while keeping the live async widget.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

_Paste the relevant output or a summary here:_

```sh
node --test tests/default-extensions.test.mjs
```

Result: 40 tests passed, 0 failed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

- `pi-subagents` issue #30 fix: initial async-start placeholder results render no visible chat-log result body when the live async widget owns status display.
- The live widget, async-start events, raw async guidance, status inspection, and completion behavior remain unchanged.

**Link to merged fork PR:**

- Related issue: https://github.com/diegopetrucci/pi-subagents/issues/30
- Fork branch commit: https://github.com/diegopetrucci/pi-subagents/commit/a7e76d212dfa788c59538e44afddad326c074b86

**Before → after pin:**

```text
git:github.com/diegopetrucci/pi-subagents@ebc58962421338d9278fa10bd41d2cd857b1e62b
→
git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86
```

**`npm run validate` result:**

Not run for this narrow pin-only PR. Focused validation run:

```sh
node --test tests/default-extensions.test.mjs
```

Result: 40 tests passed, 0 failed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/pin-pi-subagents-a7e76d2-main-test/install.sh | bash -s -- --ref pin-pi-subagents-a7e76d2-main-test --track ref
```
