### PR TITLE
Pin pi-intercom default to 0.6.2

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -76,7 +76,7 @@
     "replaces": ["npm:pi-intercom", "git:github.com/nicobailon/pi-intercom", "git:github.com/diegopetrucci/pi-intercom"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-intercom@0.6.1",
+    "source": "npm:@diegopetrucci/pi-intercom@0.6.2",
     "description": "Allow child subagents to escalate questions to the supervising session."
   }
 ]

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -31,7 +31,7 @@ const expectedBundledNpmSources = new Map([
 	["quiet-tools", "npm:@diegopetrucci/pi-quiet-tools@0.1.4"],
 	["dirty-repo-guard", "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.3"],
 	["triage-comments", "npm:@diegopetrucci/pi-triage-comments@0.1.4"],
-	["intercom", "npm:@diegopetrucci/pi-intercom@0.6.1"],
+	["intercom", "npm:@diegopetrucci/pi-intercom@0.6.2"],
 ]);
 
 function tempFixture() {
@@ -230,7 +230,7 @@ test("merge migrates legacy intercom git installs while cleaning stale critical 
 			],
 			migrateReplacements: true,
 			critical: true,
-			source: "npm:@diegopetrucci/pi-intercom@0.6.1",
+			source: "npm:@diegopetrucci/pi-intercom@0.6.2",
 		},
 		{
 			id: "helper",
@@ -255,7 +255,7 @@ test("merge migrates legacy intercom git installs while cleaning stale critical 
 
 	const settings = readJson(fixture.settings);
 	assert(settings.packages.includes("git:github.com/tlh/pi-subagents@pinned"));
-	assert(settings.packages.includes("npm:@diegopetrucci/pi-intercom@0.6.1"));
+	assert(settings.packages.includes("npm:@diegopetrucci/pi-intercom@0.6.2"));
 	assert(!settings.packages.includes("git:github.com/upstream/pi-subagents"));
 	assert(!settings.packages.includes("git:github.com/diegopetrucci/pi-intercom@tlh-v0.6.0-6"));
 	assert(!settings.packages.includes("npm:helper"));


### PR DESCRIPTION
## Summary

Pin TLH's bundled `pi-intercom` default extension to the latest scoped npm release, `npm:@diegopetrucci/pi-intercom@0.6.2`.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `npm run validate` — passed

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

Updates the bundled intercom default from `npm:@diegopetrucci/pi-intercom@0.6.1` to `npm:@diegopetrucci/pi-intercom@0.6.2`.

**Link to merged fork PR:**

N/A — npm release pin update.

**Before → after pin:**

`npm:@diegopetrucci/pi-intercom@0.6.1` → `npm:@diegopetrucci/pi-intercom@0.6.2`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/pin-pi-intercom-0.6.2/install.sh | bash -s -- --ref chore/pin-pi-intercom-0.6.2 --track ref
```
