### PR TITLE
Add parallel subagent fan-out guidance to primary agents

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -40,6 +40,8 @@ Use the `subagent` tool for minor agents:
 
 Do not create, update, or delete subagent definitions at runtime. Do not delegate to agents outside the allowed TLH minor-agent list.
 
+To run subagents concurrently, issue a single `subagent` call with a `tasks` array (optionally with `concurrency`); never emit multiple `subagent` tool calls in the same turn — a second concurrent call is rejected.
+
 Prefer async/background subagent runs for implementation work that may need supervisor decisions. Minor agents can use `contact_supervisor` to escalate blocking questions back to you.
 
 ## Session startup

--- a/agents/primary/bug-hunter.md
+++ b/agents/primary/bug-hunter.md
@@ -43,6 +43,8 @@ Use the `subagent` tool for minor agents:
 
 Do not create, update, or delete subagent definitions at runtime. Do not delegate to agents outside the allowed TLH minor-agent list.
 
+To run subagents concurrently, issue a single `subagent` call with a `tasks` array (optionally with `concurrency`); never emit multiple `subagent` tool calls in the same turn — a second concurrent call is rejected.
+
 ## Investigation process
 
 1. Restate the observed behavior and expected behavior when they are clear.

--- a/agents/primary/product.md
+++ b/agents/primary/product.md
@@ -50,6 +50,8 @@ When scoped help is needed, delegate only to:
 - `librarian` for external GitHub repositories, issues, releases, or docs research.
 - `contrarian` for sparing adversarial stress-tests of product directions, tradeoffs, assumptions, or ticket framing by steelmanning the strongest opposing case. It is not code review, and it is narrower than a broad second-opinion pass.
 
+To run subagents concurrently, issue a single `subagent` call with a `tasks` array (optionally with `concurrency`); never emit multiple `subagent` tool calls in the same turn — a second concurrent call is rejected.
+
 ## Product workflow
 
 1. Clarify the user goal, target users, constraints, non-goals, success criteria, and decision deadlines.

--- a/agents/primary/rush.md
+++ b/agents/primary/rush.md
@@ -44,6 +44,8 @@ Use minor subagents only when they materially help:
 - `contrarian` only when a plan, bug hypothesis, or review conclusion needs an adversarial stress-test. It is not the normal diff reviewer, and unlike `oracle` it should steelman the strongest opposing case rather than offer a broad second opinion. Use it sparingly rather than as a routine extra pass.
 - Never delegate implementation to `developer`.
 
+To run subagents concurrently, issue a single `subagent` call with a `tasks` array (optionally with `concurrency`); never emit multiple `subagent` tool calls in the same turn — a second concurrent call is rejected.
+
 ## Fit
 
 Rush is for small bounded implementation work, focused bug fixes, targeted tests, and local refactors.


### PR DESCRIPTION
## Summary

TLH primary agents can already run subagents concurrently via the pi-subagents PARALLEL mode (a single `subagent` call with a `tasks` array), but nothing in their prompts told them to. The single-dispatch guard in pi-subagents rejects a *second* concurrent `subagent` tool call in the same turn (`"a subagent call is already in progress. Issue exactly ONE subagent call per turn"`), so emitting sibling calls fails.

This adds one consistent guidance line to each of the four primary delegating agents (`architect`, `bug-hunter`, `product`, `rush`) telling them to fan out via a single `tasks`-array call and never emit multiple `subagent` calls per turn. No capability or guard change — prompt guidance only.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Result: passes (exit 0).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer/settings changes; prompt-only)
- [x] Relevant tests or smoke checks pass (`npm run validate`)
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (internal agent-prompt behavior; no user-facing change)
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for running subagents in parallel.
  * Standardized the format to use a single tool call with a task list, and noted that multiple concurrent calls in the same turn are not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->