### PR TITLE
[codex] Update MCP docs source pin

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP adapter
 
-TLH ships a TLH fork of `pi-mcp-adapter` as the non-critical bundled default `mcporter`. The fork is pinned to `git:github.com/diegopetrucci/pi-mcp-adapter@tlh-v2.10.0-1` and its only divergence from upstream is the MCP status-bar footer: it uses the dim style (matching the other footer lines) and lists actively-connected server names after the count when one or more servers are connected (e.g. `MCP: 1/1 servers, atlassian`).
+TLH ships a scoped package of `pi-mcp-adapter` as the non-critical bundled default `mcporter`. It is pinned to `npm:@diegopetrucci/pi-mcp-adapter@2.10.1`, preserving the TLH MCP status-bar footer behavior: it uses the dim style (matching the other footer lines) and lists actively-connected server names after the count when one or more servers are connected (e.g. `MCP: 1/1 servers, atlassian`).
 
 ## Default usage
 
@@ -18,7 +18,7 @@ Common slash commands:
 ## Configuration
 
 - Bundled default id: `mcporter`
-- Extension source: `git:github.com/diegopetrucci/pi-mcp-adapter@tlh-v2.10.0-1` (TLH fork of `npm:pi-mcp-adapter`)
+- Extension source: `npm:@diegopetrucci/pi-mcp-adapter@2.10.1`
 - Supported MCP config locations:
   - Shared config: `~/.config/mcp/mcp.json`
   - TLH isolated profile: `~/.the-last-harness/agent/mcp.json` or `${PI_CODING_AGENT_DIR}/mcp.json`


### PR DESCRIPTION
## Summary

- Update the MCP adapter docs to reflect the current scoped npm `mcporter` package source.
- Preserve the documented TLH MCP footer behavior while removing the stale git fork pin.

## Why

`config/default-extensions.json` now pins `mcporter` to `npm:@diegopetrucci/pi-mcp-adapter@2.10.1`, and the changelog already documents the migration. `docs/mcp.md` still referenced the older git fork pin.

## Validation

- Local Markdown link sanity check for 39 tracked Markdown files
- `npm run validate`

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/codex/update-mcp-docs-source/install.sh | bash -s -- --ref codex/update-mcp-docs-source --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP setup guide with the latest bundled adapter source and version details.
  * Clarified the default package reference used by TLH and kept the status-bar behavior notes intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->