### PR TITLE
Pin pi-subagents to tlh-v0.31.1 (completion-guard fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - The bundled `developer` subagent now uses `anthropic/claude-sonnet-5` with `thinking: medium` on the Anthropic path. The OpenAI-Codex model (`openai-codex/gpt-5.4`) is unchanged.
+- Updated the bundled critical `pi-subagents` default from reviewed upstream-main commit `a7e76d212dfa788c59538e44afddad326c074b86` to fork tag `tlh-v0.31.1`, adding the completion-guard validation/advisory false-positive fix and Node 26 test-harness compatibility updates while preserving the issue #30 async-start chat result body suppression and live widget behavior.
 
 ## [0.27.0] - 2026-07-01
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -67,7 +67,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86",
+    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1101,7 +1101,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86");
+	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [


### PR DESCRIPTION
## Summary

Bump TLH's bundled critical `pi-subagents` default to fork tag `tlh-v0.31.1` so isolated profiles receive the latest reviewed fork fixes.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

_Paste the relevant output or a summary here:_

- `node --test tests/default-extensions.test.mjs` — passed
- `node --test --test-reporter=dot tests/check-startup-performance.test.mjs tests/the-last-harness-extension-usage-refresh.test.mjs` — passed after a transient review-run failure
- `npm run validate` — passed end-to-end

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

- Completion-guard validation/advisory false-positive fix
- Node 26 test-harness compatibility updates
- Scoped TLH package metadata prep, while retaining this PR's git tag pin because the scoped npm package is not yet visible on npm
- Preserves the existing issue #30 async-start chat result body suppression and live widget behavior

**Link to merged fork PR:**

- https://github.com/diegopetrucci/pi-subagents/pull/35
- https://github.com/diegopetrucci/pi-subagents/pull/36
- https://github.com/diegopetrucci/pi-subagents/pull/37

**Before → after pin:**

`git:github.com/diegopetrucci/pi-subagents@a7e76d212dfa788c59538e44afddad326c074b86` → `git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1`

**`npm run validate` result:**

Passed end-to-end.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/pin-pi-subagents-tlh-v0.31.1/install.sh | bash -s -- --ref pin-pi-subagents-tlh-v0.31.1 --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled default extension pin to a newer upstream release.
  * Recorded the update in the release changelog.
  * Kept the related test expectation aligned with the new bundled version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->