### PR TITLE
Switch bundled pi-subagents to npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - The bundled `developer` subagent now uses `anthropic/claude-sonnet-5` with `thinking: medium` on the Anthropic path. The OpenAI-Codex model (`openai-codex/gpt-5.4`) is unchanged.
-- Updated the bundled critical `pi-subagents` default from reviewed upstream-main commit `a7e76d212dfa788c59538e44afddad326c074b86` to fork tag `tlh-v0.31.1`, adding the completion-guard validation/advisory false-positive fix and Node 26 test-harness compatibility updates while preserving the issue #30 async-start chat result body suppression and live widget behavior.
+- Switched the bundled critical `pi-subagents` default from the reviewed TLH git tag to the published scoped npm package `npm:@diegopetrucci/pi-subagents@0.31.1`, while preserving migration from existing upstream and TLH git installs so the isolated profile lands on one canonical bundled source without duplicates.
 
 ## [0.27.0] - 2026-07-01
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -64,10 +64,10 @@
   {
     "id": "subagents",
     "aliases": ["pi-subagents"],
-    "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents"],
+    "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.1",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1101,12 +1101,13 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1");
+	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.1");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [
 		"npm:pi-subagents",
 		"git:github.com/nicobailon/pi-subagents",
+		"git:github.com/diegopetrucci/pi-subagents",
 	]);
 	assert.equal(subagents.migrateReplacements, true, "subagents replacements must stay enabled");
 
@@ -1120,6 +1121,43 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 		"git:github.com/diegopetrucci/pi-intercom",
 	]);
 	assert.equal(intercom.migrateReplacements, true, "intercom replacements must stay enabled");
+});
+
+test("bundled merge migrates legacy upstream and TLH subagents installs to the scoped npm source without duplicates", () => {
+	const fixture = tempFixture();
+	const bundledPath = join(repoRoot, "config", "default-extensions.json");
+	writeFileSync(fixture.settings, JSON.stringify({
+		packages: [
+			"git:github.com/nicobailon/pi-subagents@v0.31.0",
+			"git:github.com/diegopetrucci/pi-subagents@tlh-v0.31.1",
+		],
+		tlh: { disabledDefaultExtensions: ["pi-subagents"] },
+	}, null, 2));
+
+	runNode(mergeScript, [
+		fixture.defaults,
+		"--settings", fixture.settings,
+		"--default-extensions", bundledPath,
+		"--quiet",
+	]);
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(
+		settings.packages.filter((entry) => packageIdentity(entry) === "npm:@diegopetrucci/pi-subagents"),
+		["npm:@diegopetrucci/pi-subagents@0.31.1"],
+	);
+	assert.equal(
+		settings.packages.some((entry) => packageIdentity(entry) === "git:github.com/nicobailon/pi-subagents"),
+		false,
+	);
+	assert.equal(
+		settings.packages.some((entry) => packageIdentity(entry) === "git:github.com/diegopetrucci/pi-subagents"),
+		false,
+	);
+	assert.deepEqual(
+		(settings.tlh?.disabledDefaultExtensions ?? []).filter((value) => value === "subagents" || value === "pi-subagents"),
+		[],
+	);
 });
 
 test("bundled merge migrates legacy TLH intercom git installs to the scoped npm source", () => {


### PR DESCRIPTION
## Summary

- Switch the bundled critical `pi-subagents` default from the TLH git tag to `npm:@diegopetrucci/pi-subagents@0.31.1`.
- Preserve conservative migration from existing upstream and TLH git installs to the scoped npm source without duplicates.
- Add focused default-extension migration coverage and update the Unreleased changelog.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
# Not run; this change only updates a bundled default extension source and migration tests.
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `node --test tests/default-extensions.test.mjs` — passed (43 tests, 0 failures)
- `npm run check:package-versions` — passed
- `npm run validate` — passed

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/switch-pi-subagents-npm/install.sh | bash -s -- --ref switch-pi-subagents-npm --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated the bundled `subagents` extension to use the published npm package version, so installs now resolve to a single consistent source.
  * Expanded migration handling to recognize more older installation sources and cleanly converge them during upgrades.
* **Tests**
  * Added coverage for upgrading mixed legacy installs to the new bundled package source without leaving duplicate entries behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->