### PR TITLE
Mitigate /review PR GraphQL quota failures

### DIFF
--- a/agents/subagents/librarian.md
+++ b/agents/subagents/librarian.md
@@ -36,12 +36,22 @@ Before relying on `gh`, verify it is available and authenticated:
 gh auth status 2>&1
 ```
 
+For GitHub-heavy work, also preflight rate limits before using GraphQL-heavy commands:
+
+```bash
+gh api rate_limit 2>&1
+```
+
+Use that output to check whether GraphQL quota is low or exhausted before reaching for commands such as `gh pr view` that commonly consume GraphQL quota.
+
 If `gh` is missing or unauthenticated, report that clearly in your findings: state what could not be verified, why (gh absent / not authenticated), and that the user must install and authenticate gh to complete that part of the research. Continue with whatever evidence is still accessible via `git` or local reads.
+
+If GraphQL quota is low, exhausted, or `gh` reports GraphQL rate-limit/quota errors, avoid further GraphQL-heavy lookups. Fall back to `gh api` GET requests against REST endpoints or to local `git` evidence when possible, and clearly report which checks were unavailable because GraphQL quota prevented them.
 
 ## Research process
 
 1. Clarify the research target and success criteria from the request.
-2. Use `gh` and `git` commands via `bash` to gather the most relevant repository or GitHub context. Start with the broadest useful query and narrow only when necessary.
+2. Use `gh` and `git` commands via `bash` to gather the most relevant repository or GitHub context. For GitHub-heavy work, check `gh api rate_limit` first and prefer REST `gh api` GET endpoints or local `git` evidence over GraphQL-heavy commands when GraphQL quota is low or exhausted. Start with the broadest useful query and narrow only when necessary.
 3. Prefer primary sources: repository files, official documentation, releases, issues, pull requests, commits, and maintainer comments.
 4. Cite concrete evidence with repository names, paths, line ranges, issue or pull request numbers, commit SHAs, release versions, and dates when available.
 5. Separate confirmed facts from hypotheses or potentially outdated information.
@@ -55,5 +65,5 @@ Return a concise markdown report with:
 - Research target and scope.
 - Key findings with citations (repo, path, line ranges, issue/PR numbers, commit SHAs, dates).
 - Relevance to the architect's task.
-- Limitations, access problems, or unverifiable claims (including any gh availability issues).
+- Limitations, access problems, or unverifiable claims (including any gh availability issues, GraphQL quota/rate-limit blockers, and checks you could not complete because of them).
 - Recommended next steps, if any, without implementing fixes.

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -390,6 +390,178 @@ function rejectFlagLike(value: string, fieldName: string): { ok: true } | { ok: 
 	return { ok: true };
 }
 
+function isGhGraphqlQuotaFailure(stderr: string): boolean {
+	return /graphql/i.test(stderr) && /(rate limit|quota|submitted too quickly)/i.test(stderr);
+}
+
+type GitHubRepoRef = { owner: string; repo: string };
+type GitHubPrRef = GitHubRepoRef & { number: number };
+type GitHubRestPrMetadata = {
+	number: number;
+	headRefName: string;
+	baseRefName: string;
+	isCrossRepository: boolean;
+};
+
+function parseGitHubPrUrl(value: string): GitHubPrRef | undefined {
+	try {
+		const url = new URL(value);
+		if (url.hostname !== "github.com") {
+			return undefined;
+		}
+		const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/.*)?$/);
+		if (!match) {
+			return undefined;
+		}
+		return { owner: match[1], repo: match[2], number: Number.parseInt(match[3], 10) };
+	} catch {
+		return undefined;
+	}
+}
+
+function parseGitHubRemoteUrl(value: string): GitHubRepoRef | undefined {
+	const trimmed = value.trim();
+	const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+	if (sshMatch) {
+		return { owner: sshMatch[1], repo: sshMatch[2] };
+	}
+
+	try {
+		const url = new URL(trimmed);
+		if (url.hostname !== "github.com") {
+			return undefined;
+		}
+		const match = url.pathname.match(/^\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+		if (!match) {
+			return undefined;
+		}
+		return { owner: match[1], repo: match[2] };
+	} catch {
+		return undefined;
+	}
+}
+
+async function resolveGitHubRepoRefFromLocalRemotes(
+	pi: ExtensionAPI,
+	cwd: string,
+): Promise<{ ok: true; repoRef: GitHubRepoRef } | { ok: false; message: string }> {
+	const remoteListResult = await pi.exec("git", ["remote"], { cwd });
+	if (remoteListResult.code !== 0) {
+		const firstLine = remoteListResult.stderr.split("\n")[0]?.trim() || "git remote failed";
+		return { ok: false, message: `could not list git remotes: ${firstLine}` };
+	}
+
+	const remoteNames = remoteListResult.stdout
+		.split(/\r?\n/u)
+		.map((name) => name.trim())
+		.filter(Boolean);
+	if (remoteNames.length === 0) {
+		return { ok: false, message: "could not resolve GitHub repository because this repo has no git remotes" };
+	}
+
+	const orderedRemoteNames = Array.from(new Set(["origin", ...remoteNames]));
+	const remoteFailures: string[] = [];
+	for (const remoteName of orderedRemoteNames) {
+		const remoteUrlResult = await pi.exec("git", ["remote", "get-url", remoteName], { cwd });
+		if (remoteUrlResult.code !== 0) {
+			const firstLine = remoteUrlResult.stderr.split("\n")[0]?.trim() || `git remote get-url ${remoteName} failed`;
+			remoteFailures.push(`${remoteName}: ${firstLine}`);
+			continue;
+		}
+
+		const repoRef = parseGitHubRemoteUrl(remoteUrlResult.stdout);
+		if (repoRef) {
+			return { ok: true, repoRef };
+		}
+		remoteFailures.push(`${remoteName}: unsupported remote URL '${remoteUrlResult.stdout.trim()}'`);
+	}
+
+	return {
+		ok: false,
+		message: `could not parse a GitHub owner/repo from local git remotes (${remoteFailures.join("; ")})`,
+	};
+}
+
+async function resolveGitHubPrRef(
+	pi: ExtensionAPI,
+	cwd: string,
+	nOrUrl: string,
+	prNumberHint: number | undefined,
+): Promise<{ ok: true; prRef: GitHubPrRef } | { ok: false; message: string }> {
+	const urlRef = parseGitHubPrUrl(nOrUrl);
+	if (urlRef) {
+		return { ok: true, prRef: urlRef };
+	}
+
+	if (prNumberHint === undefined) {
+		return { ok: false, message: `could not resolve a PR number from '${nOrUrl}'` };
+	}
+
+	const repoRefResult = await resolveGitHubRepoRefFromLocalRemotes(pi, cwd);
+	if (repoRefResult.ok === false) {
+		return { ok: false, message: repoRefResult.message };
+	}
+
+	return { ok: true, prRef: { ...repoRefResult.repoRef, number: prNumberHint } };
+}
+
+async function fetchPrMetadataViaRest(
+	pi: ExtensionAPI,
+	cwd: string,
+	prRef: GitHubPrRef,
+): Promise<{ ok: true; prData: GitHubRestPrMetadata } | { ok: false; message: string }> {
+	const result = await pi.exec("gh", ["api", `repos/${prRef.owner}/${prRef.repo}/pulls/${prRef.number}`], { cwd });
+	if (result.code !== 0) {
+		const firstLine = result.stderr.split("\n")[0]?.trim() || "gh api failed";
+		return { ok: false, message: firstLine };
+	}
+
+	try {
+		const payload = JSON.parse(result.stdout) as {
+			number?: number;
+			head?: { ref?: string; repo?: { full_name?: string | null } | null };
+			base?: { ref?: string; repo?: { full_name?: string | null } | null };
+		};
+		const number = typeof payload.number === "number" ? payload.number : prRef.number;
+		const headRefName = payload.head?.ref;
+		const baseRefName = payload.base?.ref;
+		if (!headRefName || !baseRefName) {
+			return { ok: false, message: "REST PR metadata response was missing head/base refs" };
+		}
+		return {
+			ok: true,
+			prData: {
+				number,
+				headRefName,
+				baseRefName,
+				isCrossRepository:
+					typeof payload.head?.repo?.full_name === "string" && typeof payload.base?.repo?.full_name === "string"
+						? payload.head.repo.full_name !== payload.base.repo.full_name
+						: false,
+			},
+		};
+	} catch {
+		return { ok: false, message: "Could not parse REST PR metadata response" };
+	}
+}
+
+async function fetchPrDiffViaRest(
+	pi: ExtensionAPI,
+	cwd: string,
+	prRef: GitHubPrRef,
+): Promise<{ ok: true; diff: string } | { ok: false; message: string }> {
+	const result = await pi.exec(
+		"gh",
+		["api", "-H", "Accept: application/vnd.github.v3.diff", `repos/${prRef.owner}/${prRef.repo}/pulls/${prRef.number}`],
+		{ cwd },
+	);
+	if (result.code !== 0) {
+		const firstLine = result.stderr.split("\n")[0]?.trim() || "gh api failed";
+		return { ok: false, message: firstLine };
+	}
+	return { ok: true, diff: result.stdout };
+}
+
 /**
  * Gather staged + unstaged changes vs HEAD for the uncommitted mode.
  * Also appends untracked, non-gitignored file contents so brand-new files are reviewable.
@@ -885,22 +1057,44 @@ async function gatherPr(
 		["pr", "view", nOrUrl, "--json", "number,headRefName,baseRefName,isCrossRepository,headRepository"],
 		{ cwd },
 	);
+	let prRef: GitHubPrRef | undefined;
+	let prData: { number: number; headRefName: string; baseRefName: string; isCrossRepository: boolean };
 	if (prViewResult.code !== 0) {
 		const firstLine = prViewResult.stderr.split("\n")[0]?.trim() ?? "";
-		return {
-			ok: false,
-			message: `Could not resolve PR '${nOrUrl}': ${firstLine}`,
-		};
-	}
+		if (!isGhGraphqlQuotaFailure(prViewResult.stderr)) {
+			return {
+				ok: false,
+				message: `Could not resolve PR '${nOrUrl}': ${firstLine}`,
+			};
+		}
 
-	let prData: { number: number; headRefName: string; baseRefName: string; isCrossRepository: boolean };
-	try {
-		prData = JSON.parse(prViewResult.stdout) as typeof prData;
-	} catch {
-		return {
-			ok: false,
-			message: `Could not parse PR metadata for '${nOrUrl}'.`,
-		};
+		const prNumberHint = /^\d+$/u.test(nOrUrl.trim()) ? Number.parseInt(nOrUrl.trim(), 10) : undefined;
+		const prRefResult = await resolveGitHubPrRef(pi, cwd, nOrUrl, prNumberHint);
+		if (prRefResult.ok === false) {
+			return {
+				ok: false,
+				message: `gh pr view hit a GraphQL quota/rate-limit error for '${nOrUrl}': ${firstLine}. REST fallback could not resolve the PR target: ${prRefResult.message}`,
+			};
+		}
+		prRef = prRefResult.prRef;
+
+		const restPrResult = await fetchPrMetadataViaRest(pi, cwd, prRef);
+		if (restPrResult.ok === false) {
+			return {
+				ok: false,
+				message: `gh pr view hit a GraphQL quota/rate-limit error for '${nOrUrl}': ${firstLine}. REST fallback also failed: ${restPrResult.message}`,
+			};
+		}
+		prData = restPrResult.prData;
+	} else {
+		try {
+			prData = JSON.parse(prViewResult.stdout) as typeof prData;
+		} catch {
+			return {
+				ok: false,
+				message: `Could not parse PR metadata for '${nOrUrl}'.`,
+			};
+		}
 	}
 
 	if (prData.isCrossRepository === true) {
@@ -983,21 +1177,54 @@ async function gatherPr(
 
 	// 7. Diff gathering
 	const diffResult = await pi.exec("gh", ["pr", "diff", String(prNumber)], { cwd });
+	let diffBody: string;
 	if (diffResult.code !== 0) {
 		const firstLine = diffResult.stderr.split("\n")[0]?.trim() ?? "";
-		return {
-			ok: false,
-			message: formatPostCheckoutPrFailure(
-				`gh pr diff failed for PR #${prNumber}: ${firstLine}`,
-				checkoutCtx,
-				effectiveBranch,
-			),
-		};
+		if (!isGhGraphqlQuotaFailure(diffResult.stderr)) {
+			return {
+				ok: false,
+				message: formatPostCheckoutPrFailure(
+					`gh pr diff failed for PR #${prNumber}: ${firstLine}`,
+					checkoutCtx,
+					effectiveBranch,
+				),
+			};
+		}
+
+		if (!prRef) {
+			const prRefResult = await resolveGitHubPrRef(pi, cwd, nOrUrl, prNumber);
+			if (prRefResult.ok === false) {
+				return {
+					ok: false,
+					message: formatPostCheckoutPrFailure(
+						`gh pr diff hit a GraphQL quota/rate-limit error for PR #${prNumber}: ${firstLine}. REST fallback could not resolve the PR target: ${prRefResult.message}`,
+						checkoutCtx,
+						effectiveBranch,
+					),
+				};
+			}
+			prRef = prRefResult.prRef;
+		}
+
+		const restDiffResult = await fetchPrDiffViaRest(pi, cwd, prRef);
+		if (restDiffResult.ok === false) {
+			return {
+				ok: false,
+				message: formatPostCheckoutPrFailure(
+					`gh pr diff hit a GraphQL quota/rate-limit error for PR #${prNumber}: ${firstLine}. REST fallback also failed: ${restDiffResult.message}`,
+					checkoutCtx,
+					effectiveBranch,
+				),
+			};
+		}
+		diffBody = restDiffResult.diff;
+	} else {
+		diffBody = diffResult.stdout;
 	}
 
 	const ctx: ReviewGatheredContext = {
 		currentBranch: effectiveBranch,
-		body: diffResult.stdout,
+		body: diffBody,
 		bodyKind: "diff",
 	};
 	if (checkoutCtx !== undefined) {

--- a/extensions/the-last-harness/review.ts
+++ b/extensions/the-last-harness/review.ts
@@ -419,6 +419,14 @@ function parseGitHubPrUrl(value: string): GitHubPrRef | undefined {
 	}
 }
 
+function parseGitHubRepoSlug(value: string): GitHubRepoRef | undefined {
+	const match = value.trim().match(/^([^/\s]+)\/([^/\s]+)$/u);
+	if (!match) {
+		return undefined;
+	}
+	return { owner: match[1], repo: match[2] };
+}
+
 function parseGitHubRemoteUrl(value: string): GitHubRepoRef | undefined {
 	const trimmed = value.trim();
 	const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
@@ -439,6 +447,22 @@ function parseGitHubRemoteUrl(value: string): GitHubRepoRef | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+async function resolveGitHubRepoRefFromGhDefault(pi: ExtensionAPI, cwd: string): Promise<GitHubRepoRef | undefined> {
+	const defaultRepoResult = await pi.exec("gh", ["repo", "set-default", "--view"], { cwd });
+	if (defaultRepoResult.code !== 0) {
+		return undefined;
+	}
+
+	for (const line of defaultRepoResult.stdout.split(/\r?\n/u)) {
+		const repoRef = parseGitHubRepoSlug(line);
+		if (repoRef) {
+			return repoRef;
+		}
+	}
+
+	return undefined;
 }
 
 async function resolveGitHubRepoRefFromLocalRemotes(
@@ -495,6 +519,11 @@ async function resolveGitHubPrRef(
 
 	if (prNumberHint === undefined) {
 		return { ok: false, message: `could not resolve a PR number from '${nOrUrl}'` };
+	}
+
+	const ghDefaultRepoRef = await resolveGitHubRepoRefFromGhDefault(pi, cwd);
+	if (ghDefaultRepoRef) {
+		return { ok: true, prRef: { ...ghDefaultRepoRef, number: prNumberHint } };
 	}
 
 	const repoRefResult = await resolveGitHubRepoRefFromLocalRemotes(pi, cwd);

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1206,6 +1206,184 @@ test("/review pr uses gh pr checkout before diff when switching to the PR head",
 	);
 });
 
+test("/review pr falls back to REST metadata when gh pr view hits a GraphQL rate limit", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-rest-view-");
+	const customResponses = ["pr"];
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => customResponses.shift(),
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return { code: 1, stdout: "", stderr: "GraphQL: API rate limit exceeded" };
+			}
+			if (command === "git" && args.join(" ") === "remote") {
+				return { code: 0, stdout: "origin\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "remote get-url origin") {
+				return { code: 0, stdout: "git@github.com:acme/widgets.git\n", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "api repos/acme/widgets/pulls/123") {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						head: { ref: "feature/review", repo: { full_name: "acme/widgets" } },
+						base: { ref: "main", repo: { full_name: "acme/widgets" } },
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr diff 123") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /pr: 123/);
+	assert.match(harness.sentMessages[0], /current-branch: feature\/review/);
+	assert.match(harness.sentMessages[0], /diff --git a\/src\/app.ts b\/src\/app.ts/);
+	assert.ok(
+		harness.execCalls.some(({ command, args }) => command === "gh" && args.join(" ") === "api repos/acme/widgets/pulls/123"),
+		"should fetch PR metadata via REST when GraphQL is rate-limited",
+	);
+});
+
+test("/review pr falls back to REST diff when gh pr diff hits a GraphQL rate limit after checkout", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-rest-diff-");
+	const customResponses = ["pr", true];
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => customResponses.shift(),
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						headRefName: "feature/review",
+						baseRefName: "main",
+						isCrossRepository: false,
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "main\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "status --porcelain") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr checkout 123") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr diff 123") {
+				return { code: 1, stdout: "", stderr: "GraphQL: quota exceeded\nmore detail" };
+			}
+			if (command === "git" && args.join(" ") === "remote") {
+				return { code: 0, stdout: "origin\n", stderr: "" };
+			}
+			if (command === "git" && args.join(" ") === "remote get-url origin") {
+				return { code: 0, stdout: "https://github.com/acme/widgets.git\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"api -H Accept: application/vnd.github.v3.diff repos/acme/widgets/pulls/123"
+			) {
+				return { code: 0, stdout: "diff --git a/src/rest.ts b/src/rest.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 1);
+	assert.deepEqual(harness.notifications, [
+		{
+			message: "Switched from 'main' to 'feature/review'. Use `git checkout -` to return.",
+			level: "info",
+		},
+	]);
+	assert.match(harness.sentMessages[0], /checkout: switched-from main/);
+	assert.match(harness.sentMessages[0], /diff --git a\/src\/rest.ts b\/src\/rest.ts/);
+	assert.ok(
+		harness.execCalls.findIndex(({ command, args }) => command === "gh" && args.join(" ") === "pr checkout 123") <
+			harness.execCalls.findIndex(
+				({ command, args }) => command === "gh" && args.join(" ") === "api -H Accept: application/vnd.github.v3.diff repos/acme/widgets/pulls/123",
+			),
+		"should preserve the checkout-before-diff behavior when falling back to REST diff",
+	);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "git" && args[0] === "checkout"),
+		false,
+	);
+});
+
+test("/review pr reports both the GraphQL limit and REST fallback resolution failure", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-rest-view-error-");
+	const customResponses = ["pr"];
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => customResponses.shift(),
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return { code: 1, stdout: "", stderr: "GraphQL: quota exceeded" };
+			}
+			if (command === "git" && args.join(" ") === "remote") {
+				return { code: 0, stdout: "", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.sentMessages.length, 0);
+	assert.deepEqual(harness.notifications, [
+		{
+			message:
+				"gh pr view hit a GraphQL quota/rate-limit error for '123': GraphQL: quota exceeded. REST fallback could not resolve the PR target: could not resolve GitHub repository because this repo has no git remotes",
+			level: "error",
+		},
+	]);
+});
+
 test("/review pr reports the branch switch when gh pr diff fails after checkout", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-pr-diff-failure-");
 	const customResponses = ["pr", true];

--- a/tests/review.test.mjs
+++ b/tests/review.test.mjs
@@ -1206,7 +1206,70 @@ test("/review pr uses gh pr checkout before diff when switching to the PR head",
 	);
 });
 
-test("/review pr falls back to REST metadata when gh pr view hits a GraphQL rate limit", async (t) => {
+test("/review pr uses the gh default repo for REST metadata fallback when set", async (t) => {
+	const cwd = makeTempDir(t, "tlh-review-pr-rest-view-default-repo-");
+	const customResponses = ["pr"];
+
+	const harness = createReviewHarness({
+		cwd,
+		custom: () => customResponses.shift(),
+		editor: () => "123",
+		exec: async (command, args) => {
+			if (command === "gh" && args.join(" ") === "--version") {
+				return { code: 0, stdout: "gh version 2.0.0\n", stderr: "" };
+			}
+			if (
+				command === "gh" &&
+				args.join(" ") ===
+					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
+			) {
+				return { code: 1, stdout: "", stderr: "GraphQL: API rate limit exceeded" };
+			}
+			if (command === "gh" && args.join(" ") === "repo set-default --view") {
+				return { code: 0, stdout: "acme/selected-repo\n", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "api repos/acme/selected-repo/pulls/123") {
+				return {
+					code: 0,
+					stdout: JSON.stringify({
+						number: 123,
+						head: { ref: "feature/review", repo: { full_name: "acme/selected-repo" } },
+						base: { ref: "main", repo: { full_name: "acme/selected-repo" } },
+					}),
+					stderr: "",
+				};
+			}
+			if (command === "git" && args.join(" ") === "rev-parse --abbrev-ref HEAD") {
+				return { code: 0, stdout: "feature/review\n", stderr: "" };
+			}
+			if (command === "gh" && args.join(" ") === "pr diff 123") {
+				return { code: 0, stdout: "diff --git a/src/app.ts b/src/app.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec: ${command} ${args.join(" ")}`);
+		},
+	});
+
+	await harness.handler("", harness.ctx);
+
+	assert.equal(harness.notifications.length, 0);
+	assert.equal(harness.sentMessages.length, 1);
+	assert.match(harness.sentMessages[0], /pr: 123/);
+	assert.match(harness.sentMessages[0], /current-branch: feature\/review/);
+	assert.match(harness.sentMessages[0], /diff --git a\/src\/app.ts b\/src\/app.ts/);
+	assert.ok(
+		harness.execCalls.some(
+			({ command, args }) => command === "gh" && args.join(" ") === "api repos/acme/selected-repo/pulls/123",
+		),
+		"should fetch PR metadata via REST using the gh default repository when GraphQL is rate-limited",
+	);
+	assert.equal(
+		harness.execCalls.some(({ command, args }) => command === "git" && args.join(" ") === "remote"),
+		false,
+		"should not fall back to git remotes when gh already has a default repository",
+	);
+});
+
+test("/review pr falls back to local remotes for REST metadata when no gh default repo is set", async (t) => {
 	const cwd = makeTempDir(t, "tlh-review-pr-rest-view-");
 	const customResponses = ["pr"];
 
@@ -1224,6 +1287,9 @@ test("/review pr falls back to REST metadata when gh pr view hits a GraphQL rate
 					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
 			) {
 				return { code: 1, stdout: "", stderr: "GraphQL: API rate limit exceeded" };
+			}
+			if (command === "gh" && args.join(" ") === "repo set-default --view") {
+				return { code: 0, stdout: "", stderr: "X No default remote repository has been set" };
 			}
 			if (command === "git" && args.join(" ") === "remote") {
 				return { code: 0, stdout: "origin\n", stderr: "" };
@@ -1305,6 +1371,9 @@ test("/review pr falls back to REST diff when gh pr diff hits a GraphQL rate lim
 			if (command === "gh" && args.join(" ") === "pr diff 123") {
 				return { code: 1, stdout: "", stderr: "GraphQL: quota exceeded\nmore detail" };
 			}
+			if (command === "gh" && args.join(" ") === "repo set-default --view") {
+				return { code: 0, stdout: "", stderr: "X No default remote repository has been set" };
+			}
 			if (command === "git" && args.join(" ") === "remote") {
 				return { code: 0, stdout: "origin\n", stderr: "" };
 			}
@@ -1364,6 +1433,9 @@ test("/review pr reports both the GraphQL limit and REST fallback resolution fai
 					"pr view 123 --json number,headRefName,baseRefName,isCrossRepository,headRepository"
 			) {
 				return { code: 1, stdout: "", stderr: "GraphQL: quota exceeded" };
+			}
+			if (command === "gh" && args.join(" ") === "repo set-default --view") {
+				return { code: 0, stdout: "", stderr: "X No default remote repository has been set" };
 			}
 			if (command === "git" && args.join(" ") === "remote") {
 				return { code: 0, stdout: "", stderr: "" };


### PR DESCRIPTION
## Summary

Adds a narrow REST fallback for `/review pr` when `gh pr view` or `gh pr diff` fails because GitHub GraphQL quota/rate limits are exhausted. Also updates the librarian subagent guidance to preflight GitHub rate limits and prefer REST/local evidence when GraphQL quota is unavailable.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Targeted validation:

```sh
npx tsc -p tsconfig.json --noEmit --pretty false
node --test tests/review.test.mjs
```

Result: TypeScript passed; `tests/review.test.mjs` passed 47/47 after the gh default-repo follow-up fix.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

