### PR TITLE
Show low weekly usage by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
+- Weekly subscription usage now appears by default only when less than 25% remains; explicit `/usage weekly on` or `/usage weekly off` preferences still override that auto-show behavior.
 - The bundled `developer` subagent now uses `anthropic/claude-sonnet-5` with `thinking: medium` on the Anthropic path. The OpenAI-Codex model (`openai-codex/gpt-5.4`) is unchanged.
 - Switched the bundled critical `pi-subagents` default from the reviewed TLH git tag to the published scoped npm package `npm:@diegopetrucci/pi-subagents@0.31.1`, while preserving migration from existing upstream and TLH git installs so the isolated profile lands on one canonical bundled source without duplicates.
 

--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -229,15 +229,15 @@ function deriveWeeklyRemainingPercent(window: TlhSubscriptionUsageWindow | undef
 		return undefined;
 	}
 
+	const percentUsed = finiteNumber(window.percent);
+	if (percentUsed !== undefined) {
+		return Math.max(0, Math.min(100, 100 - percentUsed));
+	}
+
 	const remaining = finiteNumber(window.remaining);
 	const limit = finiteNumber(window.limit);
 	if (remaining !== undefined && limit !== undefined && limit > 0) {
 		return Math.max(0, Math.min(100, (remaining / limit) * 100));
-	}
-
-	const percentUsed = finiteNumber(window.percent);
-	if (percentUsed !== undefined) {
-		return Math.max(0, Math.min(100, 100 - percentUsed));
 	}
 
 	return undefined;

--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -13,7 +13,7 @@ const DAY_MS = 24 * HOUR_MS;
 
 export type TlhFooterSubscriptionUsageOptions = {
 	subscriptionUsage?: TlhSubscriptionUsageSnapshotProvider;
-	shouldShowWeekly?: () => boolean;
+	shouldShowWeekly?: () => boolean | undefined;
 	nowMs?: number;
 };
 
@@ -215,12 +215,37 @@ function subscriptionUsageSnapshot(
 	}
 }
 
-function shouldShowWeeklyUsage(shouldShowWeekly: (() => boolean) | undefined): boolean {
+function getWeeklyVisibilityPreference(shouldShowWeekly: (() => boolean | undefined) | undefined): boolean | undefined {
 	try {
-		return shouldShowWeekly?.() === true;
+		const value = shouldShowWeekly?.();
+		return value === undefined ? undefined : value === true;
 	} catch {
-		return false;
+		return undefined;
 	}
+}
+
+function deriveWeeklyRemainingPercent(window: TlhSubscriptionUsageWindow | undefined): number | undefined {
+	if (!window) {
+		return undefined;
+	}
+
+	const remaining = finiteNumber(window.remaining);
+	const limit = finiteNumber(window.limit);
+	if (remaining !== undefined && limit !== undefined && limit > 0) {
+		return Math.max(0, Math.min(100, (remaining / limit) * 100));
+	}
+
+	const percentUsed = finiteNumber(window.percent);
+	if (percentUsed !== undefined) {
+		return Math.max(0, Math.min(100, 100 - percentUsed));
+	}
+
+	return undefined;
+}
+
+function shouldAutoShowWeeklyUsage(snapshot: TlhSubscriptionUsageSnapshot | undefined): boolean {
+	const remainingPercent = deriveWeeklyRemainingPercent(snapshot?.windows?.weekly);
+	return remainingPercent !== undefined && remainingPercent < 25;
 }
 
 export function getTlhSubscriptionUsageFooterState(
@@ -231,9 +256,11 @@ export function getTlhSubscriptionUsageFooterState(
 	const provider = model?.provider;
 	const subscriptionEligible = isSubscriptionUsageEligible(ctx, provider, options.subscriptionUsage);
 	const usingOAuth = isModelUsingOAuth(ctx, model);
+	const snapshot = subscriptionEligible ? subscriptionUsageSnapshot(ctx, provider, options.subscriptionUsage) : undefined;
+	const weeklyVisibilityPreference = getWeeklyVisibilityPreference(options.shouldShowWeekly);
 	const segment = subscriptionEligible
-		? formatTlhSubscriptionUsageFooterSegment(subscriptionUsageSnapshot(ctx, provider, options.subscriptionUsage), {
-				showWeekly: shouldShowWeeklyUsage(options.shouldShowWeekly),
+		? formatTlhSubscriptionUsageFooterSegment(snapshot, {
+				showWeekly: weeklyVisibilityPreference ?? shouldAutoShowWeeklyUsage(snapshot),
 				nowMs: options.nowMs,
 			})
 		: undefined;

--- a/extensions/the-last-harness/usage-limits.ts
+++ b/extensions/the-last-harness/usage-limits.ts
@@ -24,8 +24,8 @@ export function getTlhUsageLimitsConfig(cwd: string): TlhUsageLimitsConfig | und
 	}
 }
 
-export function shouldShowTlhUsageWeekly(config: TlhUsageLimitsConfig | undefined): boolean {
-	return config?.showWeekly === true;
+export function shouldShowTlhUsageWeekly(config: TlhUsageLimitsConfig | undefined): boolean | undefined {
+	return config?.showWeekly;
 }
 
 function validateTlhUsageLimitsSettings(settings: unknown): asserts settings is TlhSettings {
@@ -99,10 +99,14 @@ function nextWeeklyPreference(current: boolean, action: TlhUsageWeeklyAction): b
 	return !current;
 }
 
-function formatUsageWeeklyStatus(showWeekly: boolean): string {
-	return showWeekly
-		? "TLH usage weekly window is shown. Use /usage weekly off to hide it, or /usage weekly toggle."
-		: "TLH usage weekly window is hidden (default when unset). Use /usage weekly on to show it, or /usage weekly toggle.";
+function formatUsageWeeklyStatus(showWeekly: boolean | undefined): string {
+	if (showWeekly === true) {
+		return "TLH usage weekly window is shown. Use /usage weekly off to hide it, or /usage weekly toggle.";
+	}
+	if (showWeekly === false) {
+		return "TLH usage weekly window is hidden. Use /usage weekly on to show it, or /usage weekly toggle.";
+	}
+	return "TLH usage weekly window follows the default auto mode: it shows only when weekly remaining capacity is below 25%. Use /usage weekly on to always show it, /usage weekly off to always hide it, or /usage weekly toggle.";
 }
 
 function usageCommandCompletions(prefix: string) {
@@ -136,7 +140,7 @@ export function registerUsageCommand(pi: ExtensionAPI): void {
 				return;
 			}
 
-			const nextShowWeekly = nextWeeklyPreference(currentShowWeekly, command.action);
+			const nextShowWeekly = nextWeeklyPreference(currentShowWeekly === true, command.action);
 			try {
 				const result = writeTlhUsageWeeklyPreference(ctx.cwd, nextShowWeekly);
 				const changedLabel = result.changed ? "Updated" : "No change to";

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -47,24 +47,24 @@ function usageProvider(snapshot, onGetSnapshot, eligible = true) {
 	};
 }
 
-function openAiSnapshot() {
+function openAiSnapshot(weekly = { percent: 21.5 }) {
 	return {
 		provider: "openai-codex",
 		fetchedAt: NOW_MS,
 		windows: {
 			session: { key: "primary_window", label: "session", percent: 42 },
-			weekly: { key: "secondary_window", label: "weekly", percent: 21.5 },
+			weekly: { key: "secondary_window", label: "weekly", ...weekly },
 		},
 	};
 }
 
-function anthropicSnapshot() {
+function anthropicSnapshot(weekly = { percent: 88.9 }) {
 	return {
 		provider: "anthropic",
 		fetchedAt: NOW_MS,
 		windows: {
 			session: { key: "five_hour", label: "session", percent: 42 },
-			weekly: { key: "seven_day", label: "weekly", percent: 88.9 },
+			weekly: { key: "seven_day", label: "weekly", ...weekly },
 		},
 	};
 }
@@ -173,6 +173,60 @@ test("footer includes Anthropic weekly usage only when the preference enables it
 
 	assert.match(sessionLine, /5h session 42% used/);
 	assert.match(sessionLine, /weekly 88\.9% used/);
+});
+
+
+test("footer auto-shows weekly by default only below 25% remaining", () => {
+	const ctx = createCtx({ provider: "openai-codex" });
+	const belowThresholdLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 80 })),
+		shouldShowWeekly: () => undefined,
+	});
+	const atThresholdLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 75 })),
+		shouldShowWeekly: () => undefined,
+	});
+	const aboveThresholdLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 74.9 })),
+		shouldShowWeekly: () => undefined,
+	});
+
+	assert.match(belowThresholdLine, /weekly 80% used/);
+	assert.doesNotMatch(atThresholdLine, /weekly/);
+	assert.doesNotMatch(aboveThresholdLine, /weekly/);
+});
+
+
+test("footer auto-show derives weekly remaining from counts when percent is absent", () => {
+	const ctx = createCtx({ provider: "openai-codex" });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ used: 90, limit: 100, remaining: 10, percent: undefined })),
+		shouldShowWeekly: () => undefined,
+	});
+
+	assert.match(sessionLine, /weekly 90\/100 used/);
+});
+
+
+test("footer explicit weekly on always shows weekly even above the default threshold", () => {
+	const ctx = createCtx({ provider: "openai-codex" });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 21.5 })),
+		shouldShowWeekly: () => true,
+	});
+
+	assert.match(sessionLine, /weekly 21\.5% used/);
+});
+
+
+test("footer explicit weekly off hides weekly even below the default threshold", () => {
+	const ctx = createCtx({ provider: "openai-codex" });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 80 })),
+		shouldShowWeekly: () => false,
+	});
+
+	assert.doesNotMatch(sessionLine, /weekly/);
 });
 
 test("footer context and subscription usage keep compact token formatting", () => {

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -197,6 +197,17 @@ test("footer auto-shows weekly by default only below 25% remaining", () => {
 });
 
 
+test("footer auto-show prefers explicit weekly percent over conflicting counts", () => {
+	const ctx = createCtx({ provider: "openai-codex" });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(openAiSnapshot({ percent: 80, used: 10, limit: 100, remaining: 90 })),
+		shouldShowWeekly: () => undefined,
+	});
+
+	assert.match(sessionLine, /weekly 80% used/);
+});
+
+
 test("footer auto-show derives weekly remaining from counts when percent is absent", () => {
 	const ctx = createCtx({ provider: "openai-codex" });
 	const sessionLine = renderSessionStatsLine(ctx, {

--- a/tests/the-last-harness-usage-limits.test.mjs
+++ b/tests/the-last-harness-usage-limits.test.mjs
@@ -43,7 +43,7 @@ function registeredUsageCommand() {
 	return command;
 }
 
-test("usage command registers completions and reports weekly hidden by default", async (t) => {
+test("usage command registers completions and reports weekly auto mode by default", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-usage-limits-test-", { test: t });
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
@@ -61,8 +61,10 @@ test("usage command registers completions and reports weekly hidden by default",
 		const { ctx, notifications } = createCommandContext(fixture.dir);
 		await command.handler("", ctx);
 		assert.equal(notifications.at(-1)?.type, "info");
-		assert.match(notifications.at(-1)?.message ?? "", /hidden \(default when unset\)/);
+		assert.match(notifications.at(-1)?.message ?? "", /default auto mode/);
+		assert.match(notifications.at(-1)?.message ?? "", /below 25%/);
 		assert.match(notifications.at(-1)?.message ?? "", /\/usage weekly on/);
+		assert.match(notifications.at(-1)?.message ?? "", /\/usage weekly off/);
 	});
 });
 
@@ -175,6 +177,7 @@ test("usage weekly off and toggle persist explicit preferences", async (t) => {
 		const notice = notifications.at(-1);
 		assert.equal(notice?.type, "info");
 		assert.match(notice?.message ?? "", /hidden/);
+		assert.doesNotMatch(notice?.message ?? "", /default auto mode|default when unset/);
 		assert.match(notice?.message ?? "", /\/usage weekly on/);
 	});
 


### PR DESCRIPTION
"## Summary\n\n- Auto-show the weekly subscription usage footer segment by default only when less than 25% weekly capacity remains.\n- Keep explicit `/usage weekly on` and `/usage weekly off` preferences as always-show / always-hide overrides.\n- Update `/usage` status copy and focused tests for the new auto mode.\n\n## Change type\n\n- [ ] Installer / wrapper\n- [x] Extension / skill / prompt / theme\n- [ ] Docs\n- [ ] CI / release\n- [ ] Pin PR (update a `config/default-extensions.json` fork tag)\n- [ ] Other\n\n## Validation\n\n**Standard validation (most changes):**\n\n```sh\nnpm run validate\n```\n\nResult: passed locally.\n\n## Pre-review checklist\n\n- [x] Change preserves isolation and installer safety invariants:\n  - never mutates `~/.pi/agent` (the user's normal Pi configuration)\n  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory\n  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes\n  - does not clobber unmanaged wrapper files without an explicit `--force`\n- [x] Relevant tests or smoke checks pass\n- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it\n- [x] Diff contains no secrets, local paths, or unintended generated files\n\n---\n\n## Install this branch\n\n```sh\ncurl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/tlh/weekly-usage-auto-low/install.sh | bash -s -- --ref tlh/weekly-usage-auto-low --track ref\n```\n"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly subscription usage now appears automatically when usage drops below 25%, while still honoring explicit on/off preferences.
  * The `/usage` command now shows clearer messaging for the new auto mode and unset state.
* **Bug Fixes**
  * Weekly usage display now handles missing or partial usage data more consistently.
  * Toggling weekly visibility now preserves explicit user choices more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->