### PR TITLE
Bump pi-web-access default pin to 0.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to The Last Harness will be documented in this file.
 - Weekly subscription usage now appears by default only when less than 25% remains; explicit `/usage weekly on` or `/usage weekly off` preferences still override that auto-show behavior.
 - The bundled `developer` subagent now uses `anthropic/claude-sonnet-5` with `thinking: medium` on the Anthropic path. The OpenAI-Codex model (`openai-codex/gpt-5.4`) is unchanged.
 - Switched the bundled critical `pi-subagents` default from the reviewed TLH git tag to the published scoped npm package `npm:@diegopetrucci/pi-subagents@0.31.1`, while preserving migration from existing upstream and TLH git installs so the isolated profile lands on one canonical bundled source without duplicates.
+- Bumped the bundled managed `pi-web-access` default extension pin from `npm:@diegopetrucci/pi-web-access@0.10.8` to `npm:@diegopetrucci/pi-web-access@0.10.9`, while keeping migration coverage for upstream and prior TLH git replacement sources intact.
 
 ## [0.27.0] - 2026-07-01
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -21,7 +21,7 @@
     "id": "pi-web-access",
     "replaces": ["npm:pi-web-access", "git:github.com/nicobailon/pi-web-access", "git:github.com/diegopetrucci/pi-web-access@tlh-v0.10.7-1"],
     "migrateReplacements": true,
-    "source": "npm:@diegopetrucci/pi-web-access@0.10.8",
+    "source": "npm:@diegopetrucci/pi-web-access@0.10.9",
     "description": "Exa-backed web search and URL fetch tools (web_search, fetch_content, get_search_content) used by the web-scout subagent."
   },
   {

--- a/docs/web-search-fork-release-cadence.md
+++ b/docs/web-search-fork-release-cadence.md
@@ -11,7 +11,7 @@ Upstream: `nicobailon/pi-web-access`
 
 TLH no longer installs `pi-web-access` from a git dependency. The bundled default extension source is:
 
-- TLH bundled extension source: `npm:@diegopetrucci/pi-web-access@0.10.8`
+- TLH bundled extension source: `npm:@diegopetrucci/pi-web-access@0.10.9`
 - Source repository: <https://github.com/diegopetrucci/pi-web-access>
 - Previous git-based TLH source retained for migration coverage: `git:github.com/diegopetrucci/pi-web-access@tlh-v0.10.7-1`
 

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,14 +1,14 @@
 # Web search
 
-TLH ships [`pi-web-access`](https://github.com/diegopetrucci/pi-web-access) as a non-critical default extension. TLH manages it as the scoped package `npm:@diegopetrucci/pi-web-access@0.10.8`. The `web-scout` subagent uses its `web_search`, `fetch_content`, and `get_search_content` tools for general web research.
+TLH ships [`pi-web-access`](https://github.com/diegopetrucci/pi-web-access) as a non-critical default extension. TLH manages it as the scoped package `npm:@diegopetrucci/pi-web-access@0.10.9`. The `web-scout` subagent uses its `web_search`, `fetch_content`, and `get_search_content` tools for general web research.
 
 GitHub-specific research — repositories, issues, pull requests, releases, and project docs — still goes to the `librarian` subagent, which uses the `gh` CLI and `git` directly (no extension package required).
 
-Running another `pi-web-access` provider alongside the TLH-managed package is unsupported because the tool names conflict. During TLH install/update, TLH migrates known upstream, manual, and older TLH `pi-web-access` variants in the same isolated profile to `npm:@diegopetrucci/pi-web-access@0.10.8`. If you want TLH to stop managing that extension, opt out first with `tlh defaults disable pi-web-access`; otherwise install/update runs will keep the scoped TLH package pinned. If multiple providers are already installed, remove the extras so only one `pi-web-access` provider remains active.
+Running another `pi-web-access` provider alongside the TLH-managed package is unsupported because the tool names conflict. During TLH install/update, TLH migrates known upstream, manual, and older TLH `pi-web-access` variants in the same isolated profile to `npm:@diegopetrucci/pi-web-access@0.10.9`. If you want TLH to stop managing that extension, opt out first with `tlh defaults disable pi-web-access`; otherwise install/update runs will keep the scoped TLH package pinned. If multiple providers are already installed, remove the extras so only one `pi-web-access` provider remains active.
 
 ## Configuration
 
-- Extension source: `npm:@diegopetrucci/pi-web-access@0.10.8`
+- Extension source: `npm:@diegopetrucci/pi-web-access@0.10.9`
 - Settings: `${PI_CODING_AGENT_DIR}/extensions/pi-web-access/settings.json`
 - Cache and Exa usage tracker: `${PI_CODING_AGENT_DIR}/cache/pi-web-access/`
 - The extension never reads or writes `~/.pi/`.

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -20,7 +20,7 @@ const retiredPlannotatorPackage = "npm:@plannotator/pi-extension";
 const previousMcporterSource = "git:github.com/diegopetrucci/pi-mcp-adapter@tlh-v2.10.0-1";
 const bundledMcporterSource = "npm:@diegopetrucci/pi-mcp-adapter@2.10.1";
 const previousPiWebAccessSource = "git:github.com/diegopetrucci/pi-web-access@tlh-v0.10.7-1";
-const bundledPiWebAccessSource = "npm:@diegopetrucci/pi-web-access@0.10.8";
+const bundledPiWebAccessSource = "npm:@diegopetrucci/pi-web-access@0.10.9";
 const expectedBundledNpmSources = new Map([
 	["openai-fast", "npm:@diegopetrucci/pi-openai-fast@0.1.6"],
 	["anthropic-auth", "npm:@gotgenes/pi-anthropic-auth@1.0.0"],


### PR DESCRIPTION
## Summary

Bumps TLH's bundled managed `pi-web-access` default extension from `npm:@diegopetrucci/pi-web-access@0.10.8` to `npm:@diegopetrucci/pi-web-access@0.10.9`, with matching test, docs, and changelog updates.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

Not run; this change only updates a managed default-extension package pin and related docs/tests.

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

Not docs-only.

_Paste the relevant output or a summary here:_

- `node --test tests/default-extensions.test.mjs` passed
- `npm run validate` passed
- `git diff --check` passed

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

Updates the managed scoped npm package pin for `pi-web-access` to `0.10.9`.

**Link to merged fork PR:**

N/A.

**Before → after pin:**

`npm:@diegopetrucci/pi-web-access@0.10.8` → `npm:@diegopetrucci/pi-web-access@0.10.9`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/bump-pi-web-access-0.10.9/install.sh | bash -s -- --ref bump-pi-web-access-0.10.9 --track ref
```
