### PR TITLE
Pin pi-subagents to 0.31.2 (timeout diagnostics)

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -67,7 +67,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.1",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.2",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1101,7 +1101,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.1");
+	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.2");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [
@@ -1144,7 +1144,7 @@ test("bundled merge migrates legacy upstream and TLH subagents installs to the s
 	const settings = readJson(fixture.settings);
 	assert.deepEqual(
 		settings.packages.filter((entry) => packageIdentity(entry) === "npm:@diegopetrucci/pi-subagents"),
-		["npm:@diegopetrucci/pi-subagents@0.31.1"],
+		["npm:@diegopetrucci/pi-subagents@0.31.2"],
 	);
 	assert.equal(
 		settings.packages.some((entry) => packageIdentity(entry) === "git:github.com/nicobailon/pi-subagents"),


### PR DESCRIPTION
## Summary

Bump the bundled `subagents` default extension to the published `npm:@diegopetrucci/pi-subagents@0.31.2` release, which includes the foreground timeout diagnostics work.

Closes #245.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR (optional — delete this section if unused)

**What the new fork tag / pin includes:**

Published npm package `@diegopetrucci/pi-subagents@0.31.2`, including richer foreground timeout diagnostics and clarified hard-cancellation timeout semantics.

**Link to merged fork PR:**

- diegopetrucci/pi-subagents#39
- Upstream/fork issue: diegopetrucci/pi-subagents#38

**Before → after pin:**

`npm:@diegopetrucci/pi-subagents@0.31.1` → `npm:@diegopetrucci/pi-subagents@0.31.2`

**`npm run validate` result:**

Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/pin/pi-subagents-0.31.2/install.sh | bash -s -- --ref pin/pi-subagents-0.31.2 --track ref
```
