### PR TITLE
Retire bundled triage-comments extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the bundled `pi-triage-comments` extension. Existing TLH-managed `pi-triage-comments` installs are force-removed on the next `tlh` install or update; packages added manually to that isolated profile are preserved.
+
 ### Changed
 
 - Weekly subscription usage now appears by default only when less than 25% remains; explicit `/usage weekly on` or `/usage weekly off` preferences still override that auto-show behavior.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -57,11 +57,6 @@
     "description": "Prompt before session changes when the current git repo has uncommitted changes."
   },
   {
-    "id": "triage-comments",
-    "source": "npm:@diegopetrucci/pi-triage-comments@0.1.4",
-    "description": "Add /triage-comments and a read-only triage_comments subagent tool for review-comment triage."
-  },
-  {
     "id": "subagents",
     "aliases": ["pi-subagents"],
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -170,7 +170,6 @@ These commands are provided by bundled default extensions and are visible in TLH
 | `/mcp` | `pi-mcp-adapter` | Show MCP server status |
 | `/mcp-auth` | `pi-mcp-adapter` | Authenticate with an MCP server (OAuth) |
 | `/subagents-doctor` | `pi-subagents` | Show subagent diagnostics |
-| `/triage-comments` | `pi-triage-comments` | Collect pasted feedback or PR comments, then start a triage investigation |
 
 RTK shell-command rewriting is now a managed native integration rather than a slash-command UI. TLH does not register `/rtk`; use `RTK_DISABLED=1` for a single launch or set `"tlh": { "rtk": { "disabled": true } }` in the isolated TLH profile to disable rewriting.
 

--- a/scripts/lib/default-extensions.mjs
+++ b/scripts/lib/default-extensions.mjs
@@ -71,6 +71,7 @@ function gitIdentity(source) {
 export const RETIRED_TLH_DEFAULT_PACKAGE_SOURCES = Object.freeze([
     "npm:@plannotator/pi-extension",
     "npm:@diegopetrucci/pi-librarian",
+    "npm:@diegopetrucci/pi-triage-comments",
 ]);
 const TARGETED_DEFAULT_EXTENSION_LOAD_ORDER = [];
 export function packageSourceOf(entry) {

--- a/scripts/lib/default-extensions.mts
+++ b/scripts/lib/default-extensions.mts
@@ -106,6 +106,7 @@ function gitIdentity(source: string): string {
 export const RETIRED_TLH_DEFAULT_PACKAGE_SOURCES = Object.freeze([
 	"npm:@plannotator/pi-extension",
 	"npm:@diegopetrucci/pi-librarian",
+	"npm:@diegopetrucci/pi-triage-comments",
 ]);
 
 const TARGETED_DEFAULT_EXTENSION_LOAD_ORDER = [] as const;

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -30,7 +30,6 @@ const expectedBundledNpmSources = new Map([
 	["context-inspector", "npm:@diegopetrucci/pi-context-inspector@0.1.3"],
 	["quiet-tools", "npm:@diegopetrucci/pi-quiet-tools@0.1.4"],
 	["dirty-repo-guard", "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.3"],
-	["triage-comments", "npm:@diegopetrucci/pi-triage-comments@0.1.4"],
 	["intercom", "npm:@diegopetrucci/pi-intercom@0.6.2"],
 ]);
 
@@ -157,6 +156,7 @@ test("bundled manifest retires rtk while keeping quiet-tools bundled", () => {
 	assert.equal(ids.includes("confirm-destructive"), false);
 	assert.equal(ids.includes("librarian"), false);
 	assert.equal(ids.includes("rtk"), false);
+	assert.equal(ids.includes("triage-comments"), false);
 	assert.ok(quietTools, "bundled quiet-tools default should exist");
 	assert.deepEqual(quietTools.aliases, ["compact-bash"]);
 	assert.deepEqual(quietTools.replaces, ["npm:@diegopetrucci/pi-compact-bash"]);


### PR DESCRIPTION
## Summary

Retire the bundled `triage-comments` extension from The Last Harness, following the `pi-librarian` retirement precedent. Removes it from the bundled manifest and adds it to the managed retired-source list so existing TLH-managed installs drop the package on the next install/update; manually-added copies in the isolated profile are preserved.

## Change type

- [x] Extension / skill / prompt / theme
- [x] Docs

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed. Dry-run install confirms retirement semantics:

```
Would remove retired TLH default package: npm:@diegopetrucci/pi-triage-comments@0.1.4
```

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (managed-only removal; user-installed copies preserved; no unconditional force-removal)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated
- [x] Diff contains no secrets, local paths, or unintended generated files

### Changed files

- `config/default-extensions.json` — removed the `triage-comments` entry
- `scripts/lib/default-extensions.mts` + regenerated `.mjs` — added `npm:@diegopetrucci/pi-triage-comments` to `RETIRED_TLH_DEFAULT_PACKAGE_SOURCES`
- `tests/default-extensions.test.mjs` — dropped pinned-source expectation, added retirement assertion
- `docs/commands.md` — removed the `/triage-comments` row
- `CHANGELOG.md` — `[Unreleased] › Removed` entry
