### PR TITLE
Remove legacy Pi minimum version range

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 REPO="${TLH_REPO:-diegopetrucci/the-last-harness}"
 REF="${TLH_REF:-main}"
-# Keep in sync with MIN_NODE_VERSION, MIN_PI_VERSION, and PINNED_PI_VERSION in scripts/tlh-install.mjs.
+# Keep in sync with MIN_NODE_VERSION and PINNED_PI_VERSION in scripts/tlh-install.mjs.
 TLH_MIN_NODE_VERSION="22.19.0"
-TLH_MIN_PI_VERSION="0.80.1"
 TLH_PINNED_PI_VERSION="0.80.5"
 
 DRY_RUN=false

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -19,10 +19,8 @@ const DEFAULT_REF = "main";
 const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 const PINNED_PI_VERSION = "0.80.5";
 const PI_PACKAGE_SPEC = `${PI_PACKAGE_NAME}@${PINNED_PI_VERSION}`;
-// Keep in sync with TLH_MIN_NODE_VERSION, TLH_MIN_PI_VERSION, and TLH_PINNED_PI_VERSION in install.sh.
+// Keep in sync with TLH_MIN_NODE_VERSION and TLH_PINNED_PI_VERSION in install.sh.
 const MIN_NODE_VERSION = "22.19.0";
-const MIN_PI_VERSION = "0.80.1";
-const MAX_PI_VERSION = PINNED_PI_VERSION;
 const DEFAULT_GNOSIS_REPO = "skorokithakis/gnosis";
 const DEFAULT_GNOSIS_VERSION = "0.5.3";
 const DEFAULT_WRAPPER_NAME = "tlh";
@@ -81,10 +79,6 @@ function compareVersionTriplets(currentVersion, expectedVersion) {
 function nodeVersionMeetsMinimum(currentVersion, minimumVersion = MIN_NODE_VERSION) {
     const comparison = compareVersionTriplets(currentVersion, minimumVersion);
     return comparison !== null && comparison >= 0;
-}
-function versionAtMost(currentVersion, maximumVersion) {
-    const comparison = compareVersionTriplets(currentVersion, maximumVersion);
-    return comparison !== null && comparison <= 0;
 }
 function formatNodeVersion(version) {
     const text = String(version || "").trim();
@@ -487,9 +481,6 @@ function gitCheckoutIo() {
         warn,
     };
 }
-function supportedPiVersionRange() {
-    return `Pi >= ${MIN_PI_VERSION} and <= ${MAX_PI_VERSION}`;
-}
 function pinnedPiInstallCommand(config) {
     return `npm install -g --ignore-scripts --prefix "${piInstallPrefix(config)}" ${PI_PACKAGE_SPEC}`;
 }
@@ -589,8 +580,8 @@ function writeRuntimeMarker(config, prefix, origin) {
         throw error;
     }
 }
-function assertSupportedPiVersion(config, { piCommand = "pi", sourceDescription = "existing pi on PATH", versionCommandDisplay = "pi --version", expectedVersion, } = {}) {
-    // `pi --version` prints a bare semver (e.g. "0.80.1") on stdout. Older builds may
+function assertSupportedPiVersion(config, { piCommand = "pi", sourceDescription = "existing pi on PATH", versionCommandDisplay = "pi --version", } = {}) {
+    // `pi --version` prints a bare semver (e.g. "0.80.5") on stdout. Older builds may
     // differ, so we extract the first semver-shaped substring rather than match strictly.
     const result = spawnCapture(config, [piCommand, "--version"], {
         allowFailure: true,
@@ -598,7 +589,7 @@ function assertSupportedPiVersion(config, { piCommand = "pi", sourceDescription 
     });
     const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
     const installGuidance = pinnedPiInstallGuidance(config);
-    const requiredVersionDescription = expectedVersion ? `Pi ${expectedVersion}` : supportedPiVersionRange();
+    const requiredVersionDescription = `Pi ${PINNED_PI_VERSION}`;
     if (result.error || result.status !== 0) {
         const status = result.status ?? result.signal ?? spawnErrorCode(result.error) ?? "error";
         const probeDetails = output ? ` Probe output: ${output}` : "";
@@ -606,14 +597,10 @@ function assertSupportedPiVersion(config, { piCommand = "pi", sourceDescription 
     }
     const match = output.match(/\d+\.\d+\.\d+/);
     if (!match) {
-        const sampleVersion = expectedVersion ?? MIN_PI_VERSION;
-        throw new Error(`unable to parse Pi version from ${sourceDescription}: ${output || "<empty>"}. The Last Harness requires ${requiredVersionDescription}. Verify that \`${versionCommandDisplay}\` prints a semantic version like ${sampleVersion}, or ${installGuidance}.`);
+        throw new Error(`unable to parse Pi version from ${sourceDescription}: ${output || "<empty>"}. The Last Harness requires ${requiredVersionDescription}. Verify that \`${versionCommandDisplay}\` prints a semantic version like ${PINNED_PI_VERSION}, or ${installGuidance}.`);
     }
     const currentVersion = match[0];
-    const isSupportedVersion = expectedVersion
-        ? currentVersion === expectedVersion
-        : nodeVersionMeetsMinimum(currentVersion, MIN_PI_VERSION) && versionAtMost(currentVersion, MAX_PI_VERSION);
-    if (!isSupportedVersion) {
+    if (currentVersion !== PINNED_PI_VERSION) {
         throw new Error(`${requiredVersionDescription} is required (found ${currentVersion}). ${installGuidance}`);
     }
     verboseLog(config, `Pi version (${sourceDescription}): ${currentVersion}`);
@@ -713,7 +700,6 @@ function installPiIfNeeded(config) {
                 piCommand: piBin,
                 sourceDescription: `TLH private runtime at ${piBin}`,
                 versionCommandDisplay: `${piBin} --version`,
-                expectedVersion: PINNED_PI_VERSION,
             });
             verboseLog(config, `TLH private Pi runtime is valid: ${piBin}`);
             // Prepend the private runtime's bin dir to PATH for the remainder of this
@@ -765,7 +751,6 @@ function installPiIfNeeded(config) {
         piCommand: piBin,
         sourceDescription: `freshly installed TLH private runtime at ${piBin}`,
         versionCommandDisplay: `${piBin} --version`,
-        expectedVersion: PINNED_PI_VERSION,
     });
     // Prepend the private runtime's bin dir for the remainder of this process so
     // downstream steps (pi install, pi update, …) resolve the new binary.

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -73,10 +73,8 @@ const DEFAULT_REF = "main";
 const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 const PINNED_PI_VERSION = "0.80.5";
 const PI_PACKAGE_SPEC = `${PI_PACKAGE_NAME}@${PINNED_PI_VERSION}`;
-// Keep in sync with TLH_MIN_NODE_VERSION, TLH_MIN_PI_VERSION, and TLH_PINNED_PI_VERSION in install.sh.
+// Keep in sync with TLH_MIN_NODE_VERSION and TLH_PINNED_PI_VERSION in install.sh.
 const MIN_NODE_VERSION = "22.19.0";
-const MIN_PI_VERSION = "0.80.1";
-const MAX_PI_VERSION = PINNED_PI_VERSION;
 const DEFAULT_GNOSIS_REPO = "skorokithakis/gnosis";
 const DEFAULT_GNOSIS_VERSION = "0.5.3";
 const DEFAULT_WRAPPER_NAME = "tlh";
@@ -200,7 +198,6 @@ interface SupportedPiVersionOptions {
 	piCommand?: string;
 	sourceDescription?: string;
 	versionCommandDisplay?: string;
-	expectedVersion?: string;
 }
 
 interface PreferBinDirOptions {
@@ -241,10 +238,6 @@ function nodeVersionMeetsMinimum(currentVersion: string | number | undefined, mi
 	return comparison !== null && comparison >= 0;
 }
 
-function versionAtMost(currentVersion: string | number | undefined, maximumVersion: string): boolean {
-	const comparison = compareVersionTriplets(currentVersion, maximumVersion);
-	return comparison !== null && comparison <= 0;
-}
 
 function formatNodeVersion(version: string | number | undefined): string {
 	const text = String(version || "").trim();
@@ -669,9 +662,6 @@ function gitCheckoutIo() {
 	};
 }
 
-function supportedPiVersionRange(): string {
-	return `Pi >= ${MIN_PI_VERSION} and <= ${MAX_PI_VERSION}`;
-}
 
 function pinnedPiInstallCommand(config: InstallConfig): string {
 	return `npm install -g --ignore-scripts --prefix "${piInstallPrefix(config)}" ${PI_PACKAGE_SPEC}`;
@@ -776,10 +766,9 @@ function assertSupportedPiVersion(
 		piCommand = "pi",
 		sourceDescription = "existing pi on PATH",
 		versionCommandDisplay = "pi --version",
-		expectedVersion,
 	}: SupportedPiVersionOptions = {},
 ): void {
-	// `pi --version` prints a bare semver (e.g. "0.80.1") on stdout. Older builds may
+	// `pi --version` prints a bare semver (e.g. "0.80.5") on stdout. Older builds may
 	// differ, so we extract the first semver-shaped substring rather than match strictly.
 	const result = spawnCapture(config, [piCommand, "--version"], {
 		allowFailure: true,
@@ -787,7 +776,7 @@ function assertSupportedPiVersion(
 	});
 	const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
 	const installGuidance = pinnedPiInstallGuidance(config);
-	const requiredVersionDescription = expectedVersion ? `Pi ${expectedVersion}` : supportedPiVersionRange();
+	const requiredVersionDescription = `Pi ${PINNED_PI_VERSION}`;
 	if (result.error || result.status !== 0) {
 		const status = result.status ?? result.signal ?? spawnErrorCode(result.error) ?? "error";
 		const probeDetails = output ? ` Probe output: ${output}` : "";
@@ -795,14 +784,10 @@ function assertSupportedPiVersion(
 	}
 	const match = output.match(/\d+\.\d+\.\d+/);
 	if (!match) {
-		const sampleVersion = expectedVersion ?? MIN_PI_VERSION;
-		throw new Error(`unable to parse Pi version from ${sourceDescription}: ${output || "<empty>"}. The Last Harness requires ${requiredVersionDescription}. Verify that \`${versionCommandDisplay}\` prints a semantic version like ${sampleVersion}, or ${installGuidance}.`);
+		throw new Error(`unable to parse Pi version from ${sourceDescription}: ${output || "<empty>"}. The Last Harness requires ${requiredVersionDescription}. Verify that \`${versionCommandDisplay}\` prints a semantic version like ${PINNED_PI_VERSION}, or ${installGuidance}.`);
 	}
 	const currentVersion = match[0];
-	const isSupportedVersion = expectedVersion
-		? currentVersion === expectedVersion
-		: nodeVersionMeetsMinimum(currentVersion, MIN_PI_VERSION) && versionAtMost(currentVersion, MAX_PI_VERSION);
-	if (!isSupportedVersion) {
+	if (currentVersion !== PINNED_PI_VERSION) {
 		throw new Error(`${requiredVersionDescription} is required (found ${currentVersion}). ${installGuidance}`);
 	}
 	verboseLog(config, `Pi version (${sourceDescription}): ${currentVersion}`);
@@ -913,7 +898,6 @@ function installPiIfNeeded(config: InstallConfig): PiInstallResult {
 				piCommand: piBin,
 				sourceDescription: `TLH private runtime at ${piBin}`,
 				versionCommandDisplay: `${piBin} --version`,
-				expectedVersion: PINNED_PI_VERSION,
 			});
 			verboseLog(config, `TLH private Pi runtime is valid: ${piBin}`);
 			// Prepend the private runtime's bin dir to PATH for the remainder of this
@@ -963,7 +947,6 @@ function installPiIfNeeded(config: InstallConfig): PiInstallResult {
 		piCommand: piBin,
 		sourceDescription: `freshly installed TLH private runtime at ${piBin}`,
 		versionCommandDisplay: `${piBin} --version`,
-		expectedVersion: PINNED_PI_VERSION,
 	});
 	// Prepend the private runtime's bin dir for the remainder of this process so
 	// downstream steps (pi install, pi update, …) resolve the new binary.

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -23,7 +23,7 @@ import { validateInstallerTargets } from "../scripts/lib/tlh-install-paths.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoNodeModulesBin = join(repoRoot, "node_modules", ".bin");
-const TLH_MIN_PI_VERSION = "0.80.1";
+const TLH_NON_PINNED_PI_VERSION = "0.80.1";
 const TLH_PINNED_PI_VERSION = "0.80.5";
 
 const TLH_PI_PACKAGE_SPEC = `@earendil-works/pi-coding-agent@${TLH_PINNED_PI_VERSION}`;
@@ -166,7 +166,7 @@ function writeFakeTk(fakebin) {
 	writeFakeCommand(fakebin, "tk", "printf 'Usage: tk help\\nTicket CLI helper\\n'");
 }
 
-function writeLoggingPi(commandDir, logPath, version = TLH_MIN_PI_VERSION) {
+function writeLoggingPi(commandDir, logPath, version = TLH_PINNED_PI_VERSION) {
 	writeFakePi(commandDir, [
 		`printf '%s|%s|%s\\n' "\${PI_CODING_AGENT_DIR:-}" "$PWD" "$*" >>"${logPath}"`,
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${version}\\n'; exit 0; fi`,
@@ -174,7 +174,7 @@ function writeLoggingPi(commandDir, logPath, version = TLH_MIN_PI_VERSION) {
 	].join("\n"));
 }
 
-function writeVersionedWrapperPi(commandDir, logPath, version = TLH_MIN_PI_VERSION) {
+function writeVersionedWrapperPi(commandDir, logPath, version = TLH_PINNED_PI_VERSION) {
 	writeFakePi(commandDir, [
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${version}\\n'; exit 0; fi`,
 		`{ printf 'cmd=%s\\n' "$0"; printf 'argv=%s\\n' "$*"; printf 'agent=%s\\n' "\${PI_CODING_AGENT_DIR:-}"; printf 'path=%s\\n' "\${PATH:-}"; } >"${logPath}"`,
@@ -435,10 +435,10 @@ test("stage-1 repairs the TLH private Pi runtime even when a supported Pi exists
 	}, null, 2));
 	writeFakeCommand(fakebin, "git", "exit 0");
 	writeFakeTk(fakebin);
-	// A supported PATH pi — the installer must never use it (private runtime only).
+	// A non-pinned PATH pi — the installer must never use it (private runtime only).
 	writeFakePi(supportedPiDir, [
 		`printf '%s|%s|%s\\n' "\${PI_CODING_AGENT_DIR:-}" "$PWD" "$*" >>"${pathPiLog}"`,
-		`if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_MIN_PI_VERSION}\\n'; exit 0; fi`,
+		`if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_NON_PINNED_PI_VERSION}\\n'; exit 0; fi`,
 		"exit 0",
 	].join("\n"));
 	// Stale private runtime at 0.80.6 (above pin) triggers repair.
@@ -753,7 +753,7 @@ test("stage-1 --no-settings does not short-circuit Gnosis configure", (t) => {
 	const binDir = join(root, "bin");
 	const fakebin = join(root, "fakebin");
 	mkdirSync(homeDir, { recursive: true });
-	writeFakePi(fakebin, "if [[ \"${1:-}\" == \"--version\" ]]; then\n\tprintf '0.80.1\\n'\n\texit 0\nfi\nexit 0");
+	writeFakePi(fakebin, `if [[ "\${1:-}" == "--version" ]]; then\n\tprintf '${TLH_PINNED_PI_VERSION}\\n'\n\texit 0\nfi\nexit 0`);
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	const result = spawnSync(process.execPath, [
@@ -2596,7 +2596,7 @@ test("wrapper update --extensions helper prepends executable --pi-cmd directory 
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	mkdirSync(pinnedPiDir, { recursive: true });
-	writeFileSync(join(pinnedPiDir, "pi"), "#!/bin/sh\nif [ \"${1:-}\" = \"--version\" ]; then printf '0.80.1\\n'; exit 0; fi\nprintf 'unexpected args: %s\\n' \"$*\" >&2\nexit 1\n", "utf8");
+	writeFileSync(join(pinnedPiDir, "pi"), `#!/bin/sh\nif [ "\${1:-}" = "--version" ]; then printf '${TLH_NON_PINNED_PI_VERSION}\\n'; exit 0; fi\nprintf 'unexpected args: %s\\n' "$*" >&2\nexit 1\n`, "utf8");
 	chmodSync(join(pinnedPiDir, "pi"), 0o755);
 	writeFileSync(join(agentDir, "tlh", "recover-update.mjs"), `import { spawnSync } from "node:child_process";\nimport { writeFileSync } from "node:fs";\nconst pi = spawnSync("pi", ["--version"], { encoding: "utf8" });\nwriteFileSync(process.env.TLH_UPDATE_LOG, JSON.stringify({ argv: process.argv.slice(2), env: { PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR, PATH: process.env.PATH }, pi: { status: pi.status, stdout: pi.stdout, stderr: pi.stderr, error: pi.error?.message } }));\nprocess.exit(pi.status ?? (pi.error ? 1 : 0));\n`, "utf8");
 
@@ -2640,7 +2640,7 @@ test("wrapper update --extensions helper prepends executable --pi-cmd directory 
 	]);
 	assert.equal(updateRecord.env.PI_CODING_AGENT_DIR, agentDir);
 	assert.equal(updateRecord.pi.status, 0, JSON.stringify(updateRecord));
-	assert.match(updateRecord.pi.stdout, new RegExp(escapeRegExp(TLH_MIN_PI_VERSION)));
+	assert.match(updateRecord.pi.stdout, new RegExp(escapeRegExp(TLH_NON_PINNED_PI_VERSION)));
 
 	const updatePathEntries = updateRecord.env.PATH.split(delimiter);
 	assert.equal(updatePathEntries[0], pinnedPiDir, `expected pinned_dir first; got ${updatePathEntries.join(delimiter)}`);
@@ -3217,7 +3217,7 @@ test("stage-1 installPiIfNeeded: broken npm install (wrong pi version) throws", 
 	// Legacy pi at ~/.local/bin/pi — must NOT be removed when install fails.
 	writeFakePi(legacyBin, `if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_PINNED_PI_VERSION}\\n'; exit 0; fi\nexit 0`);
 
-	// Template pi with WRONG version (0.80.6 > MAX 0.80.5) — simulates a broken npm install.
+	// Template pi with a clearly wrong non-pinned version (0.80.6) — simulates a broken npm install.
 	writeFakePi(templateDir, "if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.80.6\\n'; exit 0; fi\nexit 0");
 
 	// Fake npm: always installs the wrong-version template pi.


### PR DESCRIPTION
## Summary

Removes the legacy minimum/maximum Pi version range scaffolding from the TLH installer. TLH now installs and validates an exact pinned private Pi runtime, so the installer only enforces `PINNED_PI_VERSION`.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
bash install.sh --dry-run --agent-dir "$(mktemp -d)/agent" --bin-dir "$(mktemp -d)"
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `npm run validate` passed.
- A first validate attempt hit a transient `tests/tlh-rtk.test.mjs` failure; rerunning that targeted test passed, and rerunning full `npm run validate` passed.
- Audit found no `TLH_MIN_PI_VERSION`, `MIN_PI_VERSION`, `MAX_PI_VERSION`, or `supportedPiVersionRange` references in installer/docs/tests.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/remove-pi-min-version/install.sh | bash -s -- --ref remove-pi-min-version --track ref
```
