### PR TITLE
Quiet idle ticket workflow footer

### DIFF
--- a/extensions/the-last-harness/ticket-workflow-ui.ts
+++ b/extensions/the-last-harness/ticket-workflow-ui.ts
@@ -1,4 +1,6 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { statSync } from "node:fs";
+import { join } from "node:path";
 
 import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 
@@ -20,7 +22,7 @@ const TK_STATUS_HELP = "Use /tk-status for details.";
 
 type TkWorkflowSnapshot =
 	| { kind: "disabled" }
-	| { kind: "unavailable"; message: string }
+	| { kind: "unavailable"; message: string; hasRepoEvidence: boolean }
 	| { kind: "no-repo"; message: string }
 	| { kind: "no-tickets" }
 	| {
@@ -65,6 +67,14 @@ function runTkCommand(command: string, cwd: string, args: string[]): TkCommandRe
 	});
 }
 
+function hasTicketRepoEvidence(cwd: string): boolean {
+	try {
+		return statSync(join(cwd, ".tickets")).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
 function parseJsonLines(output: string): Array<{ status?: string }> {
 	const lines = output
 		.split(/\r?\n/)
@@ -86,27 +96,28 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 	}
 
 	const settings = getTlhGlobalSettings(cwd);
+	const repoEvidence = hasTicketRepoEvidence(cwd);
 	const command = findValidTlhTicketCommand(settings, getAgentDir());
 	if (!command) {
-		return { kind: "unavailable", message: "tk is unavailable for this TLH profile." };
+		return { kind: "unavailable", message: "tk is unavailable for this TLH profile.", hasRepoEvidence: repoEvidence };
 	}
 
 	const queryResult = runTkCommand(command, cwd, ["query"]);
 	const queryFailure = firstOutputLine(queryResult);
 	if (queryResult.error) {
-		return { kind: "unavailable", message: queryResult.error.message };
+		return { kind: "unavailable", message: queryResult.error.message, hasRepoEvidence: repoEvidence };
 	}
 	if (queryResult.status !== 0) {
 		return isNoRepoMessage(queryFailure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: queryFailure ?? "tk query failed." };
+			: { kind: "unavailable", message: queryFailure ?? "tk query failed.", hasRepoEvidence: repoEvidence };
 	}
 
 	let tickets: Array<{ status?: string }>;
 	try {
 		tickets = parseJsonLines(queryResult.stdout || "");
 	} catch {
-		return { kind: "unavailable", message: "Could not parse tk query output." };
+		return { kind: "unavailable", message: "Could not parse tk query output.", hasRepoEvidence: repoEvidence };
 	}
 	if (tickets.length === 0) {
 		return { kind: "no-tickets" };
@@ -114,24 +125,24 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 
 	const readyResult = runTkCommand(command, cwd, ["ready"]);
 	if (readyResult.error) {
-		return { kind: "unavailable", message: readyResult.error.message };
+		return { kind: "unavailable", message: readyResult.error.message, hasRepoEvidence: repoEvidence };
 	}
 	if (readyResult.status !== 0) {
 		const failure = firstOutputLine(readyResult);
 		return isNoRepoMessage(failure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: failure ?? "tk ready failed." };
+			: { kind: "unavailable", message: failure ?? "tk ready failed.", hasRepoEvidence: repoEvidence };
 	}
 
 	const blockedResult = runTkCommand(command, cwd, ["blocked"]);
 	if (blockedResult.error) {
-		return { kind: "unavailable", message: blockedResult.error.message };
+		return { kind: "unavailable", message: blockedResult.error.message, hasRepoEvidence: repoEvidence };
 	}
 	if (blockedResult.status !== 0) {
 		const failure = firstOutputLine(blockedResult);
 		return isNoRepoMessage(failure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: failure ?? "tk blocked failed." };
+			: { kind: "unavailable", message: failure ?? "tk blocked failed.", hasRepoEvidence: repoEvidence };
 	}
 
 	const active = tickets.filter((ticket) => ticket.status === "open" || ticket.status === "in_progress").length;
@@ -149,13 +160,10 @@ function formatTkWorkflowSummary(snapshot: TkWorkflowSnapshot): string | undefin
 		return undefined;
 	}
 	if (snapshot.kind === "unavailable") {
-		return "tk: unavailable";
+		return snapshot.hasRepoEvidence ? "tk: unavailable" : undefined;
 	}
-	if (snapshot.kind === "no-repo") {
-		return "tk: no repo";
-	}
-	if (snapshot.kind === "no-tickets") {
-		return "tk: no tickets";
+	if (snapshot.kind === "no-repo" || snapshot.kind === "no-tickets") {
+		return undefined;
 	}
 	return `tk: ${snapshot.ready.length} ready • ${snapshot.blocked.length} blocked • ${snapshot.active} active`;
 }

--- a/tests/tlh-ticket-workflow-ui.test.mjs
+++ b/tests/tlh-ticket-workflow-ui.test.mjs
@@ -93,6 +93,10 @@ case "\${1:-}" in
     echo "Tickets stored as markdown files in .tickets/"
     ;;
   query)
+    if [[ ! -d .tickets ]]; then
+      echo "no .tickets directory found" >&2
+      exit 1
+    fi
     case "$state" in
       default)
         cat <<'EOF'
@@ -113,6 +117,10 @@ EOF
     esac
     ;;
   ready)
+    if [[ ! -d .tickets ]]; then
+      echo "no .tickets directory found" >&2
+      exit 1
+    fi
     case "$state" in
       default)
         echo "tlhf-7rd2 [P2][open] - Implement read-only ticket workflow status UI"
@@ -122,6 +130,10 @@ EOF
     esac
     ;;
   blocked)
+    if [[ ! -d .tickets ]]; then
+      echo "no .tickets directory found" >&2
+      exit 1
+    fi
     case "$state" in
       default|updated)
         echo "tlhf-16ll [P2][open] - Document and validate ticket workflow UI experiment <- [tlhf-7rd2]"
@@ -162,6 +174,7 @@ test("ticket workflow UI stays completely disabled by default", async (t) => {
 
 test("enabled ticket workflow UI renders read-only status, ignores unrelated bash results, refreshes after tk bash and user_bash results, and exposes /tk-status", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
 	const statePath = join(fixture.dir, "tk-state");
 	writeFileSync(statePath, "default\n");
 	installFakeTk(fixture.agent, statePath);
@@ -210,6 +223,7 @@ test("enabled ticket workflow UI renders read-only status, ignores unrelated bas
 
 test("ticket workflow UI reacts to current-session experimental enable and disable", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
 	const statePath = join(fixture.dir, "tk-state");
 	writeFileSync(statePath, "default\n");
 	installFakeTk(fixture.agent, statePath);
@@ -250,45 +264,78 @@ test("ticket workflow UI reacts to current-session experimental enable and disab
 	});
 });
 
-test("enabled /tk-status reports unavailable tk and no tickets clearly", async (t) => {
-	const unavailableFixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+test("enabled ticket workflow UI stays quiet without a .tickets repo while /tk-status reports no-repo", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	const statePath = join(fixture.dir, "tk-state");
+	writeFileSync(statePath, "default\n");
+	installFakeTk(fixture.agent, statePath);
 	writeFileSync(
-		join(unavailableFixture.agent, "settings.json"),
+		join(fixture.agent, "settings.json"),
 		`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [TICKET_WORKFLOW_UI_FEATURE] } } }, null, 2)}\n`,
 	);
 
-	await withEnv({ HOME: unavailableFixture.home, PI_CODING_AGENT_DIR: unavailableFixture.agent, PATH: "" }, async () => {
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const pi = createPiHarness();
 		registerTlhTicketWorkflowUi(pi);
 		const uiHarness = createUiHarness();
-		const ctx = createCtx(unavailableFixture.cwd, uiHarness.ui);
+		const ctx = createCtx(fixture.cwd, uiHarness.ui);
 
 		await fireAll(pi, "session_start", { reason: "restore" }, ctx);
-		assert.match(uiHarness.statusUpdates.at(-1)?.text ?? "", /tk: unavailable/);
+		assert.equal(pi.commands.has("tk-status"), true);
+		assert.deepEqual(uiHarness.statusUpdates, [{ key: "tlh-ticket-workflow", text: undefined }]);
+		assert.deepEqual(uiHarness.widgetUpdates, [{ key: "tlh-ticket-workflow", content: undefined, options: undefined }]);
 
 		await pi.commands.get("tk-status").handler("", ctx);
-		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /Ticket workflow status unavailable: tk is unavailable/i);
+		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /No \.tickets directory found/i);
 	});
+});
 
-	const noTicketsFixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
-	const statePath = join(noTicketsFixture.dir, "tk-state");
+test("enabled ticket workflow UI stays quiet for an empty ticket repo while /tk-status reports no tickets", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
+	const statePath = join(fixture.dir, "tk-state");
 	writeFileSync(statePath, "empty\n");
-	installFakeTk(noTicketsFixture.agent, statePath);
+	installFakeTk(fixture.agent, statePath);
 	writeFileSync(
-		join(noTicketsFixture.agent, "settings.json"),
+		join(fixture.agent, "settings.json"),
 		`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [TICKET_WORKFLOW_UI_FEATURE] } } }, null, 2)}\n`,
 	);
 
-	await withEnv({ HOME: noTicketsFixture.home, PI_CODING_AGENT_DIR: noTicketsFixture.agent }, async () => {
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const pi = createPiHarness();
 		registerTlhTicketWorkflowUi(pi);
 		const uiHarness = createUiHarness();
-		const ctx = createCtx(noTicketsFixture.cwd, uiHarness.ui);
+		const ctx = createCtx(fixture.cwd, uiHarness.ui);
 
 		await fireAll(pi, "session_start", { reason: "restore" }, ctx);
-		assert.match(uiHarness.statusUpdates.at(-1)?.text ?? "", /tk: no tickets/);
+		assert.equal(pi.commands.has("tk-status"), true);
+		assert.deepEqual(uiHarness.statusUpdates, [{ key: "tlh-ticket-workflow", text: undefined }]);
+		assert.deepEqual(uiHarness.widgetUpdates, [{ key: "tlh-ticket-workflow", content: undefined, options: undefined }]);
 
 		await pi.commands.get("tk-status").handler("", ctx);
 		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /tk: no tickets in this repo/i);
+	});
+});
+
+test("enabled ticket workflow UI may show unavailable when .tickets exists and tk is missing", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
+	writeFileSync(
+		join(fixture.agent, "settings.json"),
+		`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [TICKET_WORKFLOW_UI_FEATURE] } } }, null, 2)}\n`,
+	);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, PATH: "" }, async () => {
+		const pi = createPiHarness();
+		registerTlhTicketWorkflowUi(pi);
+		const uiHarness = createUiHarness();
+		const ctx = createCtx(fixture.cwd, uiHarness.ui);
+
+		await fireAll(pi, "session_start", { reason: "restore" }, ctx);
+		assert.match(uiHarness.statusUpdates.at(-1)?.text ?? "", /tk: unavailable/);
+		assert.deepEqual(uiHarness.widgetUpdates.at(-1)?.content, ["tk: unavailable", "Use /tk-status for details."]);
+
+		await pi.commands.get("tk-status").handler("", ctx);
+		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /Ticket workflow status unavailable: tk is unavailable/i);
 	});
 });


### PR DESCRIPTION
## Summary

Quiet the experimental `ticket-workflow-ui` footer/widget before an active tk ticket repo exists. `/tk-status` still reports explicit diagnostics for no repo, no tickets, or unavailable tk states.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Focused check also run:

```sh
node --test tests/tlh-ticket-workflow-ui.test.mjs
```

Relevant result summary: both focused ticket-workflow UI tests and `npm run validate` passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants: N/A for installer paths; this only changes an extension UI surface and tests.
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/quiet-ticket-workflow-footer/install.sh | bash -s -- --ref fix/quiet-ticket-workflow-footer --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket workflow status is now shown only when a repository has ticket evidence and the ticket tool is unavailable.
  * Repositories without a `.tickets` directory or without tickets no longer display misleading workflow status text.
  * `/tk-status` now provides clearer messages for missing ticket directories, empty ticket repositories, and unavailable ticket tooling.
* **Tests**
  * Added coverage for ticket repository detection and the updated status behavior across supported workflow states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->