### PR TITLE
Quiet unavailable ticket workflow footer

### DIFF
--- a/extensions/the-last-harness/ticket-workflow-ui.ts
+++ b/extensions/the-last-harness/ticket-workflow-ui.ts
@@ -1,6 +1,4 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { statSync } from "node:fs";
-import { join } from "node:path";
 
 import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 
@@ -22,7 +20,7 @@ const TK_STATUS_HELP = "Use /tk-status for details.";
 
 type TkWorkflowSnapshot =
 	| { kind: "disabled" }
-	| { kind: "unavailable"; message: string; hasRepoEvidence: boolean }
+	| { kind: "unavailable"; message: string }
 	| { kind: "no-repo"; message: string }
 	| { kind: "no-tickets" }
 	| {
@@ -67,14 +65,6 @@ function runTkCommand(command: string, cwd: string, args: string[]): TkCommandRe
 	});
 }
 
-function hasTicketRepoEvidence(cwd: string): boolean {
-	try {
-		return statSync(join(cwd, ".tickets")).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
 function parseJsonLines(output: string): Array<{ status?: string }> {
 	const lines = output
 		.split(/\r?\n/)
@@ -96,28 +86,27 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 	}
 
 	const settings = getTlhGlobalSettings(cwd);
-	const repoEvidence = hasTicketRepoEvidence(cwd);
 	const command = findValidTlhTicketCommand(settings, getAgentDir());
 	if (!command) {
-		return { kind: "unavailable", message: "tk is unavailable for this TLH profile.", hasRepoEvidence: repoEvidence };
+		return { kind: "unavailable", message: "tk is unavailable for this TLH profile." };
 	}
 
 	const queryResult = runTkCommand(command, cwd, ["query"]);
 	const queryFailure = firstOutputLine(queryResult);
 	if (queryResult.error) {
-		return { kind: "unavailable", message: queryResult.error.message, hasRepoEvidence: repoEvidence };
+		return { kind: "unavailable", message: queryResult.error.message };
 	}
 	if (queryResult.status !== 0) {
 		return isNoRepoMessage(queryFailure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: queryFailure ?? "tk query failed.", hasRepoEvidence: repoEvidence };
+			: { kind: "unavailable", message: queryFailure ?? "tk query failed." };
 	}
 
 	let tickets: Array<{ status?: string }>;
 	try {
 		tickets = parseJsonLines(queryResult.stdout || "");
 	} catch {
-		return { kind: "unavailable", message: "Could not parse tk query output.", hasRepoEvidence: repoEvidence };
+		return { kind: "unavailable", message: "Could not parse tk query output." };
 	}
 	if (tickets.length === 0) {
 		return { kind: "no-tickets" };
@@ -125,24 +114,24 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 
 	const readyResult = runTkCommand(command, cwd, ["ready"]);
 	if (readyResult.error) {
-		return { kind: "unavailable", message: readyResult.error.message, hasRepoEvidence: repoEvidence };
+		return { kind: "unavailable", message: readyResult.error.message };
 	}
 	if (readyResult.status !== 0) {
 		const failure = firstOutputLine(readyResult);
 		return isNoRepoMessage(failure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: failure ?? "tk ready failed.", hasRepoEvidence: repoEvidence };
+			: { kind: "unavailable", message: failure ?? "tk ready failed." };
 	}
 
 	const blockedResult = runTkCommand(command, cwd, ["blocked"]);
 	if (blockedResult.error) {
-		return { kind: "unavailable", message: blockedResult.error.message, hasRepoEvidence: repoEvidence };
+		return { kind: "unavailable", message: blockedResult.error.message };
 	}
 	if (blockedResult.status !== 0) {
 		const failure = firstOutputLine(blockedResult);
 		return isNoRepoMessage(failure)
 			? { kind: "no-repo", message: "No .tickets directory found for this repo." }
-			: { kind: "unavailable", message: failure ?? "tk blocked failed.", hasRepoEvidence: repoEvidence };
+			: { kind: "unavailable", message: failure ?? "tk blocked failed." };
 	}
 
 	const active = tickets.filter((ticket) => ticket.status === "open" || ticket.status === "in_progress").length;
@@ -160,7 +149,7 @@ function formatTkWorkflowSummary(snapshot: TkWorkflowSnapshot): string | undefin
 		return undefined;
 	}
 	if (snapshot.kind === "unavailable") {
-		return snapshot.hasRepoEvidence ? "tk: unavailable" : undefined;
+		return undefined;
 	}
 	if (snapshot.kind === "no-repo" || snapshot.kind === "no-tickets") {
 		return undefined;

--- a/tests/tlh-ticket-workflow-ui.test.mjs
+++ b/tests/tlh-ticket-workflow-ui.test.mjs
@@ -317,7 +317,7 @@ test("enabled ticket workflow UI stays quiet for an empty ticket repo while /tk-
 	});
 });
 
-test("enabled ticket workflow UI may show unavailable when .tickets exists and tk is missing", async (t) => {
+test("enabled ticket workflow UI stays quiet when .tickets exists and tk is missing while /tk-status keeps diagnostics", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
 	mkdirSync(join(fixture.cwd, ".tickets"));
 	writeFileSync(
@@ -332,8 +332,8 @@ test("enabled ticket workflow UI may show unavailable when .tickets exists and t
 		const ctx = createCtx(fixture.cwd, uiHarness.ui);
 
 		await fireAll(pi, "session_start", { reason: "restore" }, ctx);
-		assert.match(uiHarness.statusUpdates.at(-1)?.text ?? "", /tk: unavailable/);
-		assert.deepEqual(uiHarness.widgetUpdates.at(-1)?.content, ["tk: unavailable", "Use /tk-status for details."]);
+		assert.deepEqual(uiHarness.statusUpdates, [{ key: "tlh-ticket-workflow", text: undefined }]);
+		assert.deepEqual(uiHarness.widgetUpdates, [{ key: "tlh-ticket-workflow", content: undefined, options: undefined }]);
 
 		await pi.commands.get("tk-status").handler("", ctx);
 		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /Ticket workflow status unavailable: tk is unavailable/i);


### PR DESCRIPTION
## Summary

Suppress the experimental ticket workflow footer/widget when `tk` is unavailable, including the `Use /tk-status for details.` helper line, while preserving `/tk-status` diagnostics.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

_Paste the relevant output or a summary here:_

- `node --test --test-reporter=dot tests/tlh-ticket-workflow-ui.test.mjs` passed.
- `npm run validate` passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - extension-only change; no installer/profile mutation paths changed
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
  - not updated; small experimental UI noise reduction
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/quiet-unavailable-ticket-footer/install.sh | bash -s -- --ref quiet-unavailable-ticket-footer --track ref
```