### PR TITLE
Split default-extension installer tests

### DIFF
--- a/tests/install-stage1-default-extensions-test-helpers.mjs
+++ b/tests/install-stage1-default-extensions-test-helpers.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir, readPiLogRecords } from "./install-stage1-test-helpers.mjs";
+
+import { buildInstallConfig, parseArgs } from "../scripts/tlh-install.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function scrubInstallerEnv(overrides = {}, baseEnv = process.env) {
+	const env = {};
+	for (const [key, value] of Object.entries(baseEnv)) {
+		if (key === "PI_CODING_AGENT_DIR" || key.startsWith("TLH_")) continue;
+		env[key] = value;
+	}
+	return { ...env, ...overrides };
+}
+
+function writeFakeCommand(fakebin, name, body) {
+	mkdirSync(fakebin, { recursive: true });
+	const commandPath = join(fakebin, name);
+	writeFileSync(commandPath, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`, "utf8");
+	chmodSync(commandPath, 0o755);
+}
+
+function writeFakePi(fakebin, body) {
+	writeFakeCommand(fakebin, "pi", body);
+}
+
+export function makeDefaultExtensionInstallConfig(t, { defaultExtensions, settings, dryRun = false, fakePiBody = "exit 0", fakeGitBody = "" }) {
+	const root = makeTempDir();
+	const homeDir = join(root, "home");
+	const agentDir = join(root, "agent");
+	const binDir = join(root, "bin");
+	const fakebin = join(root, "fakebin");
+	const piLog = join(root, "pi.log");
+	const defaultsPath = join(root, "default-extensions.json");
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(defaultsPath, JSON.stringify(defaultExtensions, null, 2));
+	writeFileSync(join(agentDir, "settings.json"), JSON.stringify(settings, null, 2));
+	writeFakePi(fakebin, fakePiBody);
+	if (fakeGitBody) writeFakeCommand(fakebin, "git", fakeGitBody);
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+
+	const env = scrubInstallerEnv({
+		HOME: homeDir,
+		PATH: `${fakebin}:${process.env.PATH || ""}`,
+		PI_LOG: piLog,
+		AGENT_DIR: agentDir,
+	});
+	const args = ["--agent-dir", agentDir, "--bin-dir", binDir];
+	if (dryRun) args.unshift("--dry-run");
+	const config = buildInstallConfig(parseArgs(args, env), env);
+	if (!dryRun) config.quiet = true;
+	config.piCmd = join(fakebin, "pi");
+	config.supportFilePaths.TLH_DEFAULTS_SCRIPT = join(repoRoot, "scripts/tlh-defaults.mjs");
+	config.supportFilePaths.DEFAULT_EXTENSIONS_FILE = defaultsPath;
+	return { config, agentDir, piLog };
+}
+
+export function assertPiCommands(path, agentDir, commands) {
+	const records = readPiLogRecords(path);
+	assert.deepEqual(records.map((record) => [record.agentDir, record.command]), commands.map((command) => [agentDir, command]));
+	for (const record of records) assert.equal(realpathSync(record.cwd), realpathSync(agentDir));
+}

--- a/tests/install-stage1-default-extensions.test.mjs
+++ b/tests/install-stage1-default-extensions.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { captureConsole, readPiLog } from "./install-stage1-test-helpers.mjs";
+import {
+	assertPiCommands,
+	makeDefaultExtensionInstallConfig,
+} from "./install-stage1-default-extensions-test-helpers.mjs";
+
+import { installDefaultExtensions } from "../scripts/tlh-install.mjs";
+
+test("stage-1 batches non-critical default extension updates", (t) => {
+	const defaults = [
+		{ id: "helper-a", source: "npm:helper-a" },
+		{ id: "helper-b", source: "npm:helper-b" },
+	];
+	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
+		defaultExtensions: defaults,
+		settings: { packages: defaults.map((entry) => entry.source) },
+		fakePiBody: "printf '%s|%s|%s\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
+	});
+
+	installDefaultExtensions(config);
+
+	assertPiCommands(piLog, agentDir, ["update --extensions"]);
+});
+
+test("stage-1 falls back to old-CLI positional per-source non-critical updates when batch update fails", (t) => {
+	const criticalSource = "git:github.com/example/critical";
+	const defaults = [
+		{ id: "critical", critical: true, source: criticalSource },
+		{ id: "helper-a", source: "npm:helper-a" },
+		{ id: "helper-b", source: "npm:helper-b" },
+	];
+	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
+		defaultExtensions: defaults,
+		settings: { packages: defaults.map((entry) => entry.source) },
+		fakePiBody: [
+			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extensions\" ]]; then",
+			"\tprintf 'batch failed\\n' >&2",
+			"\texit 42",
+			"fi",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" ]]; then",
+			"\tprintf 'old pi does not support --extension\\n' >&2",
+			"\texit 98",
+			"fi",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-a\" ]]; then",
+			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-a.done\"",
+			"\texit 0",
+			"fi",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-b\" ]]; then",
+			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-b.attempted\"",
+			"\tprintf 'helper-b failed\\n' >&2",
+			"\texit 43",
+			"fi",
+			"if [[ \"$1\" == \"install\" && \"${2:-}\" == \"git:github.com/example/critical\" ]]; then",
+			"\t[[ -f \"${PI_CODING_AGENT_DIR}/fallback-a.done\" && -f \"${PI_CODING_AGENT_DIR}/fallback-b.attempted\" ]] || { printf 'critical install ran before fallback completed\\n' >&2; exit 44; }",
+			"\texit 0",
+			"fi",
+		].join("\n"),
+	});
+
+	const stderr = captureConsole("error", () => installDefaultExtensions(config));
+
+	assertPiCommands(piLog, agentDir, [
+		"update --extensions",
+		"update npm:helper-a",
+		"update npm:helper-b",
+		"install git:github.com/example/critical",
+	]);
+	assert.match(stderr, /warning: settings-wide extension refresh from merged settings failed; falling back to per-source updates for only 2 non-critical bundled default source\(s\)/);
+	assert.match(stderr, /warning: default extension package update failed; continuing: npm:helper-b/);
+	assert.match(stderr, /warning: 1 bundled default extension package\(s\) failed to update/);
+});
+
+test("stage-1 rejects unsafe critical default checkouts before settings-wide updates", (t) => {
+	const criticalSource = "git:github.com/example/critical@pin";
+	const defaults = [
+		{ id: "critical", critical: true, source: criticalSource },
+		{ id: "helper", source: "npm:helper" },
+	];
+	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
+		defaultExtensions: defaults,
+		settings: { packages: defaults.map((entry) => entry.source) },
+		fakePiBody: [
+			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
+			"printf 'pi should not run for unsafe critical checkout\\n' >&2",
+			"exit 45",
+		].join("\n"),
+	});
+	mkdirSync(join(agentDir, "git", "github.com", "example", "critical"), { recursive: true });
+
+	assert.throws(
+		() => installDefaultExtensions(config),
+		/refusing to use existing non-git critical default extension package checkout/,
+	);
+	assert.deepEqual(readPiLog(piLog), []);
+});
+
+test("stage-1 preflights critical checkouts before batch and validates critical refs after", (t) => {
+	const criticalSource = "git:github.com/example/critical@pin";
+	const defaults = [
+		{ id: "critical", critical: true, source: criticalSource },
+		{ id: "helper", source: "npm:helper" },
+	];
+	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
+		defaultExtensions: defaults,
+		settings: { packages: defaults.map((entry) => entry.source) },
+		fakePiBody: [
+			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extensions\" ]]; then",
+			"\t[[ -f \"${PI_CODING_AGENT_DIR}/preflight-safe.done\" ]] || { printf 'settings-wide update ran before critical preflight\\n' >&2; exit 46; }",
+			"\tprintf 'stage:settings-wide-batch\\n' >>\"${PI_LOG}.order\"",
+			"\ttouch \"${PI_CODING_AGENT_DIR}/settings-wide-update.done\"",
+			"\texit 0",
+			"fi",
+			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" ]]; then",
+			"\tprintf 'unexpected per-source fallback: %s\\n' \"$*\" >&2",
+			"\texit 47",
+			"fi",
+			"if [[ \"$1\" == \"install\" && \"${2:-}\" == \"git:github.com/example/critical@pin\" ]]; then",
+			"\t[[ -f \"${PI_CODING_AGENT_DIR}/settings-wide-update.done\" ]] || { printf 'critical install ran before settings-wide update\\n' >&2; exit 48; }",
+			"\t[[ -f \"${PI_CODING_AGENT_DIR}/critical-preinstall-validation.done\" ]] || { printf 'critical install ran before post-batch safety validation\\n' >&2; exit 49; }",
+			"\tprintf 'stage:critical-install\\n' >>\"${PI_LOG}.order\"",
+			"\ttouch \"${PI_CODING_AGENT_DIR}/critical-install.done\"",
+			"\texit 0",
+			"fi",
+		].join("\n"),
+		fakeGitBody: [
+			"target=''",
+			"if [[ \"${1:-}\" == \"-C\" ]]; then target=\"$2\"; shift 2; fi",
+			"record_stage() { local stage=\"$1\" marker=\"$2\"; if [[ ! -f \"${AGENT_DIR}/${marker}\" ]]; then printf 'stage:%s\\n' \"$stage\" >>\"${PI_LOG}.order\"; touch \"${AGENT_DIR}/${marker}\"; fi; }",
+			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--show-toplevel\" ]]; then",
+			"\tif [[ ! -f \"${AGENT_DIR}/settings-wide-update.done\" ]]; then",
+			"\t\trecord_stage preflight-safe preflight-safe.done",
+			"\telif [[ ! -f \"${AGENT_DIR}/critical-install.done\" ]]; then",
+			"\t\t[[ -f \"${AGENT_DIR}/preflight-safe.done\" ]] || { printf 'post-batch validation ran before preflight\\n' >&2; exit 50; }",
+			"\t\trecord_stage critical-preinstall-validation critical-preinstall-validation.done",
+			"\telse",
+			"\t\t[[ -f \"${AGENT_DIR}/settings-wide-update.done\" ]] || { printf 'ref validation ran before settings-wide update\\n' >&2; exit 51; }",
+			"\t\trecord_stage critical-ref-validation critical-ref-validation.done",
+			"\tfi",
+			"\tprintf '%s\\n' \"$target\"",
+			"\texit 0",
+			"fi",
+			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--absolute-git-dir\" ]]; then printf '%s/.git\\n' \"$target\"; exit 0; fi",
+			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--git-common-dir\" ]]; then printf '%s/.git\\n' \"$target\"; exit 0; fi",
+			"exit 0",
+		].join("\n"),
+	});
+	mkdirSync(join(agentDir, "git", "github.com", "example", "critical", ".git"), { recursive: true });
+
+	installDefaultExtensions(config);
+
+	assertPiCommands(piLog, agentDir, [
+		"update --extensions",
+		"install git:github.com/example/critical@pin",
+	]);
+	const stages = readFileSync(`${piLog}.order`, "utf8").trim().split(/\r?\n/);
+	assert.deepEqual(stages, [
+		"stage:preflight-safe",
+		"stage:settings-wide-batch",
+		"stage:critical-preinstall-validation",
+		"stage:critical-install",
+		"stage:critical-ref-validation",
+	]);
+});
+
+test("stage-1 keeps critical defaults on per-source install path while dry-run shows batch fallback", (t) => {
+	const criticalSource = "git:github.com/example/critical@pin";
+	const defaults = [
+		{ id: "critical", critical: true, source: criticalSource },
+		{ id: "helper", source: "npm:helper" },
+	];
+	const { config } = makeDefaultExtensionInstallConfig(t, {
+		defaultExtensions: defaults,
+		settings: { packages: defaults.map((entry) => entry.source) },
+		dryRun: true,
+	});
+
+	const stdout = captureConsole("log", () => installDefaultExtensions(config));
+
+	assert.match(stdout, /Would preflight 1 critical bundled default git checkout target\(s\) before any settings-wide default extension update/);
+	assert.match(stdout, /pi install git:github\.com\/example\/critical@pin/);
+	assert.match(stdout, /git -C .*\/git\/github\.com\/example\/critical fetch --prune --tags origin/);
+	assert.match(stdout, /Dry run: settings-wide extension refresh will run from merged settings/);
+	assert.match(stdout, /PI_CODING_AGENT_DIR=.*pi update --extensions/);
+	assert.match(stdout, /would retry only 1 non-critical bundled default source\(s\) individually/i);
+	assert.doesNotMatch(stdout, /^Would.*\bpi\s+update\b/m);
+	assert.doesNotMatch(stdout, /pi update --extension npm:helper/);
+});

--- a/tests/install-stage1-test-helpers.mjs
+++ b/tests/install-stage1-test-helpers.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,4 +18,16 @@ export function captureConsole(method, callback) {
 		console[method] = original;
 	}
 	return lines.join("\n");
+}
+
+export function readPiLog(path) {
+	if (!existsSync(path)) return [];
+	return readFileSync(path, "utf8").trim().split(/\r?\n/).filter(Boolean);
+}
+
+export function readPiLogRecords(path) {
+	return readPiLog(path).map((line) => {
+		const [agentDir, cwd, ...commandParts] = line.split("|");
+		return { agentDir, cwd, command: commandParts.join("|") };
+	});
 }

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -6,7 +6,7 @@ import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { captureConsole, makeTempDir } from "./install-stage1-test-helpers.mjs";
+import { makeTempDir, readPiLogRecords } from "./install-stage1-test-helpers.mjs";
 
 import {
 	MIN_NODE_VERSION,
@@ -14,7 +14,6 @@ import {
 	RUNTIME_OWNED_TOPLEVEL,
 	assertSupportedNodeRuntime,
 	buildInstallConfig,
-	installDefaultExtensions,
 	nodeVersionMeetsMinimum,
 	parseArgs,
 	usage,
@@ -235,62 +234,9 @@ function runStage1LocalPackageInstall(t, {
 	return { result, homeDir, agentDir, binDir, piLog };
 }
 
-function makeDefaultExtensionInstallConfig(t, { defaultExtensions, settings, dryRun = false, fakePiBody = "exit 0", fakeGitBody = "" }) {
-	const root = makeTempDir();
-	const homeDir = join(root, "home");
-	const agentDir = join(root, "agent");
-	const binDir = join(root, "bin");
-	const fakebin = join(root, "fakebin");
-	const piLog = join(root, "pi.log");
-	const defaultsPath = join(root, "default-extensions.json");
-	mkdirSync(homeDir, { recursive: true });
-	mkdirSync(agentDir, { recursive: true });
-	writeFileSync(defaultsPath, JSON.stringify(defaultExtensions, null, 2));
-	writeFileSync(join(agentDir, "settings.json"), JSON.stringify(settings, null, 2));
-	writeFakePi(fakebin, fakePiBody);
-	if (fakeGitBody) writeFakeCommand(fakebin, "git", fakeGitBody);
-	t.after(() => rmSync(root, { recursive: true, force: true }));
-
-	const env = scrubInstallerEnv({
-		HOME: homeDir,
-		PATH: `${fakebin}:${process.env.PATH || ""}`,
-		PI_LOG: piLog,
-		AGENT_DIR: agentDir,
-	});
-	const args = ["--agent-dir", agentDir, "--bin-dir", binDir];
-	if (dryRun) args.unshift("--dry-run");
-	const config = buildInstallConfig(parseArgs(args, env), env);
-	if (!dryRun) config.quiet = true;
-	// In the private-runtime model, absolutePiCmd(config) resolves to the private
-	// runtime path which doesn't exist in tests.  Seed piCmd to the fakebin pi so
-	// installDefaultExtensions can invoke pi without a real npm install.
-	config.piCmd = join(fakebin, "pi");
-	config.supportFilePaths.TLH_DEFAULTS_SCRIPT = join(repoRoot, "scripts/tlh-defaults.mjs");
-	config.supportFilePaths.DEFAULT_EXTENSIONS_FILE = defaultsPath;
-	return { config, agentDir, piLog };
-}
-
-function readPiLog(path) {
-	if (!existsSync(path)) return [];
-	return readFileSync(path, "utf8").trim().split(/\r?\n/).filter(Boolean);
-}
-
-function readPiLogRecords(path) {
-	return readPiLog(path).map((line) => {
-		const [agentDir, cwd, ...commandParts] = line.split("|");
-		return { agentDir, cwd, command: commandParts.join("|") };
-	});
-}
-
 function readJsonLines(path) {
 	if (!existsSync(path)) return [];
 	return readFileSync(path, "utf8").trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
-}
-
-function assertPiCommands(path, agentDir, commands) {
-	const records = readPiLogRecords(path);
-	assert.deepEqual(records.map((record) => [record.agentDir, record.command]), commands.map((command) => [agentDir, command]));
-	for (const record of records) assert.equal(realpathSync(record.cwd), realpathSync(agentDir));
 }
 
 test("stage-1 enforces the TLH Node runtime minimum", () => {
@@ -2009,187 +1955,6 @@ test("tlh update removes isolated bin and skips non-file bash candidates before 
 	}
 });
 
-test("stage-1 batches non-critical default extension updates", (t) => {
-	const defaults = [
-		{ id: "helper-a", source: "npm:helper-a" },
-		{ id: "helper-b", source: "npm:helper-b" },
-	];
-	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
-		defaultExtensions: defaults,
-		settings: { packages: defaults.map((entry) => entry.source) },
-		fakePiBody: "printf '%s|%s|%s\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
-	});
-
-	installDefaultExtensions(config);
-
-	assertPiCommands(piLog, agentDir, ["update --extensions"]);
-});
-
-test("stage-1 falls back to old-CLI positional per-source non-critical updates when batch update fails", (t) => {
-	const criticalSource = "git:github.com/example/critical";
-	const defaults = [
-		{ id: "critical", critical: true, source: criticalSource },
-		{ id: "helper-a", source: "npm:helper-a" },
-		{ id: "helper-b", source: "npm:helper-b" },
-	];
-	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
-		defaultExtensions: defaults,
-		settings: { packages: defaults.map((entry) => entry.source) },
-		fakePiBody: [
-			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extensions\" ]]; then",
-			"\tprintf 'batch failed\\n' >&2",
-			"\texit 42",
-			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" ]]; then",
-			"\tprintf 'old pi does not support --extension\\n' >&2",
-			"\texit 98",
-			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-a\" ]]; then",
-			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-a.done\"",
-			"\texit 0",
-			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"npm:helper-b\" ]]; then",
-			"\ttouch \"${PI_CODING_AGENT_DIR}/fallback-b.attempted\"",
-			"\tprintf 'helper-b failed\\n' >&2",
-			"\texit 43",
-			"fi",
-			"if [[ \"$1\" == \"install\" && \"${2:-}\" == \"git:github.com/example/critical\" ]]; then",
-			"\t[[ -f \"${PI_CODING_AGENT_DIR}/fallback-a.done\" && -f \"${PI_CODING_AGENT_DIR}/fallback-b.attempted\" ]] || { printf 'critical install ran before fallback completed\\n' >&2; exit 44; }",
-			"\texit 0",
-			"fi",
-		].join("\n"),
-	});
-
-	const stderr = captureConsole("error", () => installDefaultExtensions(config));
-
-	assertPiCommands(piLog, agentDir, [
-		"update --extensions",
-		"update npm:helper-a",
-		"update npm:helper-b",
-		"install git:github.com/example/critical",
-	]);
-	assert.match(stderr, /warning: settings-wide extension refresh from merged settings failed; falling back to per-source updates for only 2 non-critical bundled default source\(s\)/);
-	assert.match(stderr, /warning: default extension package update failed; continuing: npm:helper-b/);
-	assert.match(stderr, /warning: 1 bundled default extension package\(s\) failed to update/);
-});
-
-test("stage-1 rejects unsafe critical default checkouts before settings-wide updates", (t) => {
-	const criticalSource = "git:github.com/example/critical@pin";
-	const defaults = [
-		{ id: "critical", critical: true, source: criticalSource },
-		{ id: "helper", source: "npm:helper" },
-	];
-	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
-		defaultExtensions: defaults,
-		settings: { packages: defaults.map((entry) => entry.source) },
-		fakePiBody: [
-			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
-			"printf 'pi should not run for unsafe critical checkout\\n' >&2",
-			"exit 45",
-		].join("\n"),
-	});
-	mkdirSync(join(agentDir, "git", "github.com", "example", "critical"), { recursive: true });
-
-	assert.throws(
-		() => installDefaultExtensions(config),
-		/refusing to use existing non-git critical default extension package checkout/,
-	);
-	assert.deepEqual(readPiLog(piLog), []);
-});
-
-test("stage-1 preflights critical checkouts before batch and validates critical refs after", (t) => {
-	const criticalSource = "git:github.com/example/critical@pin";
-	const defaults = [
-		{ id: "critical", critical: true, source: criticalSource },
-		{ id: "helper", source: "npm:helper" },
-	];
-	const { config, agentDir, piLog } = makeDefaultExtensionInstallConfig(t, {
-		defaultExtensions: defaults,
-		settings: { packages: defaults.map((entry) => entry.source) },
-		fakePiBody: [
-			"printf '%s|%s|%s\\n' \"${PI_CODING_AGENT_DIR:-}\" \"$PWD\" \"$*\" >>\"${PI_LOG}\"",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extensions\" ]]; then",
-			"\t[[ -f \"${PI_CODING_AGENT_DIR}/preflight-safe.done\" ]] || { printf 'settings-wide update ran before critical preflight\\n' >&2; exit 46; }",
-			"\tprintf 'stage:settings-wide-batch\\n' >>\"${PI_LOG}.order\"",
-			"\ttouch \"${PI_CODING_AGENT_DIR}/settings-wide-update.done\"",
-			"\texit 0",
-			"fi",
-			"if [[ \"$1\" == \"update\" && \"${2:-}\" == \"--extension\" ]]; then",
-			"\tprintf 'unexpected per-source fallback: %s\\n' \"$*\" >&2",
-			"\texit 47",
-			"fi",
-			"if [[ \"$1\" == \"install\" && \"${2:-}\" == \"git:github.com/example/critical@pin\" ]]; then",
-			"\t[[ -f \"${PI_CODING_AGENT_DIR}/settings-wide-update.done\" ]] || { printf 'critical install ran before settings-wide update\\n' >&2; exit 48; }",
-			"\t[[ -f \"${PI_CODING_AGENT_DIR}/critical-preinstall-validation.done\" ]] || { printf 'critical install ran before post-batch safety validation\\n' >&2; exit 49; }",
-			"\tprintf 'stage:critical-install\\n' >>\"${PI_LOG}.order\"",
-			"\ttouch \"${PI_CODING_AGENT_DIR}/critical-install.done\"",
-			"\texit 0",
-			"fi",
-		].join("\n"),
-		fakeGitBody: [
-			"target=''",
-			"if [[ \"${1:-}\" == \"-C\" ]]; then target=\"$2\"; shift 2; fi",
-			"record_stage() { local stage=\"$1\" marker=\"$2\"; if [[ ! -f \"${AGENT_DIR}/${marker}\" ]]; then printf 'stage:%s\\n' \"$stage\" >>\"${PI_LOG}.order\"; touch \"${AGENT_DIR}/${marker}\"; fi; }",
-			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--show-toplevel\" ]]; then",
-			"\tif [[ ! -f \"${AGENT_DIR}/settings-wide-update.done\" ]]; then",
-			"\t\trecord_stage preflight-safe preflight-safe.done",
-			"\telif [[ ! -f \"${AGENT_DIR}/critical-install.done\" ]]; then",
-			"\t\t[[ -f \"${AGENT_DIR}/preflight-safe.done\" ]] || { printf 'post-batch validation ran before preflight\\n' >&2; exit 50; }",
-			"\t\trecord_stage critical-preinstall-validation critical-preinstall-validation.done",
-			"\telse",
-			"\t\t[[ -f \"${AGENT_DIR}/settings-wide-update.done\" ]] || { printf 'ref validation ran before settings-wide update\\n' >&2; exit 51; }",
-			"\t\trecord_stage critical-ref-validation critical-ref-validation.done",
-			"\tfi",
-			"\tprintf '%s\\n' \"$target\"",
-			"\texit 0",
-			"fi",
-			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--absolute-git-dir\" ]]; then printf '%s/.git\\n' \"$target\"; exit 0; fi",
-			"if [[ \"${1:-}\" == \"rev-parse\" && \"${2:-}\" == \"--git-common-dir\" ]]; then printf '%s/.git\\n' \"$target\"; exit 0; fi",
-			"exit 0",
-		].join("\n"),
-	});
-	mkdirSync(join(agentDir, "git", "github.com", "example", "critical", ".git"), { recursive: true });
-
-	installDefaultExtensions(config);
-
-	assertPiCommands(piLog, agentDir, [
-		"update --extensions",
-		"install git:github.com/example/critical@pin",
-	]);
-	const stages = readFileSync(`${piLog}.order`, "utf8").trim().split(/\r?\n/);
-	assert.deepEqual(stages, [
-		"stage:preflight-safe",
-		"stage:settings-wide-batch",
-		"stage:critical-preinstall-validation",
-		"stage:critical-install",
-		"stage:critical-ref-validation",
-	]);
-});
-
-test("stage-1 keeps critical defaults on per-source install path while dry-run shows batch fallback", (t) => {
-	const criticalSource = "git:github.com/example/critical@pin";
-	const defaults = [
-		{ id: "critical", critical: true, source: criticalSource },
-		{ id: "helper", source: "npm:helper" },
-	];
-	const { config } = makeDefaultExtensionInstallConfig(t, {
-		defaultExtensions: defaults,
-		settings: { packages: defaults.map((entry) => entry.source) },
-		dryRun: true,
-	});
-
-	const stdout = captureConsole("log", () => installDefaultExtensions(config));
-
-	assert.match(stdout, /Would preflight 1 critical bundled default git checkout target\(s\) before any settings-wide default extension update/);
-	assert.match(stdout, /pi install git:github\.com\/example\/critical@pin/);
-	assert.match(stdout, /git -C .*\/git\/github\.com\/example\/critical fetch --prune --tags origin/);
-	assert.match(stdout, /Dry run: settings-wide extension refresh will run from merged settings/);
-	assert.match(stdout, /PI_CODING_AGENT_DIR=.*pi update --extensions/);
-	assert.match(stdout, /would retry only 1 non-critical bundled default source\(s\) individually/i);
-	assert.doesNotMatch(stdout, /^Would.*\bpi\s+update\b/m);
-	assert.doesNotMatch(stdout, /pi update --extension npm:helper/);
-});
 
 test("stage-1 canonicalizes relative target dirs before deriving wrapper and state paths", (t) => {
 	const root = makeTempDir();


### PR DESCRIPTION
## Summary

Splits the default-extension update coverage out of the large `tests/install-stage1.test.mjs` monolith into a focused test file for #258. Adds default-extension-specific helpers and moves generic Pi-log readers into the shared install-stage1 test helper module.

Refs #258.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

**Installer-specific checks (use temp paths — do not touch a real profile):**

```sh
node --test tests/install-stage1.test.mjs tests/install-stage1-default-extensions.test.mjs
npm run lint
```

**Docs-only changes:** narrower validation is acceptable; confirm rendered content shape and review the diff before opening.

_Paste the relevant output or a summary here:_

- `node --test tests/install-stage1.test.mjs tests/install-stage1-default-extensions.test.mjs` passed: 67 tests, 0 failures.
- `npm run lint` passed.
- `npm run validate` passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/split-default-extension-installer-tests/install.sh | bash -s -- --ref split-default-extension-installer-tests --track ref
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for default extension installation, including batch updates, fallback handling, critical checkout validation, and dry-run behavior.
  * Added validation for command execution order, working directories, wrapper options, and update behavior.
  * Improved test utilities for isolated environments, command-history tracking, and log parsing.
  * Added coverage for canonicalizing relative target directories before deriving installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->