### PR TITLE
Hide installer details unless verbose

### DIFF
--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -353,6 +353,10 @@ function detailLog(config, message) {
 function warn(message) {
     console.error(`warning: ${message}`);
 }
+function verboseWarn(config, message) {
+    if (config.verbose && !config.quiet)
+        warn(message);
+}
 function printCommand(commandArgs) {
     console.log(`+ ${renderShellWords(commandArgs)} `);
 }
@@ -614,10 +618,10 @@ function preferBinDirOnPathForCurrentInstall(config, binDir, { addMessage, prepe
     const alreadyPresent = currentEntries.includes(binDir);
     config.env.PATH = [binDir, ...currentEntries.filter((entry) => entry !== binDir)].join(delimiter);
     if (alreadyPresent) {
-        warn(prependMessage);
+        verboseWarn(config, prependMessage);
         return;
     }
-    warn(`${addMessage} Added it to PATH for this install; add it to your shell profile with: export PATH="${binDir}:$PATH"`);
+    verboseWarn(config, `${addMessage} Added it to PATH for this install; add it to your shell profile with: export PATH="${binDir}:$PATH"`);
 }
 function runtimePrefix(config) {
     // Private TLH runtime prefix: sibling of agent/ under ~/.the-last-harness/.
@@ -1179,7 +1183,7 @@ function updateNonCriticalDefaultExtensions(config, sources) {
         log(config, "Dry run: settings-wide extension refresh will run from merged settings.");
     }
     else {
-        log(config, `Running settings-wide extension refresh from merged settings; fallback retries only ${fallbackDescription} individually.`);
+        verboseLog(config, `Running settings-wide extension refresh from merged settings; fallback retries only ${fallbackDescription} individually.`);
     }
     try {
         runIsolatedPi(config, [absolutePiCmd(config), "update", "--extensions"]);

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -521,6 +521,10 @@ function warn(message: string): void {
 	console.error(`warning: ${message}`);
 }
 
+function verboseWarn(config: InstallConfig, message: string): void {
+	if (config.verbose && !config.quiet) warn(message);
+}
+
 function printCommand(commandArgs: Iterable<unknown>): void {
 	console.log(`+ ${renderShellWords(commandArgs)} `);
 }
@@ -801,10 +805,10 @@ function preferBinDirOnPathForCurrentInstall(config: InstallConfig, binDir: stri
 	const alreadyPresent = currentEntries.includes(binDir);
 	config.env.PATH = [binDir, ...currentEntries.filter((entry: string) => entry !== binDir)].join(delimiter);
 	if (alreadyPresent) {
-		warn(prependMessage);
+		verboseWarn(config, prependMessage);
 		return;
 	}
-	warn(`${addMessage} Added it to PATH for this install; add it to your shell profile with: export PATH="${binDir}:$PATH"`);
+	verboseWarn(config, `${addMessage} Added it to PATH for this install; add it to your shell profile with: export PATH="${binDir}:$PATH"`);
 }
 
 function runtimePrefix(config: InstallConfig): string {
@@ -1374,7 +1378,7 @@ function updateNonCriticalDefaultExtensions(config: InstallConfig, sources: stri
 	if (config.dryRun) {
 		log(config, "Dry run: settings-wide extension refresh will run from merged settings.");
 	} else {
-		log(config, `Running settings-wide extension refresh from merged settings; fallback retries only ${fallbackDescription} individually.`);
+		verboseLog(config, `Running settings-wide extension refresh from merged settings; fallback retries only ${fallbackDescription} individually.`);
 	}
 
 	try {

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -181,6 +181,7 @@ function runStage1LocalPackageInstall(t, {
 	dryRun = false,
 	noSettings = false,
 	force = false,
+	verbose = false,
 	existingSupportFiles,
 	existingLibrarianConfig,
 	envOverrides = {},
@@ -230,6 +231,7 @@ function runStage1LocalPackageInstall(t, {
 	if (dryRun) args.unshift("--dry-run");
 	if (noSettings) args.push("--no-settings");
 	if (force) args.push("--force");
+	if (verbose) args.push("--verbose");
 	const result = runInstaller(args, env);
 	return { result, homeDir, agentDir, binDir, piLog };
 }
@@ -238,6 +240,26 @@ function readJsonLines(path) {
 	if (!existsSync(path)) return [];
 	return readFileSync(path, "utf8").trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
 }
+
+test("stage-1 hides PATH-adjustment and refresh fallback detail lines unless --verbose", (t) => {
+	for (const verbose of [false, true]) {
+		const { result, agentDir } = runStage1LocalPackageInstall(t, { verbose });
+		const output = `${result.stdout}\n${result.stderr}`;
+		const runtimeBinDir = join(dirname(agentDir), "runtime", "bin");
+		const runtimePiPath = join(runtimeBinDir, "pi");
+		const pathNotice = `warning: ${runtimePiPath} installed but ${runtimeBinDir} is not on PATH. Added it to PATH for this install; add it to your shell profile with: export PATH="${runtimeBinDir}:$PATH"`;
+		const refreshDetailPattern = /Running settings-wide extension refresh from merged settings; fallback retries only 10 non-critical bundled default source\(s\) individually\./;
+
+		assert.equal(result.status, 0, output);
+		if (verbose) {
+			assert.ok(output.includes(pathNotice), output);
+			assert.match(output, refreshDetailPattern);
+		} else {
+			assert.equal(output.includes(pathNotice), false, output);
+			assert.doesNotMatch(output, refreshDetailPattern);
+		}
+	}
+});
 
 test("stage-1 enforces the TLH Node runtime minimum", () => {
 	assert.equal(MIN_NODE_VERSION, "22.19.0");


### PR DESCRIPTION
## Summary

Hide routine private-runtime PATH guidance and extension-refresh fallback details during normal installs while retaining both under `--verbose`. Installer behavior is unchanged; only output verbosity changes.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
node --test tests/install-stage1.test.mjs
npm run check:runtime
```

All passed. The focused stage-1 suite passed 63/63 tests.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this output-only adjustment)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/quiet-installer-detail-messages/install.sh | bash -s -- --ref quiet-installer-detail-messages --track ref
```
