### PR TITLE
Refresh AGENTS.md project structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@ This repository packages **The Last Harness** as an isolated profile for the ups
 - Contributor docs: `README.md` covers install/update/uninstall and security, `CONTRIBUTING.md` explains contribution workflow, `VALIDATING.md` and `npm run validate` define the standard validation pass, `CHANGELOG.md` tracks releases, and `VISION.md` captures product direction.
 - Extended docs: `docs/` contains install, integration, MCP, telemetry, local-development, release, workflow-eval, and web-search reference material.
 - Package/tooling manifests: `package.json`, `package-lock.json`, `eslint.config.mjs`, `tsconfig.json`, and `tsconfig.runtime-scripts.json` define the Node package, linting, and TypeScript settings used by contributors and validation.
-- Additional contributor guidance: `AGENTS.md` documents repo-specific agent instructions, and `CLAUDE.md` carries Claude-focused contributor guidance.
 
 ## Safety Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,19 @@ This repository packages **The Last Harness** as an isolated profile for the ups
 
 ## Project Structure
 
-- `install.sh` — one-line installer and `tlh` wrapper creator.
-- `scripts/merge-settings.mjs` — conservative settings merge helper for the isolated profile.
-- `scripts/tlh-defaults.mjs` — manages persistent opt-outs for bundled default extensions.
-- `scripts/tlh-gnosis.mjs` — manages Gnosis integration settings for the isolated profile.
-- `config/settings.defaults.json` — installer-owned default Pi settings.
-- `config/default-extensions.json` — bundled default extension package manifest.
-- `config/APPEND_SYSTEM.md` — packaged system-prompt guidance.
-- `extensions/` — Pi extensions exposed by `package.json`.
-- `skills/` — Pi skills exposed by `package.json`.
-- `prompts/` — Pi prompt templates exposed by `package.json`.
-- `themes/` — Pi themes exposed by `package.json`.
-- `README.md` — public install, update, uninstall, and security documentation.
-- `CHANGELOG.md` — release notes for versioned releases.
-- `docs/releasing.md` — tag-based release checklist and process.
-- `docs/web-search-fork-release-cadence.md` — pinned fork/tag process notes for the web-search fork; durable web-search / web-scout decisions live in repo-local Gnosis entries `ywsuwh` and `gbmehw`.
-- `.github/workflows/release.yml` — tag-triggered GitHub Release workflow.
+- Installer entrypoints: `install.sh` performs install/update bootstrap work and creates the `tlh` wrapper; `uninstall.sh` removes the isolated profile and managed wrapper artifacts.
+- Installer/runtime scripts: `scripts/` contains installer, update, doctor, wrapper, merge, runtime-TypeScript, release-notes, and ticket/RTK helpers; `scripts/lib/` holds shared installer modules; `scripts/installer-smoke/` contains staged smoke-test helpers; `scripts/check-installer-smoke.sh`, `scripts/check-package-versions.mjs`, and `scripts/check-startup-performance.mjs` are contributor-facing validation checks.
+- Packaged profile defaults: `config/` contains installer-owned settings, keybindings, librarian defaults, bundled extension manifests, and appended system prompt text for the isolated profile.
+- Packaged resources: `extensions/`, `prompts/`, and `themes/` are published package resources; `skills/` is an intentional future package placeholder and is not currently present in this repository (per Gnosis `zeqwga`).
+- Agent definitions: `agents/primary/` and `agents/subagents/` hold packaged primary-agent and subagent prompt specs used by tlh.
+- Tests and evals: `tests/` contains the automated test suite and fixture helpers, while `tests/evals/` contains deterministic workflow/trace-policy checks plus opt-in live-eval tooling.
+- Contributor automation: `.github/workflows/` defines CI, release, startup-performance, and Claude automation; `.github/PULL_REQUEST_TEMPLATE.md` provides PR guidance.
+- Contributor-local tooling: `.pi/` stores repo-local prompts and skills for contributors, `.gnosis/entries.jsonl` stores repo-local Gnosis memory, and `.symphony/setup` contains local dependency setup automation.
+- Repository illustrations: `assets/` stores documentation and workflow illustrations used in the repository and is not shipped in the npm package.
+- Contributor docs: `README.md` covers install/update/uninstall and security, `CONTRIBUTING.md` explains contribution workflow, `VALIDATING.md` and `npm run validate` define the standard validation pass, `CHANGELOG.md` tracks releases, and `VISION.md` captures product direction.
+- Extended docs: `docs/` contains install, integration, MCP, telemetry, local-development, release, workflow-eval, and web-search reference material.
+- Package/tooling manifests: `package.json`, `package-lock.json`, `eslint.config.mjs`, `tsconfig.json`, and `tsconfig.runtime-scripts.json` define the Node package, linting, and TypeScript settings used by contributors and validation.
+- Additional contributor guidance: `AGENTS.md` documents repo-specific agent instructions, and `CLAUDE.md` carries Claude-focused contributor guidance.
 
 ## Safety Requirements
 


### PR DESCRIPTION
## Summary

Refresh the `AGENTS.md` Project Structure section so agent sessions and contributors receive an accurate, purpose-focused map of the current repository. This covers installer/runtime scripts, agents, tests and evals, automation, contributor tooling, assets, docs, and the intentional absent `skills/` placeholder.

Closes #295.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
git diff --check
```

`npm run validate` passed on rerun after one unrelated timeout in `tests/check-startup-performance.test.mjs`; `git diff --check` passed after the final wording-only corrections. Final review found no issues.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/docs/refresh-agents-project-structure/install.sh | bash -s -- --ref docs/refresh-agents-project-structure --track ref
```
