### PR TITLE
Use GPT-5.6 Sol for reasoning agents

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Clarifies requirements, manages implementation tasks, and orchestrates minor subagents.
 model: anthropic/claude-opus-4-8
-tlhOpenaiModels: openai-codex/gpt-5.5
+tlhOpenaiModels: openai-codex/gpt-5.6-sol
 thinking: high
 applyModel: true
 applyThinking: true

--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Reviews diffs against assigned tasks for correctness, security, and maintainability.
 tools: read, grep, find, ls, bash, contact_supervisor
-tlhOpenaiModels: openai-codex/gpt-5.5
+tlhOpenaiModels: openai-codex/gpt-5.6-sol
 tlhAnthropicModels: anthropic/claude-opus-4-8
 preferOppositeProvider: true
 thinking: high

--- a/agents/subagents/contrarian.md
+++ b/agents/subagents/contrarian.md
@@ -2,7 +2,7 @@
 name: contrarian
 description: Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case.
 tools: read, grep, find, ls, bash, contact_supervisor
-tlhOpenaiModels: openai-codex/gpt-5.5
+tlhOpenaiModels: openai-codex/gpt-5.6-sol
 tlhAnthropicModels: anthropic/claude-opus-4-8
 preferOppositeProvider: true
 thinking: high

--- a/agents/subagents/oracle.md
+++ b/agents/subagents/oracle.md
@@ -2,7 +2,7 @@
 name: oracle
 description: Provides read-only high-reasoning second opinions and direct analysis.
 tools: read, grep, find, ls, contact_supervisor, bash
-tlhOpenaiModels: openai-codex/gpt-5.5
+tlhOpenaiModels: openai-codex/gpt-5.6-sol
 tlhAnthropicModels: anthropic/claude-opus-4-8
 preferOppositeProvider: true
 thinking: high

--- a/tests/hermetic-core-workflow.test.mjs
+++ b/tests/hermetic-core-workflow.test.mjs
@@ -243,7 +243,7 @@ function writeFakeTk(path) {
 function registerScriptedProviders(modelRegistry, scriptState) {
 	const models = {
 		anthropic: ["claude-opus-4-8", "claude-sonnet-4-6"],
-		"openai-codex": ["gpt-5.4", "gpt-5.5"],
+		"openai-codex": ["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"],
 	};
 	for (const [provider, ids] of Object.entries(models)) {
 		modelRegistry.registerProvider(provider, {
@@ -278,7 +278,7 @@ function scriptedRoleForModel(model) {
 	if (model.provider === "openai-codex" && model.id === "gpt-5.4") {
 		return "developer";
 	}
-	if (model.provider === "openai-codex" && model.id === "gpt-5.5") {
+	if (model.provider === "openai-codex" && (model.id === "gpt-5.5" || model.id === "gpt-5.6-sol")) {
 		return "code-reviewer";
 	}
 	return currentRole();
@@ -551,7 +551,11 @@ test("hermetic core architect workflow runs end-to-end with deterministic subage
 					appendSystemPrompt: [],
 				});
 				await resourceLoader.reload();
-				const modelKey = params.model?.includes("/") ? params.model.split("/") : role === "developer" ? ["openai-codex", "gpt-5.4"] : ["openai-codex", "gpt-5.5"];
+				const modelKey = params.model?.includes("/")
+					? params.model.split("/")
+					: role === "developer"
+						? ["openai-codex", "gpt-5.4"]
+						: ["openai-codex", "gpt-5.6-sol"];
 				const model = modelRegistry.find(modelKey[0], modelKey[1]);
 				assert.ok(model, `expected subagent model ${modelKey.join("/")}`);
 				return createAgentSession({
@@ -655,6 +659,7 @@ test("hermetic core architect workflow runs end-to-end with deterministic subage
 		assert.equal(scriptState.providerCalls.some((entry) => entry.role === "architect" && entry.step === 1), true, diagnostics);
 		assert.equal(scriptState.providerCalls.some((entry) => entry.role === "architect" && entry.step === 2), true, diagnostics);
 		assert.equal(scriptState.providerCalls.some((entry) => entry.role === "code-reviewer"), true, diagnostics);
+		assert.equal(scriptState.providerCalls.some((entry) => entry.role === "code-reviewer" && entry.model === "openai-codex/gpt-5.6-sol"), true, diagnostics);
 		const architectTools = toolLogs.filter((entry) => entry.role === "architect");
 		const developerTools = toolLogs.filter((entry) => entry.role === "developer");
 		const reviewerTools = toolLogs.filter((entry) => entry.role === "code-reviewer");

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -361,7 +361,7 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	const rush = primaryAgents.get("rush");
 	assert.ok(architect, "architect primary prompt should load");
 	assert.ok(rush, "Rush primary prompt should load");
-	assert.deepEqual(architect.tlhOpenaiModels, ["openai-codex/gpt-5.5"]);
+	assert.deepEqual(architect.tlhOpenaiModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.deepEqual(rush.tlhOpenaiModels, ["openai-codex/gpt-5.5"]);
 	assert.equal(rush.thinking, "low");
 	assert.equal(rush.tlhOpenaiThinking, "off");
@@ -391,6 +391,18 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	assert.deepEqual(
 		loadSubagentMetadata().find((agent) => agent.name === "developer")?.tlhOpenaiModels,
 		["openai-codex/gpt-5.4"],
+	);
+	assert.deepEqual(
+		loadSubagentMetadata().find((agent) => agent.name === "code-reviewer")?.tlhOpenaiModels,
+		["openai-codex/gpt-5.6-sol"],
+	);
+	assert.deepEqual(
+		loadSubagentMetadata().find((agent) => agent.name === "oracle")?.tlhOpenaiModels,
+		["openai-codex/gpt-5.6-sol"],
+	);
+	assert.deepEqual(
+		loadSubagentMetadata().find((agent) => agent.name === "contrarian")?.tlhOpenaiModels,
+		["openai-codex/gpt-5.6-sol"],
 	);
 
 	const primaryPrompt = buildTlhSystemPrompt(rush, loadSubagentMetadata(), true);

--- a/tests/the-last-harness-model-defaults.test.mjs
+++ b/tests/the-last-harness-model-defaults.test.mjs
@@ -17,14 +17,14 @@ const developer = {
 
 const codeReviewer = {
 	name: "code-reviewer",
-	tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
 	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 	preferOppositeProvider: true,
 };
 
 const oracle = {
 	name: "oracle",
-	tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
 	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 	preferOppositeProvider: true,
 };
@@ -32,15 +32,15 @@ const oracle = {
 const anthropicParentPrefersCodexReviewer = {
 	name: "anthropic-parent-prefers-codex-reviewer",
 	model: "anthropic/claude-opus-4-8",
-	tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
 	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 	preferOppositeProvider: true,
 };
 
 const openaiParentPrefersAnthropicReviewer = {
 	name: "openai-parent-prefers-anthropic-reviewer",
-	model: "openai-codex/gpt-5.5",
-	tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+	model: "openai-codex/gpt-5.6-sol",
+	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
 	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 	preferOppositeProvider: true,
 };
@@ -75,6 +75,7 @@ const anthropicAvailable = [
 const codexAvailable = [
 	{ provider: "openai-codex", id: "gpt-5.4" },
 	{ provider: "openai-codex", id: "gpt-5.5" },
+	{ provider: "openai-codex", id: "gpt-5.6-sol" },
 ];
 
 const openaiAvailable = [
@@ -135,12 +136,12 @@ test("provider-aware opposite-provider preference picks Codex for opted-in Anthr
 
 	assert.equal(
 		selectProviderAwareAgentModelId(anthropicParentPrefersCodexReviewer, available, "anthropic"),
-		"openai-codex/gpt-5.5",
+		"openai-codex/gpt-5.6-sol",
 	);
 
 	const input = { agent: anthropicParentPrefersCodexReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "anthropic"), 1);
-	assert.equal(input.model, "openai-codex/gpt-5.5");
+	assert.equal(input.model, "openai-codex/gpt-5.6-sol");
 	assert.deepEqual(input.fallbackModels, ["anthropic/claude-opus-4-8"]);
 	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
@@ -161,7 +162,7 @@ test("provider-aware opposite-provider preference picks Anthropic for opted-in O
 	const input = { agent: openaiParentPrefersAnthropicReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "openai-codex"), 1);
 	assert.equal(input.model, "anthropic/claude-opus-4-8");
-	assert.deepEqual(input.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.deepEqual(input.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
 
@@ -179,14 +180,14 @@ test("provider-aware subagent mutation gives code-reviewer the opposite availabl
 
 	const anthropicInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(anthropicInput, agents, available, "anthropic"), 1);
-	assert.equal(anthropicInput.model, "openai-codex/gpt-5.5");
+	assert.equal(anthropicInput.model, "openai-codex/gpt-5.6-sol");
 	assert.deepEqual(anthropicInput.fallbackModels, ["anthropic/claude-opus-4-8"]);
 	assert.equal(anthropicInput.modelFallbackNotice, reducedIndependenceNotice);
 
 	const codexInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(codexInput, agents, available, "openai-codex"), 1);
 	assert.equal(codexInput.model, "anthropic/claude-opus-4-8");
-	assert.deepEqual(codexInput.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.deepEqual(codexInput.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(codexInput.modelFallbackNotice, reducedIndependenceNotice);
 
 	const noOppositeInput = { agent: "code-reviewer" };
@@ -210,7 +211,7 @@ test("provider-aware subagent mutation gives code-reviewer and oracle current-se
 		),
 		1,
 	);
-	assert.equal(reviewerInput.model, "openai-codex/gpt-5.5");
+	assert.equal(reviewerInput.model, "openai-codex/gpt-5.6-sol");
 	assert.deepEqual(reviewerInput.fallbackModels, ["anthropic/claude-sonnet-4-6"]);
 	assert.equal(reviewerInput.modelFallbackNotice, reducedIndependenceNotice);
 
@@ -354,7 +355,7 @@ test("provider-aware subagent mutation injects model but preserves caller-suppli
 	// caller-provided fallbackModels kept, TLH auto-adds modelFallbackNotice.
 	const withFallbackModels = { agent: "code-reviewer", fallbackModels: ["custom/provider-model"] };
 	assert.equal(applyProviderAwareSubagentModels(withFallbackModels, agents, available, "anthropic"), 1);
-	assert.equal(withFallbackModels.model, "openai-codex/gpt-5.5");
+	assert.equal(withFallbackModels.model, "openai-codex/gpt-5.6-sol");
 	assert.deepEqual(withFallbackModels.fallbackModels, ["custom/provider-model"]);
 	assert.equal(withFallbackModels.modelFallbackNotice, reducedIndependenceNotice);
 
@@ -363,7 +364,7 @@ test("provider-aware subagent mutation injects model but preserves caller-suppli
 	const withFallbackNotice = { agent: "oracle", modelFallbackNotice: "custom fallback notice" };
 	assert.equal(applyProviderAwareSubagentModels(withFallbackNotice, agents, available, "openai-codex"), 1);
 	assert.equal(withFallbackNotice.model, "anthropic/claude-opus-4-8");
-	assert.deepEqual(withFallbackNotice.fallbackModels, ["openai-codex/gpt-5.5"]);
+	assert.deepEqual(withFallbackNotice.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(withFallbackNotice.modelFallbackNotice, "custom fallback notice");
 
 	// Explicit model still prevents all injection regardless of other fallback fields.
@@ -403,6 +404,6 @@ test("provider-aware subagent mutation handles chain sequential and parallel ste
 
 	assert.equal(applyProviderAwareSubagentModels(input, agents, codexAvailable, "openai-codex"), 2);
 	assert.equal(input.chain[0].model, "openai-codex/gpt-5.4");
-	assert.equal(input.chain[1].parallel[0].model, "openai-codex/gpt-5.5");
+	assert.equal(input.chain[1].parallel[0].model, "openai-codex/gpt-5.6-sol");
 	assert.equal(input.chain[1].parallel[1].model, "openai/gpt-5.4");
 });

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -112,7 +112,7 @@ function contrarianMetadata() {
 	return {
 		name: "contrarian",
 		description: "Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case.",
-		tlhOpenaiModels: ["openai-codex/gpt-5.5"],
+		tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
 		tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
 		preferOppositeProvider: true,
 	};


### PR DESCRIPTION
## Summary

Update the Architect, Oracle, Contrarian, and Code Reviewer OpenAI Codex defaults to `gpt-5.6-sol` while preserving high thinking and existing provider-selection behavior.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed.

Focused model and prompt tests also passed (91/91).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/use-gpt-5-6-sol/install.sh | bash -s -- --ref use-gpt-5-6-sol --track ref
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the configured Codex model to `openai-codex/gpt-5.6-sol` across primary and supporting review agents.

* **Tests**
  * Updated model-selection, fallback, runtime, and nested task expectations to reflect the new Codex model.
  * Added coverage for the updated model across relevant agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->