### PR TITLE
Enable showCacheMissNotices in default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
+- The isolated profile defaults now enable Pi's `showCacheMissNotices` setting, showing transcript notices for significant prompt-cache misses; existing user values are preserved by the settings merge.
 - Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.3` to `npm:@diegopetrucci/pi-subagents@0.31.4`, picking up the builtin-disable runtime invariant fix from the merged fork release.
 - Bumped TLH's pinned upstream Pi runtime and package compatibility metadata from 0.80.5 to 0.80.6.
 - Refreshed package dependency pins, including `@tailwindcss/browser` 4.3.2, `@types/node` 26.1.1, `eslint` 10.6.0, and `typescript-eslint` 8.63.0; TypeScript remains on 6.0.3 as the latest version supported by the updated `typescript-eslint` peer range.

--- a/config/settings.defaults.json
+++ b/config/settings.defaults.json
@@ -15,5 +15,6 @@
   },
   "warnings": {
     "anthropicExtraUsage": false
-  }
+  },
+  "showCacheMissNotices": true
 }


### PR DESCRIPTION
## Summary

Enable Pi's `showCacheMissNotices` setting by default in the isolated tlh profile. Introduced in pi 0.80.4/0.80.5, it shows transcript notices for significant prompt-cache misses. Fixes #311.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Passes. One unrelated installer-smoke test (`install-managed does not clean up a managed bin directory when parent revalidation fails`) flaked on a timeout in a first run and passed cleanly on re-run. The dry-run settings merge in validation output confirms the merge engine picks up the new key: `Would set showCacheMissNotices`.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/enable-cache-miss-notices/install.sh | bash -s -- --ref enable-cache-miss-notices --track ref
```
