### PR TITLE
Lazy-load core command implementations

### DIFF
--- a/extensions/the-last-harness/attribution-command.ts
+++ b/extensions/the-last-harness/attribution-command.ts
@@ -1,0 +1,82 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+import { formatHomePath, isRecord } from "./common.js";
+import { withLockedTlhSettingsWrite } from "./profile-state.js";
+import { resolveTlhCommitAttribution } from "./attribution.js";
+import type { TlhAttributionConfig, TlhAttributionWriteResult, TlhCommitAttributionState, TlhSettings } from "./types.js";
+
+const TOGGLE_TLH_GIT_ATTRIBUTION_COMMAND_HELP = "Usage: /toggle-tlh-git-attribution";
+
+function validateTlhAttributionSettings(settings: unknown): asserts settings is TlhSettings {
+	if (!isRecord(settings)) {
+		throw new Error("settings.json must contain a JSON object");
+	}
+	const tlh = settings.tlh;
+	if (tlh !== undefined && !isRecord(tlh)) {
+		throw new Error("settings field 'tlh' must be an object if present");
+	}
+	const attribution = isRecord(tlh) ? tlh.attribution : undefined;
+	if (attribution !== undefined && !isRecord(attribution)) {
+		throw new Error("settings field 'tlh.attribution' must be an object if present");
+	}
+	const commit = isRecord(attribution) ? attribution.commit : undefined;
+	if (commit !== undefined && typeof commit !== "boolean") {
+		throw new Error("settings field 'tlh.attribution.commit' must be a boolean if present");
+	}
+}
+
+function parseTlhSettingsContent(content: string | undefined): TlhSettings {
+	if (!content) {
+		return {};
+	}
+	const parsed = JSON.parse(content) as unknown;
+	validateTlhAttributionSettings(parsed);
+	return parsed;
+}
+
+function ensureMutableAttributionSettings(settings: TlhSettings): asserts settings is TlhSettings & {
+	tlh: { attribution: TlhAttributionConfig };
+} {
+	validateTlhAttributionSettings(settings);
+	settings.tlh ??= {};
+	settings.tlh.attribution ??= {};
+}
+
+function toggleTlhCommitAttribution(cwd: string): TlhAttributionWriteResult {
+	return withLockedTlhSettingsWrite(cwd, "Refusing to write attribution settings outside the isolated TLH profile.", (current) => {
+		const settings = parseTlhSettingsContent(current);
+		const currentState = resolveTlhCommitAttribution(settings.tlh?.attribution);
+		const nextEnabled = !currentState.enabled;
+
+		ensureMutableAttributionSettings(settings);
+		settings.tlh.attribution = { commit: nextEnabled };
+		return {
+			changed: true,
+			state: resolveTlhCommitAttribution(settings.tlh.attribution),
+			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
+		};
+	});
+}
+
+function formatCommitAttributionStatus(state: TlhCommitAttributionState): string {
+	return state.enabled ? "TLH commit attribution is enabled." : "TLH commit attribution is disabled.";
+}
+
+export async function handleToggleTlhGitAttributionCommand(_pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void> {
+	if (args.trim()) {
+		ctx.ui.notify(TOGGLE_TLH_GIT_ATTRIBUTION_COMMAND_HELP, "error");
+		return;
+	}
+
+	try {
+		const result = toggleTlhCommitAttribution(ctx.cwd);
+		const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
+		ctx.ui.notify(
+			`Updated TLH commit attribution at ${formatHomePath(result.settingsPath)}. ${formatCommitAttributionStatus(result.state)}${backupLabel}`,
+			"info",
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Could not update TLH commit attribution: ${message}`, "error");
+	}
+}

--- a/extensions/the-last-harness/attribution.ts
+++ b/extensions/the-last-harness/attribution.ts
@@ -1,7 +1,6 @@
-import { SettingsManager, getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
-import { formatHomePath, isRecord } from "./common.js";
-import { withLockedTlhSettingsWrite } from "./profile-state.js";
+import { isRecord } from "./common.js";
 import {
 	commandBasename,
 	extractHereDocBodies,
@@ -19,11 +18,10 @@ import {
 	stripLeadingShellCommandPrefixes,
 	tokenizeShellWords,
 } from "./shell-parser.js";
-import type { TlhAttributionConfig, TlhAttributionWriteResult, TlhCommitAttributionState, TlhSettings } from "./types.js";
+import type { TlhAttributionConfig, TlhCommitAttributionState, TlhSettings } from "./types.js";
 
 export const TLH_DEFAULT_COMMIT_ATTRIBUTION = `Co-authored-by: The Last Harness <hi@thelastharness.com>`;
 
-const TOGGLE_TLH_GIT_ATTRIBUTION_COMMAND_HELP = "Usage: /toggle-tlh-git-attribution";
 const TLH_GIT_COMMIT_ATTRIBUTION_PROMPT_HEADING = "## TLH Git Commit Attribution";
 const TLH_GIT_COMMIT_BLOCK_REASON = "Blocked TLH bash git commit because the commit message is missing the required TLH attribution footer.";
 const GIT_GLOBAL_OPTIONS_WITH_VALUES = new Set(["-C", "-c", "--config-env", "--git-dir", "--namespace", "--super-prefix", "--work-tree"]);
@@ -497,81 +495,36 @@ export function getTlhGitCommitAttributionBlockReason(command: string, state: Tl
 	return getWrappedShellGitCommitAttributionBlockReason(command, state.footer);
 }
 
-function validateTlhAttributionSettings(settings: unknown): asserts settings is TlhSettings {
-	if (!isRecord(settings)) {
-		throw new Error("settings.json must contain a JSON object");
-	}
-	const tlh = settings.tlh;
-	if (tlh !== undefined && !isRecord(tlh)) {
-		throw new Error("settings field 'tlh' must be an object if present");
-	}
-	const attribution = isRecord(tlh) ? tlh.attribution : undefined;
-	if (attribution !== undefined && !isRecord(attribution)) {
-		throw new Error("settings field 'tlh.attribution' must be an object if present");
-	}
-	const commit = isRecord(attribution) ? attribution.commit : undefined;
-	if (commit !== undefined && typeof commit !== "boolean") {
-		throw new Error("settings field 'tlh.attribution.commit' must be a boolean if present");
-	}
+type AttributionCommandModule = {
+	handleToggleTlhGitAttributionCommand(pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void>;
+};
+
+type TlhAttributionCommandFacadeOptions = {
+	loadModule?: () => Promise<AttributionCommandModule>;
+};
+
+function createRetryableLazyImport<TModule>(loader: () => Promise<TModule>): () => Promise<TModule> {
+	let modulePromise: Promise<TModule> | undefined;
+	return () => {
+		if (!modulePromise) {
+			modulePromise = loader().catch((error) => {
+				modulePromise = undefined;
+				throw error;
+			});
+		}
+		return modulePromise;
+	};
 }
 
-function parseTlhSettingsContent(content: string | undefined): TlhSettings {
-	if (!content) {
-		return {};
-	}
-	const parsed = JSON.parse(content) as unknown;
-	validateTlhAttributionSettings(parsed);
-	return parsed;
-}
-
-function ensureMutableAttributionSettings(settings: TlhSettings): asserts settings is TlhSettings & {
-	tlh: { attribution: TlhAttributionConfig };
-} {
-	validateTlhAttributionSettings(settings);
-	settings.tlh ??= {};
-	settings.tlh.attribution ??= {};
-}
-
-function toggleTlhCommitAttribution(cwd: string): TlhAttributionWriteResult {
-	return withLockedTlhSettingsWrite(cwd, "Refusing to write attribution settings outside the isolated TLH profile.", (current) => {
-		const settings = parseTlhSettingsContent(current);
-		const currentState = resolveTlhCommitAttribution(settings.tlh?.attribution);
-		const nextEnabled = !currentState.enabled;
-
-		ensureMutableAttributionSettings(settings);
-		settings.tlh.attribution = { commit: nextEnabled };
-		return {
-			changed: true,
-			state: resolveTlhCommitAttribution(settings.tlh.attribution),
-			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
-		};
-	});
-}
-
-function formatCommitAttributionStatus(state: TlhCommitAttributionState): string {
-	return state.enabled ? "TLH commit attribution is enabled." : "TLH commit attribution is disabled.";
-}
-
-export function registerToggleTlhGitAttributionCommand(pi: ExtensionAPI): void {
+export function registerToggleTlhGitAttributionCommand(pi: ExtensionAPI, options: TlhAttributionCommandFacadeOptions = {}): void {
+	const loadModule = createRetryableLazyImport(
+		options.loadModule ?? (() => import("./attribution-command.js") as Promise<AttributionCommandModule>),
+	);
 	pi.registerCommand("toggle-tlh-git-attribution", {
 		description: "Toggle TLH git commit attribution",
 		handler: async (args, ctx) => {
-			if (args.trim()) {
-				ctx.ui.notify(TOGGLE_TLH_GIT_ATTRIBUTION_COMMAND_HELP, "error");
-				return;
-			}
-
-			try {
-				const result = toggleTlhCommitAttribution(ctx.cwd);
-				const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
-				ctx.ui.notify(
-					`Updated TLH commit attribution at ${formatHomePath(result.settingsPath)}. ${formatCommitAttributionStatus(result.state)}${backupLabel}`,
-					"info",
-				);
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Could not update TLH commit attribution: ${message}`, "error");
-			}
+			const module = await loadModule();
+			await module.handleToggleTlhGitAttributionCommand(pi, args, ctx);
 		},
 	});
 }

--- a/extensions/the-last-harness/effort-command.ts
+++ b/extensions/the-last-harness/effort-command.ts
@@ -1,0 +1,75 @@
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+import { selectProviderAwareAgentDefaults } from "./model-defaults.js";
+import type { TlhPrimaryAgentRuntime } from "./primary-agent-runtime.js";
+import {
+	formatThinkingLevelOption,
+	getAvailableThinkingLevels,
+	isThinkingLevel,
+	parseThinkingLevelOption,
+	setExtensionThinkingLevel,
+	thinkingLevelAtLeast,
+} from "./thinking.js";
+import type { ReasoningModel } from "./types.js";
+
+export async function handleThinkingLevelCommand(
+	pi: ExtensionAPI,
+	args: string,
+	ctx: ExtensionCommandContext,
+	runtime?: TlhPrimaryAgentRuntime,
+): Promise<void> {
+	const primary = runtime?.activePrimaryAgentPrompt();
+
+	if (primary?.lockThinking) {
+		const defaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
+		const level = defaults.thinking ?? "off";
+		ctx.ui.notify(`Thinking is locked at "${level}" for the ${primary.name} primary agent.`, "error");
+		return;
+	}
+
+	const currentLevel = pi.getThinkingLevel();
+	const availableLevels = getAvailableThinkingLevels(ctx.model as ReasoningModel | undefined);
+	const requestedLevel = args.trim().toLowerCase();
+	const minThinking = primary?.minThinking;
+
+	if (requestedLevel) {
+		if (!isThinkingLevel(requestedLevel)) {
+			ctx.ui.notify(`Unknown thinking level "${args.trim()}". Available: ${availableLevels.join(", ")}.`, "error");
+			return;
+		}
+		if (!availableLevels.includes(requestedLevel)) {
+			ctx.ui.notify(
+				`Thinking level "${requestedLevel}" is not available for the current model. Available: ${availableLevels.join(", ")}.`,
+				"warning",
+			);
+			return;
+		}
+		if (minThinking !== undefined && !thinkingLevelAtLeast(requestedLevel, minThinking)) {
+			ctx.ui.notify(`${primary!.name} requires at least ${minThinking} thinking.`, "error");
+			return;
+		}
+		setExtensionThinkingLevel(pi, requestedLevel);
+		ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
+		return;
+	}
+
+	const pickerLevels =
+		minThinking !== undefined
+			? availableLevels.filter((level) => thinkingLevelAtLeast(level, minThinking))
+			: availableLevels;
+
+	if (!ctx.hasUI) {
+		ctx.ui.notify(`Available thinking levels: ${pickerLevels.join(", ")}. Current: ${currentLevel}.`, "info");
+		return;
+	}
+
+	const options = pickerLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
+	const selected = await ctx.ui.select("Pick thinking level", options);
+	const selectedLevel = selected ? parseThinkingLevelOption(selected) : undefined;
+	if (!selectedLevel) {
+		return;
+	}
+
+	setExtensionThinkingLevel(pi, selectedLevel);
+	ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
+}

--- a/extensions/the-last-harness/effort.ts
+++ b/extensions/the-last-harness/effort.ts
@@ -1,17 +1,34 @@
 import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { THINKING_LEVEL_DESCRIPTIONS, THINKING_LEVELS } from "./constants.js";
-import { selectProviderAwareAgentDefaults } from "./model-defaults.js";
 import type { TlhPrimaryAgentRuntime } from "./primary-agent-runtime.js";
-import {
-	formatThinkingLevelOption,
-	getAvailableThinkingLevels,
-	isThinkingLevel,
-	parseThinkingLevelOption,
-	setExtensionThinkingLevel,
-	thinkingLevelAtLeast,
-} from "./thinking.js";
-import type { ReasoningModel } from "./types.js";
+import { thinkingLevelAtLeast } from "./thinking.js";
+
+type EffortCommandModule = {
+	handleThinkingLevelCommand(
+		pi: ExtensionAPI,
+		args: string,
+		ctx: ExtensionCommandContext,
+		runtime?: TlhPrimaryAgentRuntime,
+	): Promise<void>;
+};
+
+type TlhEffortCommandFacadeOptions = {
+	loadModule?: () => Promise<EffortCommandModule>;
+};
+
+function createRetryableLazyImport<TModule>(loader: () => Promise<TModule>): () => Promise<TModule> {
+	let modulePromise: Promise<TModule> | undefined;
+	return () => {
+		if (!modulePromise) {
+			modulePromise = loader().catch((error) => {
+				modulePromise = undefined;
+				throw error;
+			});
+		}
+		return modulePromise;
+	};
+}
 
 function getThinkingLevelCompletions(prefix: string, runtime?: TlhPrimaryAgentRuntime) {
 	const primary = runtime?.activePrimaryAgentPrompt();
@@ -34,74 +51,22 @@ function getThinkingLevelCompletions(prefix: string, runtime?: TlhPrimaryAgentRu
 	return completions.length > 0 ? completions : null;
 }
 
-async function handleThinkingLevelCommand(
+export function registerEffortCommand(
 	pi: ExtensionAPI,
-	args: string,
-	ctx: ExtensionCommandContext,
 	runtime?: TlhPrimaryAgentRuntime,
-): Promise<void> {
-	const primary = runtime?.activePrimaryAgentPrompt();
+	options: TlhEffortCommandFacadeOptions = {},
+): void {
+	const loadModule = createRetryableLazyImport(options.loadModule ?? (() => import("./effort-command.js") as Promise<EffortCommandModule>));
+	const runHandler = async (args: string, ctx: ExtensionCommandContext) => {
+		const module = await loadModule();
+		await module.handleThinkingLevelCommand(pi, args, ctx, runtime);
+	};
 
-	if (primary?.lockThinking) {
-		const defaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
-		const level = defaults.thinking ?? "off";
-		ctx.ui.notify(`Thinking is locked at "${level}" for the ${primary.name} primary agent.`, "error");
-		return;
-	}
-
-	const currentLevel = pi.getThinkingLevel();
-	const availableLevels = getAvailableThinkingLevels(ctx.model as ReasoningModel | undefined);
-	const requestedLevel = args.trim().toLowerCase();
-	const minThinking = primary?.minThinking;
-
-	if (requestedLevel) {
-		if (!isThinkingLevel(requestedLevel)) {
-			ctx.ui.notify(`Unknown thinking level "${args.trim()}". Available: ${availableLevels.join(", ")}.`, "error");
-			return;
-		}
-		if (!availableLevels.includes(requestedLevel)) {
-			ctx.ui.notify(
-				`Thinking level "${requestedLevel}" is not available for the current model. Available: ${availableLevels.join(", ")}.`,
-				"warning",
-			);
-			return;
-		}
-		if (minThinking !== undefined && !thinkingLevelAtLeast(requestedLevel, minThinking)) {
-			ctx.ui.notify(`${primary!.name} requires at least ${minThinking} thinking.`, "error");
-			return;
-		}
-		setExtensionThinkingLevel(pi, requestedLevel);
-		ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
-		return;
-	}
-
-	const pickerLevels =
-		minThinking !== undefined
-			? availableLevels.filter((level) => thinkingLevelAtLeast(level, minThinking))
-			: availableLevels;
-
-	if (!ctx.hasUI) {
-		ctx.ui.notify(`Available thinking levels: ${pickerLevels.join(", ")}. Current: ${currentLevel}.`, "info");
-		return;
-	}
-
-	const options = pickerLevels.map((level) => formatThinkingLevelOption(level, currentLevel));
-	const selected = await ctx.ui.select("Pick thinking level", options);
-	const selectedLevel = selected ? parseThinkingLevelOption(selected) : undefined;
-	if (!selectedLevel) {
-		return;
-	}
-
-	setExtensionThinkingLevel(pi, selectedLevel);
-	ctx.ui.notify(`Thinking level set to ${pi.getThinkingLevel()}.`, "info");
-}
-
-export function registerEffortCommand(pi: ExtensionAPI, runtime?: TlhPrimaryAgentRuntime): void {
 	for (const commandName of ["effort", "thinking"] as const) {
 		pi.registerCommand(commandName, {
 			description: "Pick the model thinking level",
 			getArgumentCompletions: (prefix) => getThinkingLevelCompletions(prefix, runtime),
-			handler: (args, ctx) => handleThinkingLevelCommand(pi, args, ctx, runtime),
+			handler: runHandler,
 		});
 	}
 }

--- a/extensions/the-last-harness/experimental-command.ts
+++ b/extensions/the-last-harness/experimental-command.ts
@@ -1,0 +1,229 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+import { formatHomePath, isRecord } from "./common.js";
+import {
+	availableExperimentalFeatureList,
+	EXPERIMENTAL_COMMAND_COMPLETIONS,
+	EXPERIMENTAL_COMMAND_HELP,
+	getExperimentalFeature,
+	getTlhExperimentalConfig,
+	hasRegisteredExperimentalFeatures,
+	isTlhExperimentalFeatureEnabled,
+	noExperimentalFeaturesMessage,
+	normalizeEnabledFeatures,
+	parseExperimentalSlashAction,
+	TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT,
+	TLH_EXPERIMENTAL_FEATURES,
+	unknownExperimentalFeatureMessage,
+} from "./experimental.js";
+import { withLockedTlhSettingsWrite } from "./profile-state.js";
+import type { TlhExperimentalConfig, TlhExperimentalFeatureId, TlhSettings } from "./types.js";
+
+type TlhExperimentalWriteResult = {
+	changed: boolean;
+	settingsPath: string;
+	backupPath?: string;
+	enabled: boolean;
+};
+
+function validateTlhExperimentalSettings(settings: unknown): asserts settings is TlhSettings {
+	if (!isRecord(settings)) {
+		throw new Error("settings.json must contain a JSON object");
+	}
+	const tlh = settings.tlh;
+	if (tlh !== undefined && !isRecord(tlh)) {
+		throw new Error("settings field 'tlh' must be an object if present");
+	}
+	const experimental = isRecord(tlh) ? tlh.experimental : undefined;
+	if (experimental !== undefined && !isRecord(experimental)) {
+		throw new Error("settings field 'tlh.experimental' must be an object if present");
+	}
+	const enabledFeatures = isRecord(experimental) ? experimental.enabledFeatures : undefined;
+	if (enabledFeatures !== undefined && !Array.isArray(enabledFeatures)) {
+		throw new Error("settings field 'tlh.experimental.enabledFeatures' must be an array if present");
+	}
+	if (Array.isArray(enabledFeatures) && enabledFeatures.some((feature) => typeof feature !== "string")) {
+		throw new Error("settings field 'tlh.experimental.enabledFeatures' must contain only strings");
+	}
+}
+
+function parseTlhSettingsContent(content: string | undefined): TlhSettings {
+	if (!content) {
+		return {};
+	}
+	const parsed = JSON.parse(content) as unknown;
+	validateTlhExperimentalSettings(parsed);
+	return parsed;
+}
+
+function ensureMutableExperimentalSettings(settings: TlhSettings): asserts settings is TlhSettings & {
+	tlh: { experimental: TlhExperimentalConfig };
+} {
+	validateTlhExperimentalSettings(settings);
+	settings.tlh ??= {};
+	settings.tlh.experimental ??= {};
+}
+
+function formatExperimentalFeatureStatus(featureId: TlhExperimentalFeatureId, enabled: boolean): string {
+	const feature = getExperimentalFeature(featureId);
+	if (!feature) {
+		return unknownExperimentalFeatureMessage(featureId);
+	}
+	const enabledLabel = enabled ? "enabled" : "disabled (default)";
+	const nextStep = enabled
+		? `Disable with /experimental disable ${feature.id}.`
+		: `Enable with /experimental enable ${feature.id}.`;
+	return `- ${feature.id}: ${enabledLabel}. ${feature.description} ${nextStep}`;
+}
+
+function formatExperimentalStatusMessage(config: TlhExperimentalConfig | undefined, featureId?: string): string {
+	if (featureId) {
+		const feature = getExperimentalFeature(featureId);
+		if (!feature) {
+			return unknownExperimentalFeatureMessage(featureId);
+		}
+		return formatExperimentalFeatureStatus(feature.id, isTlhExperimentalFeatureEnabled(config, feature.id));
+	}
+	if (!hasRegisteredExperimentalFeatures()) {
+		return noExperimentalFeaturesMessage();
+	}
+	return [
+		"TLH experimental features:",
+		...TLH_EXPERIMENTAL_FEATURES.map((feature) => formatExperimentalFeatureStatus(feature.id, isTlhExperimentalFeatureEnabled(config, feature.id))),
+	].join("\n");
+}
+
+function experimentalFeaturePickerOption(featureId: TlhExperimentalFeatureId, enabled: boolean): string {
+	const feature = getExperimentalFeature(featureId);
+	if (!feature) {
+		return featureId;
+	}
+	const stateLabel = enabled ? "enabled" : "disabled (default)";
+	return `${enabled ? "●" : "○"} ${feature.id} — ${stateLabel} — ${feature.description}`;
+}
+
+function notifyExperimentalWriteResult(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	featureId: TlhExperimentalFeatureId,
+	result: TlhExperimentalWriteResult,
+): void {
+	const changedLabel = result.changed ? "Updated" : "No change to";
+	const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
+	const stateLabel = result.enabled ? "enabled" : "disabled";
+	const undoLabel = result.enabled ? `Undo with /experimental disable ${featureId}.` : `Undo with /experimental enable ${featureId}.`;
+	pi.events?.emit?.(TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT, {
+		cwd: ctx.cwd,
+		enabled: result.enabled,
+		featureId,
+	});
+	ctx.ui.notify(
+		`${changedLabel} TLH experimental feature ${featureId} at ${formatHomePath(result.settingsPath)}. It is now ${stateLabel}. ${undoLabel}${backupLabel}`,
+		"info",
+	);
+}
+
+async function showExperimentalFeaturePicker(pi: ExtensionAPI, ctx: ExtensionCommandContext): Promise<void> {
+	if (ctx.mode !== "tui" || !ctx.hasUI || !hasRegisteredExperimentalFeatures() || typeof ctx.ui.select !== "function") {
+		ctx.ui.notify(formatExperimentalStatusMessage(getTlhExperimentalConfig(ctx.cwd)), "info");
+		return;
+	}
+
+	while (true) {
+		const config = getTlhExperimentalConfig(ctx.cwd);
+		const featureIdsByOption = new Map(
+			TLH_EXPERIMENTAL_FEATURES.map((feature) => {
+				const option = experimentalFeaturePickerOption(feature.id, isTlhExperimentalFeatureEnabled(config, feature.id));
+				return [option, feature.id] as const;
+			}),
+		);
+		const selectedOption = await ctx.ui.select("Toggle TLH experimental features (Esc to close)", [...featureIdsByOption.keys()]);
+		if (!selectedOption) {
+			return;
+		}
+		const selectedFeatureId = featureIdsByOption.get(selectedOption);
+		if (!selectedFeatureId) {
+			ctx.ui.notify("Unknown TLH experimental feature picker selection.", "error");
+			return;
+		}
+
+		try {
+			notifyExperimentalWriteResult(pi, ctx, selectedFeatureId, writeExperimentalFeaturePreference(ctx.cwd, selectedFeatureId, "toggle"));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			ctx.ui.notify(`Could not update TLH experimental feature ${selectedFeatureId}: ${message}`, "error");
+		}
+	}
+}
+
+function nextEnabledState(currentEnabled: boolean, action: "enable" | "disable" | "toggle"): boolean {
+	if (action === "enable") return true;
+	if (action === "disable") return false;
+	return !currentEnabled;
+}
+
+function writeExperimentalFeaturePreference(
+	cwd: string,
+	featureId: TlhExperimentalFeatureId,
+	action: "enable" | "disable" | "toggle",
+): TlhExperimentalWriteResult {
+	const feature = getExperimentalFeature(featureId);
+	if (!feature) {
+		throw new Error(unknownExperimentalFeatureMessage(featureId));
+	}
+	return withLockedTlhSettingsWrite(cwd, "Refusing to write experimental settings outside the isolated TLH profile.", (current) => {
+		const settings = parseTlhSettingsContent(current);
+		const currentEnabledFeatures = normalizeEnabledFeatures(settings.tlh?.experimental?.enabledFeatures);
+		const currentEnabled = currentEnabledFeatures.includes(feature.id);
+		const enabled = nextEnabledState(currentEnabled, action);
+		if (enabled === currentEnabled) {
+			return { changed: false, enabled };
+		}
+
+		const nextEnabledFeatures = enabled
+			? normalizeEnabledFeatures([...currentEnabledFeatures, feature.id])
+			: currentEnabledFeatures.filter((currentFeatureId) => currentFeatureId !== feature.id);
+
+		ensureMutableExperimentalSettings(settings);
+		settings.tlh.experimental.enabledFeatures = nextEnabledFeatures;
+		return {
+			changed: true,
+			enabled,
+			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
+		};
+	});
+}
+
+export function getExperimentalCommandCompletions(prefix: string) {
+	const normalizedPrefix = prefix.trim().toLowerCase();
+	const completions = EXPERIMENTAL_COMMAND_COMPLETIONS
+		.filter((option) => option.value.startsWith(normalizedPrefix))
+		.map((option) => ({ value: option.value, label: option.value, description: option.description }));
+	return completions.length > 0 ? completions : null;
+}
+
+export async function handleExperimentalCommand(pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void> {
+	const command = parseExperimentalSlashAction(args);
+	if (!command) {
+		ctx.ui.notify(`${EXPERIMENTAL_COMMAND_HELP} Available: ${availableExperimentalFeatureList()}.`, "error");
+		return;
+	}
+
+	if (command.type === "picker") {
+		await showExperimentalFeaturePicker(pi, ctx);
+		return;
+	}
+
+	if (command.type === "list" || command.type === "status") {
+		const featureId = command.type === "status" ? command.featureId : undefined;
+		ctx.ui.notify(formatExperimentalStatusMessage(getTlhExperimentalConfig(ctx.cwd), featureId), "info");
+		return;
+	}
+
+	try {
+		notifyExperimentalWriteResult(pi, ctx, command.featureId, writeExperimentalFeaturePreference(ctx.cwd, command.featureId, command.type));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Could not update TLH experimental feature ${command.featureId}: ${message}`, "error");
+	}
+}

--- a/extensions/the-last-harness/experimental.ts
+++ b/extensions/the-last-harness/experimental.ts
@@ -5,8 +5,6 @@ import {
 	normalizeExperimentalFeatureId,
 	readEnabledExperimentalFeatures,
 } from "../the-last-harness-subagent-safety.mjs";
-import { formatHomePath, isRecord } from "./common.js";
-import { withLockedTlhSettingsWrite } from "./profile-state.js";
 import type { AgentPrompt, TlhExperimentalConfig, TlhExperimentalFeatureId, TlhSettings } from "./types.js";
 
 export const DELTA_FOLLOW_UP_REVIEWS_FEATURE: TlhExperimentalFeatureId = "delta-follow-up-reviews";
@@ -14,7 +12,7 @@ export const CI_FAILURE_INVESTIGATION_FEATURE: TlhExperimentalFeatureId = "ci-fa
 export const TICKET_WORKFLOW_UI_FEATURE: TlhExperimentalFeatureId = "ticket-workflow-ui";
 export const TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT = "tlh:experimental-feature-changed";
 
-const EXPERIMENTAL_COMMAND_HELP = [
+export const EXPERIMENTAL_COMMAND_HELP = [
 	"Usage: /experimental [list|status [feature]|enable <feature>|disable <feature>|toggle <feature>]",
 	"With no argument, /experimental opens the TLH experimental feature picker when UI is available, otherwise it lists feature status.",
 ].join(" ");
@@ -73,14 +71,7 @@ type TlhExperimentalSlashAction =
 	| { type: "status"; featureId?: string }
 	| { type: "enable" | "disable" | "toggle"; featureId: string };
 
-type TlhExperimentalWriteResult = {
-	changed: boolean;
-	settingsPath: string;
-	backupPath?: string;
-	enabled: boolean;
-};
-
-const TLH_EXPERIMENTAL_FEATURES: TlhExperimentalFeature[] = [
+export const TLH_EXPERIMENTAL_FEATURES: TlhExperimentalFeature[] = [
 	{
 		id: DELTA_FOLLOW_UP_REVIEWS_FEATURE,
 		description: "Architect and code-reviewer guidance to scope follow-up reviews to a requested delta after fixes.",
@@ -104,64 +95,26 @@ const TLH_EXPERIMENTAL_FEATURES: TlhExperimentalFeature[] = [
 
 const TLH_EXPERIMENTAL_FEATURES_BY_ID = new Map(TLH_EXPERIMENTAL_FEATURES.map((feature) => [feature.id, feature]));
 
-function hasRegisteredExperimentalFeatures(): boolean {
+export function hasRegisteredExperimentalFeatures(): boolean {
 	return TLH_EXPERIMENTAL_FEATURES.length > 0;
 }
 
-function availableExperimentalFeatureList(): string {
+export function availableExperimentalFeatureList(): string {
 	return hasRegisteredExperimentalFeatures() ? TLH_EXPERIMENTAL_FEATURES.map((feature) => feature.id).join(", ") : "none currently registered";
 }
 
-function noExperimentalFeaturesMessage(): string {
+export function noExperimentalFeaturesMessage(): string {
 	return "TLH experimental features: none currently registered. Future TLH feature flags will appear here when available.";
 }
 
-function unknownExperimentalFeatureMessage(featureId: string): string {
+export function unknownExperimentalFeatureMessage(featureId: string): string {
 	const base = `Unknown TLH experimental feature "${featureId}".`;
 	return hasRegisteredExperimentalFeatures()
 		? `${base} Available: ${availableExperimentalFeatureList()}.`
 		: `${base} ${noExperimentalFeaturesMessage()}`;
 }
 
-function validateTlhExperimentalSettings(settings: unknown): asserts settings is TlhSettings {
-	if (!isRecord(settings)) {
-		throw new Error("settings.json must contain a JSON object");
-	}
-	const tlh = settings.tlh;
-	if (tlh !== undefined && !isRecord(tlh)) {
-		throw new Error("settings field 'tlh' must be an object if present");
-	}
-	const experimental = isRecord(tlh) ? tlh.experimental : undefined;
-	if (experimental !== undefined && !isRecord(experimental)) {
-		throw new Error("settings field 'tlh.experimental' must be an object if present");
-	}
-	const enabledFeatures = isRecord(experimental) ? experimental.enabledFeatures : undefined;
-	if (enabledFeatures !== undefined && !Array.isArray(enabledFeatures)) {
-		throw new Error("settings field 'tlh.experimental.enabledFeatures' must be an array if present");
-	}
-	if (Array.isArray(enabledFeatures) && enabledFeatures.some((feature) => typeof feature !== "string")) {
-		throw new Error("settings field 'tlh.experimental.enabledFeatures' must contain only strings");
-	}
-}
-
-function parseTlhSettingsContent(content: string | undefined): TlhSettings {
-	if (!content) {
-		return {};
-	}
-	const parsed = JSON.parse(content) as unknown;
-	validateTlhExperimentalSettings(parsed);
-	return parsed;
-}
-
-function ensureMutableExperimentalSettings(settings: TlhSettings): asserts settings is TlhSettings & {
-	tlh: { experimental: TlhExperimentalConfig };
-} {
-	validateTlhExperimentalSettings(settings);
-	settings.tlh ??= {};
-	settings.tlh.experimental ??= {};
-}
-
-function normalizeEnabledFeatures(enabledFeatures: string[] | undefined): string[] {
+export function normalizeEnabledFeatures(enabledFeatures: string[] | undefined): string[] {
 	return normalizeEnabledExperimentalFeatures(enabledFeatures) as string[];
 }
 
@@ -169,7 +122,7 @@ function readEnabledFeatures(config: unknown): string[] {
 	return readEnabledExperimentalFeatures(config) as string[];
 }
 
-function getExperimentalFeature(featureId: string): TlhExperimentalFeature | undefined {
+export function getExperimentalFeature(featureId: string): TlhExperimentalFeature | undefined {
 	const normalized = normalizeExperimentalFeatureId(featureId) as string | undefined;
 	return normalized ? TLH_EXPERIMENTAL_FEATURES_BY_ID.get(normalized) : undefined;
 }
@@ -203,7 +156,7 @@ export function isTlhExperimentalFeatureEnabled(config: unknown, featureId: TlhE
 	return feature ? readEnabledFeatures(config).includes(feature.id) : false;
 }
 
-function parseExperimentalSlashAction(args: string): TlhExperimentalSlashAction | undefined {
+export function parseExperimentalSlashAction(args: string): TlhExperimentalSlashAction | undefined {
 	const parts = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
 	if (parts.length === 0) {
 		return { type: "picker" };
@@ -220,145 +173,16 @@ function parseExperimentalSlashAction(args: string): TlhExperimentalSlashAction 
 	return undefined;
 }
 
-function experimentalCommandCompletions(prefix: string) {
-	const options = [
-		{ value: "list", description: "List TLH experimental features" },
-		{ value: "status", description: "Show TLH experimental feature status" },
-		...TLH_EXPERIMENTAL_FEATURES.flatMap((feature) => [
-			{ value: `status ${feature.id}`, description: `Show status for ${feature.id}` },
-			{ value: `enable ${feature.id}`, description: `Enable ${feature.id}` },
-			{ value: `disable ${feature.id}`, description: `Disable ${feature.id}` },
-			{ value: `toggle ${feature.id}`, description: `Toggle ${feature.id}` },
-		]),
-	];
-	const normalizedPrefix = prefix.trim().toLowerCase();
-	const completions = options
-		.filter((option) => option.value.startsWith(normalizedPrefix))
-		.map((option) => ({ value: option.value, label: option.value, description: option.description }));
-	return completions.length > 0 ? completions : null;
-}
-
-function formatExperimentalFeatureStatus(feature: TlhExperimentalFeature, enabled: boolean): string {
-	const enabledLabel = enabled ? "enabled" : "disabled (default)";
-	const nextStep = enabled
-		? `Disable with /experimental disable ${feature.id}.`
-		: `Enable with /experimental enable ${feature.id}.`;
-	return `- ${feature.id}: ${enabledLabel}. ${feature.description} ${nextStep}`;
-}
-
-function formatExperimentalStatusMessage(config: TlhExperimentalConfig | undefined, featureId?: string): string {
-	if (featureId) {
-		const feature = getExperimentalFeature(featureId);
-		if (!feature) {
-			return unknownExperimentalFeatureMessage(featureId);
-		}
-		return formatExperimentalFeatureStatus(feature, isTlhExperimentalFeatureEnabled(config, feature.id));
-	}
-	if (!hasRegisteredExperimentalFeatures()) {
-		return noExperimentalFeaturesMessage();
-	}
-	return [
-		"TLH experimental features:",
-		...TLH_EXPERIMENTAL_FEATURES.map((feature) => formatExperimentalFeatureStatus(feature, isTlhExperimentalFeatureEnabled(config, feature.id))),
-	].join("\n");
-}
-
-function experimentalFeaturePickerOption(feature: TlhExperimentalFeature, enabled: boolean): string {
-	const stateLabel = enabled ? "enabled" : "disabled (default)";
-	return `${enabled ? "●" : "○"} ${feature.id} — ${stateLabel} — ${feature.description}`;
-}
-
-function notifyExperimentalWriteResult(
-	pi: ExtensionAPI,
-	ctx: ExtensionCommandContext,
-	featureId: string,
-	result: TlhExperimentalWriteResult,
-): void {
-	const changedLabel = result.changed ? "Updated" : "No change to";
-	const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
-	const stateLabel = result.enabled ? "enabled" : "disabled";
-	const undoLabel = result.enabled ? `Undo with /experimental disable ${featureId}.` : `Undo with /experimental enable ${featureId}.`;
-	pi.events?.emit?.(TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT, {
-		cwd: ctx.cwd,
-		enabled: result.enabled,
-		featureId,
-	});
-	ctx.ui.notify(
-		`${changedLabel} TLH experimental feature ${featureId} at ${formatHomePath(result.settingsPath)}. It is now ${stateLabel}. ${undoLabel}${backupLabel}`,
-		"info",
-	);
-}
-
-async function showExperimentalFeaturePicker(pi: ExtensionAPI, ctx: ExtensionCommandContext): Promise<void> {
-	if (ctx.mode !== "tui" || !ctx.hasUI || !hasRegisteredExperimentalFeatures() || typeof ctx.ui.select !== "function") {
-		ctx.ui.notify(formatExperimentalStatusMessage(getTlhExperimentalConfig(ctx.cwd)), "info");
-		return;
-	}
-
-	while (true) {
-		const config = getTlhExperimentalConfig(ctx.cwd);
-		const featureIdsByOption = new Map(
-			TLH_EXPERIMENTAL_FEATURES.map((feature) => {
-				const option = experimentalFeaturePickerOption(feature, isTlhExperimentalFeatureEnabled(config, feature.id));
-				return [option, feature.id] as const;
-			}),
-		);
-		const selectedOption = await ctx.ui.select("Toggle TLH experimental features (Esc to close)", [...featureIdsByOption.keys()]);
-		if (!selectedOption) {
-			return;
-		}
-		const selectedFeatureId = featureIdsByOption.get(selectedOption);
-		if (!selectedFeatureId) {
-			ctx.ui.notify("Unknown TLH experimental feature picker selection.", "error");
-			return;
-		}
-
-		try {
-			notifyExperimentalWriteResult(pi, ctx, selectedFeatureId, writeExperimentalFeaturePreference(ctx.cwd, selectedFeatureId, "toggle"));
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			ctx.ui.notify(`Could not update TLH experimental feature ${selectedFeatureId}: ${message}`, "error");
-		}
-	}
-}
-
-function nextEnabledState(currentEnabled: boolean, action: "enable" | "disable" | "toggle"): boolean {
-	if (action === "enable") return true;
-	if (action === "disable") return false;
-	return !currentEnabled;
-}
-
-function writeExperimentalFeaturePreference(
-	cwd: string,
-	featureId: string,
-	action: "enable" | "disable" | "toggle",
-): TlhExperimentalWriteResult {
-	const feature = getExperimentalFeature(featureId);
-	if (!feature) {
-		throw new Error(unknownExperimentalFeatureMessage(featureId));
-	}
-	return withLockedTlhSettingsWrite(cwd, "Refusing to write experimental settings outside the isolated TLH profile.", (current) => {
-		const settings = parseTlhSettingsContent(current);
-		const currentEnabledFeatures = normalizeEnabledFeatures(settings.tlh?.experimental?.enabledFeatures);
-		const currentEnabled = currentEnabledFeatures.includes(feature.id);
-		const enabled = nextEnabledState(currentEnabled, action);
-		if (enabled === currentEnabled) {
-			return { changed: false, enabled };
-		}
-
-		const nextEnabledFeatures = enabled
-			? normalizeEnabledFeatures([...currentEnabledFeatures, feature.id])
-			: currentEnabledFeatures.filter((currentFeatureId) => currentFeatureId !== feature.id);
-
-		ensureMutableExperimentalSettings(settings);
-		settings.tlh.experimental.enabledFeatures = nextEnabledFeatures;
-		return {
-			changed: true,
-			enabled,
-			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
-		};
-	});
-}
+export const EXPERIMENTAL_COMMAND_COMPLETIONS = [
+	{ value: "list", description: "List TLH experimental features" },
+	{ value: "status", description: "Show TLH experimental feature status" },
+	...TLH_EXPERIMENTAL_FEATURES.flatMap((feature) => [
+		{ value: `status ${feature.id}`, description: `Show status for ${feature.id}` },
+		{ value: `enable ${feature.id}`, description: `Enable ${feature.id}` },
+		{ value: `disable ${feature.id}`, description: `Disable ${feature.id}` },
+		{ value: `toggle ${feature.id}`, description: `Toggle ${feature.id}` },
+	]),
+] as const;
 
 export function buildPrimaryExperimentalPrompt(
 	primary: AgentPrompt | undefined,
@@ -380,34 +204,43 @@ export function buildChildExperimentalPrompt(
 	return enabledExperimentalPrompts(config, "codeReviewerPrompt").join("\n\n") || undefined;
 }
 
-export function registerExperimentalCommand(pi: ExtensionAPI): void {
+type ExperimentalCommandModule = {
+	handleExperimentalCommand(pi: ExtensionAPI, args: string, ctx: ExtensionCommandContext): Promise<void>;
+};
+
+type TlhExperimentalCommandFacadeOptions = {
+	loadModule?: () => Promise<ExperimentalCommandModule>;
+};
+
+function createRetryableLazyImport<TModule>(loader: () => Promise<TModule>): () => Promise<TModule> {
+	let modulePromise: Promise<TModule> | undefined;
+	return () => {
+		if (!modulePromise) {
+			modulePromise = loader().catch((error) => {
+				modulePromise = undefined;
+				throw error;
+			});
+		}
+		return modulePromise;
+	};
+}
+
+export function registerExperimentalCommand(pi: ExtensionAPI, options: TlhExperimentalCommandFacadeOptions = {}): void {
+	const loadModule = createRetryableLazyImport(
+		options.loadModule ?? (() => import("./experimental-command.js") as Promise<ExperimentalCommandModule>),
+	);
 	pi.registerCommand("experimental", {
 		description: "List or change TLH experimental features",
-		getArgumentCompletions: experimentalCommandCompletions,
+		getArgumentCompletions: (prefix) => {
+			const normalizedPrefix = prefix.trim().toLowerCase();
+			const completions = EXPERIMENTAL_COMMAND_COMPLETIONS
+				.filter((option) => option.value.startsWith(normalizedPrefix))
+				.map((option) => ({ value: option.value, label: option.value, description: option.description }));
+			return completions.length > 0 ? completions : null;
+		},
 		handler: async (args, ctx) => {
-			const command = parseExperimentalSlashAction(args);
-			if (!command) {
-				ctx.ui.notify(`${EXPERIMENTAL_COMMAND_HELP} Available: ${availableExperimentalFeatureList()}.`, "error");
-				return;
-			}
-
-			if (command.type === "picker") {
-				await showExperimentalFeaturePicker(pi, ctx);
-				return;
-			}
-
-			if (command.type === "list" || command.type === "status") {
-				const featureId = command.type === "status" ? command.featureId : undefined;
-				ctx.ui.notify(formatExperimentalStatusMessage(getTlhExperimentalConfig(ctx.cwd), featureId), "info");
-				return;
-			}
-
-			try {
-				notifyExperimentalWriteResult(pi, ctx, command.featureId, writeExperimentalFeaturePreference(ctx.cwd, command.featureId, command.type));
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Could not update TLH experimental feature ${command.featureId}: ${message}`, "error");
-			}
+			const module = await loadModule();
+			await module.handleExperimentalCommand(pi, args, ctx);
 		},
 	});
 }

--- a/extensions/the-last-harness/usage-limits-command.ts
+++ b/extensions/the-last-harness/usage-limits-command.ts
@@ -1,0 +1,124 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+import { formatHomePath, isRecord } from "./common.js";
+import { withLockedTlhSettingsWrite } from "./profile-state.js";
+import { getTlhUsageLimitsConfig, shouldShowTlhUsageWeekly, USAGE_COMMAND_HELP } from "./usage-limits.js";
+import type {
+	TlhSettings,
+	TlhUsageLimitsConfig,
+	TlhUsageLimitsWriteResult,
+	TlhUsageWeeklyAction,
+} from "./types.js";
+
+type TlhUsageSlashAction =
+	| { type: "status" }
+	| { type: "weekly"; action: TlhUsageWeeklyAction };
+
+function validateTlhUsageLimitsSettings(settings: unknown): asserts settings is TlhSettings {
+	if (!isRecord(settings)) {
+		throw new Error("settings.json must contain a JSON object");
+	}
+	const tlh = settings.tlh;
+	if (tlh !== undefined && !isRecord(tlh)) {
+		throw new Error("settings field 'tlh' must be an object if present");
+	}
+	const usageLimits = isRecord(tlh) ? tlh.usageLimits : undefined;
+	if (usageLimits !== undefined && !isRecord(usageLimits)) {
+		throw new Error("settings field 'tlh.usageLimits' must be an object if present");
+	}
+}
+
+function ensureMutableUsageLimitsSettings(settings: TlhSettings): asserts settings is TlhSettings & {
+	tlh: { usageLimits: TlhUsageLimitsConfig };
+} {
+	validateTlhUsageLimitsSettings(settings);
+	settings.tlh ??= {};
+	settings.tlh.usageLimits ??= {};
+}
+
+function parseTlhSettingsContent(content: string | undefined): TlhSettings {
+	if (!content) {
+		return {};
+	}
+	const parsed = JSON.parse(content) as unknown;
+	validateTlhUsageLimitsSettings(parsed);
+	return parsed;
+}
+
+function writeTlhUsageWeeklyPreference(cwd: string, showWeekly: boolean): TlhUsageLimitsWriteResult {
+	return withLockedTlhSettingsWrite(cwd, "Refusing to write usage-limit settings outside the isolated TLH profile.", (current) => {
+		const settings = parseTlhSettingsContent(current);
+		ensureMutableUsageLimitsSettings(settings);
+
+		if (settings.tlh.usageLimits.showWeekly === showWeekly) {
+			return { changed: false };
+		}
+
+		settings.tlh.usageLimits.showWeekly = showWeekly;
+		return {
+			changed: true,
+			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
+		};
+	});
+}
+
+function parseUsageSlashAction(args: string): TlhUsageSlashAction | undefined {
+	const parts = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (parts.length === 0) {
+		return { type: "status" };
+	}
+	if (parts.length === 1 && parts[0] === "status") {
+		return { type: "status" };
+	}
+	if (parts.length === 2 && parts[0] === "weekly") {
+		const action = parts[1];
+		if (action === "on" || action === "off" || action === "toggle") {
+			return { type: "weekly", action };
+		}
+	}
+	return undefined;
+}
+
+function nextWeeklyPreference(current: boolean, action: TlhUsageWeeklyAction): boolean {
+	if (action === "on") return true;
+	if (action === "off") return false;
+	return !current;
+}
+
+function formatUsageWeeklyStatus(showWeekly: boolean | undefined): string {
+	if (showWeekly === true) {
+		return "TLH usage weekly window is shown. Use /usage weekly off to hide it, or /usage weekly toggle.";
+	}
+	if (showWeekly === false) {
+		return "TLH usage weekly window is hidden. Use /usage weekly on to show it, or /usage weekly toggle.";
+	}
+	return "TLH usage weekly window follows the default auto mode: it shows only when weekly remaining capacity is below 25%. Use /usage weekly on to always show it, /usage weekly off to always hide it, or /usage weekly toggle.";
+}
+
+export async function handleUsageCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
+	const command = parseUsageSlashAction(args);
+	if (!command) {
+		ctx.ui.notify(USAGE_COMMAND_HELP, "error");
+		return;
+	}
+
+	const currentShowWeekly = shouldShowTlhUsageWeekly(getTlhUsageLimitsConfig(ctx.cwd));
+	if (command.type === "status") {
+		ctx.ui.notify(formatUsageWeeklyStatus(currentShowWeekly), "info");
+		return;
+	}
+
+	const nextShowWeekly = nextWeeklyPreference(currentShowWeekly === true, command.action);
+	try {
+		const result = writeTlhUsageWeeklyPreference(ctx.cwd, nextShowWeekly);
+		const changedLabel = result.changed ? "Updated" : "No change to";
+		const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
+		ctx.ui.notify(
+			`${changedLabel} TLH usage weekly-window preference at ${formatHomePath(result.settingsPath)}. ${formatUsageWeeklyStatus(nextShowWeekly)}${backupLabel}`,
+			"info",
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(`Could not update TLH usage weekly-window preference: ${message}`, "error");
+	}
+}

--- a/extensions/the-last-harness/usage-limits.ts
+++ b/extensions/the-last-harness/usage-limits.ts
@@ -1,19 +1,36 @@
-import { SettingsManager, getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
-import { formatHomePath, isRecord } from "./common.js";
-import { withLockedTlhSettingsWrite } from "./profile-state.js";
-import type {
-	TlhSettings,
-	TlhUsageLimitsConfig,
-	TlhUsageLimitsWriteResult,
-	TlhUsageWeeklyAction,
-} from "./types.js";
+import type { TlhSettings, TlhUsageLimitsConfig } from "./types.js";
 
-type TlhUsageSlashAction =
-	| { type: "status" }
-	| { type: "weekly"; action: TlhUsageWeeklyAction };
+export const USAGE_COMMAND_HELP = "Usage: /usage [status|weekly on|weekly off|weekly toggle]. With no argument, /usage shows status.";
 
-const USAGE_COMMAND_HELP = "Usage: /usage [status|weekly on|weekly off|weekly toggle]. With no argument, /usage shows status.";
+const USAGE_COMMAND_COMPLETIONS = [
+	{ value: "status", description: "Show TLH usage-limit footer preferences" },
+	{ value: "weekly on", description: "Show the weekly usage-limit window in the footer" },
+	{ value: "weekly off", description: "Hide the weekly usage-limit window in the footer" },
+	{ value: "weekly toggle", description: "Toggle the weekly usage-limit window in the footer" },
+] as const;
+
+type UsageLimitsCommandModule = {
+	handleUsageCommand(args: string, ctx: ExtensionCommandContext): Promise<void>;
+};
+
+type TlhUsageCommandFacadeOptions = {
+	loadModule?: () => Promise<UsageLimitsCommandModule>;
+};
+
+function createRetryableLazyImport<TModule>(loader: () => Promise<TModule>): () => Promise<TModule> {
+	let modulePromise: Promise<TModule> | undefined;
+	return () => {
+		if (!modulePromise) {
+			modulePromise = loader().catch((error) => {
+				modulePromise = undefined;
+				throw error;
+			});
+		}
+		return modulePromise;
+	};
+}
 
 export function getTlhUsageLimitsConfig(cwd: string): TlhUsageLimitsConfig | undefined {
 	try {
@@ -28,131 +45,22 @@ export function shouldShowTlhUsageWeekly(config: TlhUsageLimitsConfig | undefine
 	return config?.showWeekly;
 }
 
-function validateTlhUsageLimitsSettings(settings: unknown): asserts settings is TlhSettings {
-	if (!isRecord(settings)) {
-		throw new Error("settings.json must contain a JSON object");
-	}
-	const tlh = settings.tlh;
-	if (tlh !== undefined && !isRecord(tlh)) {
-		throw new Error("settings field 'tlh' must be an object if present");
-	}
-	const usageLimits = isRecord(tlh) ? tlh.usageLimits : undefined;
-	if (usageLimits !== undefined && !isRecord(usageLimits)) {
-		throw new Error("settings field 'tlh.usageLimits' must be an object if present");
-	}
-}
-
-function ensureMutableUsageLimitsSettings(settings: TlhSettings): asserts settings is TlhSettings & {
-	tlh: { usageLimits: TlhUsageLimitsConfig };
-} {
-	validateTlhUsageLimitsSettings(settings);
-	settings.tlh ??= {};
-	settings.tlh.usageLimits ??= {};
-}
-
-function parseTlhSettingsContent(content: string | undefined): TlhSettings {
-	if (!content) {
-		return {};
-	}
-	const parsed = JSON.parse(content) as unknown;
-	validateTlhUsageLimitsSettings(parsed);
-	return parsed;
-}
-
-function writeTlhUsageWeeklyPreference(cwd: string, showWeekly: boolean): TlhUsageLimitsWriteResult {
-	return withLockedTlhSettingsWrite(cwd, "Refusing to write usage-limit settings outside the isolated TLH profile.", (current) => {
-		const settings = parseTlhSettingsContent(current);
-		ensureMutableUsageLimitsSettings(settings);
-
-		if (settings.tlh.usageLimits.showWeekly === showWeekly) {
-			return { changed: false };
-		}
-
-		settings.tlh.usageLimits.showWeekly = showWeekly;
-		return {
-			changed: true,
-			nextContent: `${JSON.stringify(settings, null, 2)}\n`,
-		};
-	});
-}
-
-function parseUsageSlashAction(args: string): TlhUsageSlashAction | undefined {
-	const parts = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
-	if (parts.length === 0) {
-		return { type: "status" };
-	}
-	if (parts.length === 1 && parts[0] === "status") {
-		return { type: "status" };
-	}
-	if (parts.length === 2 && parts[0] === "weekly") {
-		const action = parts[1];
-		if (action === "on" || action === "off" || action === "toggle") {
-			return { type: "weekly", action };
-		}
-	}
-	return undefined;
-}
-
-function nextWeeklyPreference(current: boolean, action: TlhUsageWeeklyAction): boolean {
-	if (action === "on") return true;
-	if (action === "off") return false;
-	return !current;
-}
-
-function formatUsageWeeklyStatus(showWeekly: boolean | undefined): string {
-	if (showWeekly === true) {
-		return "TLH usage weekly window is shown. Use /usage weekly off to hide it, or /usage weekly toggle.";
-	}
-	if (showWeekly === false) {
-		return "TLH usage weekly window is hidden. Use /usage weekly on to show it, or /usage weekly toggle.";
-	}
-	return "TLH usage weekly window follows the default auto mode: it shows only when weekly remaining capacity is below 25%. Use /usage weekly on to always show it, /usage weekly off to always hide it, or /usage weekly toggle.";
-}
-
 function usageCommandCompletions(prefix: string) {
-	const options = [
-		{ value: "status", description: "Show TLH usage-limit footer preferences" },
-		{ value: "weekly on", description: "Show the weekly usage-limit window in the footer" },
-		{ value: "weekly off", description: "Hide the weekly usage-limit window in the footer" },
-		{ value: "weekly toggle", description: "Toggle the weekly usage-limit window in the footer" },
-	];
 	const normalizedPrefix = prefix.trim().toLowerCase();
-	const completions = options
+	const completions = USAGE_COMMAND_COMPLETIONS
 		.filter((option) => option.value.startsWith(normalizedPrefix))
 		.map((option) => ({ value: option.value, label: option.value, description: option.description }));
 	return completions.length > 0 ? completions : null;
 }
 
-export function registerUsageCommand(pi: ExtensionAPI): void {
+export function registerUsageCommand(pi: ExtensionAPI, options: TlhUsageCommandFacadeOptions = {}): void {
+	const loadModule = createRetryableLazyImport(options.loadModule ?? (() => import("./usage-limits-command.js") as Promise<UsageLimitsCommandModule>));
 	pi.registerCommand("usage", {
 		description: "Show or change TLH usage-limit footer preferences",
 		getArgumentCompletions: usageCommandCompletions,
 		handler: async (args, ctx) => {
-			const command = parseUsageSlashAction(args);
-			if (!command) {
-				ctx.ui.notify(USAGE_COMMAND_HELP, "error");
-				return;
-			}
-
-			const currentShowWeekly = shouldShowTlhUsageWeekly(getTlhUsageLimitsConfig(ctx.cwd));
-			if (command.type === "status") {
-				ctx.ui.notify(formatUsageWeeklyStatus(currentShowWeekly), "info");
-				return;
-			}
-
-			const nextShowWeekly = nextWeeklyPreference(currentShowWeekly === true, command.action);
-			try {
-				const result = writeTlhUsageWeeklyPreference(ctx.cwd, nextShowWeekly);
-				const changedLabel = result.changed ? "Updated" : "No change to";
-				const backupLabel = result.backupPath ? ` Backup: ${formatHomePath(result.backupPath)}.` : "";
-				ctx.ui.notify(
-					`${changedLabel} TLH usage weekly-window preference at ${formatHomePath(result.settingsPath)}. ${formatUsageWeeklyStatus(nextShowWeekly)}${backupLabel}`,
-					"info",
-				);
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Could not update TLH usage weekly-window preference: ${message}`, "error");
-			}
+			const module = await loadModule();
+			await module.handleUsageCommand(args, ctx);
 		},
 	});
 }

--- a/scripts/check-startup-performance.mjs
+++ b/scripts/check-startup-performance.mjs
@@ -45,9 +45,11 @@ const ANSI_PATTERN = new RegExp(
 	`${String.raw`\u001B`}(?:\\][^${String.raw`\u0007\u001B`}]*(?:${String.raw`\u0007`}|${String.raw`\u001B\\`})|\\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])`,
 	"gu",
 );
-const HEADER_MARKERS = ["Context:", "Press Ctrl+Shift+E", "Warning: running TLH from"];
+const HEADER_TEXT_MARKERS = ["Context:", "Press Ctrl+Shift+E", "Warning: running TLH from"];
 const HEADER_LOGO_PATTERN = /(^|\n)\s*tlh(?:\s+v\d[^\n]*)?\s*(?=\n|$)/u;
+const HEADER_RULE_PATTERN = /(^|\n)[^\n]*─(?:[^\n]*─){19,}[^\n]*(?=\n|$)/u;
 const FOOTER_MARKER = "agent: ";
+const FOOTER_CWD_PATTERN = /(^|\n)(?:~|\/)[^\n]* \([^\n()]+\)(?=\n|$)/u;
 let interruptSignal;
 const PYTHON_PTY_BRIDGE = String.raw`
 import os
@@ -401,11 +403,13 @@ function stripTerminalNoise(text) {
 }
 
 function hasHeaderMarker(text) {
-	return HEADER_MARKERS.some((marker) => text.includes(marker)) || HEADER_LOGO_PATTERN.test(text);
+	return HEADER_TEXT_MARKERS.some((marker) => text.includes(marker))
+		|| HEADER_LOGO_PATTERN.test(text)
+		|| HEADER_RULE_PATTERN.test(text);
 }
 
 function hasFooterMarker(text) {
-	return text.includes(FOOTER_MARKER);
+	return text.includes(FOOTER_MARKER) || FOOTER_CWD_PATTERN.test(text);
 }
 
 function delay(ms) {

--- a/tests/check-startup-performance.test.mjs
+++ b/tests/check-startup-performance.test.mjs
@@ -161,6 +161,68 @@ test("check-startup-performance keeps custom --command launches usable", (t) => 
 	assert.equal(result.stderr, "");
 });
 
+test("check-startup-performance requires genuine header output after a delayed rendered footer", (t) => {
+	const fixture = createManagedWrapperFixture();
+	t.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+	writeExecutable(fixture.customCommandPath, `#!/usr/bin/env bash
+set -euo pipefail
+printf '~/Developer/the-last-harness-minotaur (main)\n'
+sleep 0.15
+printf '────────────────────────────────────────────────────────────────────────────────\n'
+trap 'exit 0' INT TERM
+while true; do
+  sleep 1
+done
+`);
+	const result = runCheckStartupPerformance(fixture, [
+		"--runs",
+		"2",
+		"--budget-ms",
+		"10000",
+		"--timeout-ms",
+		"2000",
+		"--profile-source",
+		fixture.agentDir,
+		"--command",
+		fixture.customCommandPath,
+	]);
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stdout, /PASS warm first-header mean/);
+	const warmRun = result.stdout.match(/run\s+2 warm\s+output [\d.]+ms\s+header ([\d.]+)ms\s+footer ([\d.]+)ms/u);
+	assert.ok(warmRun, `expected warm-run timing output, got:\n${result.stdout}`);
+	assert.ok(Number(warmRun[1]) - Number(warmRun[2]) >= 100, `expected delayed header after footer, got: ${warmRun[0]}`);
+	assert.equal(result.stderr, "");
+});
+
+test("check-startup-performance does not treat rendered footer cwd output as a header", (t) => {
+	const fixture = createManagedWrapperFixture();
+	t.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+	writeExecutable(fixture.customCommandPath, `#!/usr/bin/env bash
+set -euo pipefail
+printf '~/Developer/the-last-harness-minotaur (main)\n'
+trap 'exit 0' INT TERM
+while true; do
+  sleep 1
+done
+`);
+	const result = runCheckStartupPerformance(fixture, [
+		"--runs",
+		"2",
+		"--budget-ms",
+		"10000",
+		"--timeout-ms",
+		"300",
+		"--profile-source",
+		fixture.agentDir,
+		"--command",
+		fixture.customCommandPath,
+	]);
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /timed out waiting for header/);
+});
+
 test("check-startup-performance cleans up the active child process group and temp workspace on SIGINT", async (t) => {
 	if (!hasPython3PtyBridge()) {
 		t.skip("requires python3 PTY bridge coverage");

--- a/tests/the-last-harness-command-facades.test.mjs
+++ b/tests/the-last-harness-command-facades.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { registerToggleTlhGitAttributionCommand } = await jiti.import("../extensions/the-last-harness/attribution.ts");
+const { registerEffortCommand } = await jiti.import("../extensions/the-last-harness/effort.ts");
+const { registerExperimentalCommand, TICKET_WORKFLOW_UI_FEATURE } = await jiti.import("../extensions/the-last-harness/experimental.ts");
+const { registerUsageCommand } = await jiti.import("../extensions/the-last-harness/usage-limits.ts");
+
+function createPiHarness() {
+	const commands = new Map();
+	return {
+		commands,
+		registerCommand(name, command) {
+			commands.set(name, command);
+		},
+		getThinkingLevel: () => "medium",
+		setThinkingLevel() {},
+		events: { emit() {} },
+	};
+}
+
+function createCtx() {
+	const notifications = [];
+	return {
+		notifications,
+		ctx: {
+			cwd: "/tmp/tlh-facade-test",
+			hasUI: false,
+			ui: {
+				notify(message, type) {
+					notifications.push({ message, type });
+				},
+			},
+			model: { provider: "anthropic", id: "claude-sonnet-4-20250514", contextWindow: 200000 },
+		},
+	};
+}
+
+test("attribution facade lazy-loads on demand and retries after a failed import", async () => {
+	const pi = createPiHarness();
+	let attempt = 0;
+	registerToggleTlhGitAttributionCommand(pi, {
+		loadModule: async () => {
+			attempt += 1;
+			if (attempt === 1) {
+				throw new Error("boom");
+			}
+			return {
+				handleToggleTlhGitAttributionCommand: async (_pi, _args, ctx) => {
+					ctx.ui.notify("recovered", "info");
+				},
+			};
+		},
+	});
+	const command = pi.commands.get("toggle-tlh-git-attribution");
+	assert.equal(attempt, 0);
+	await assert.rejects(() => command.handler("", createCtx().ctx), /boom/);
+	const secondRun = createCtx();
+	await command.handler("", secondRun.ctx);
+	assert.equal(attempt, 2);
+	assert.deepEqual(secondRun.notifications, [{ message: "recovered", type: "info" }]);
+});
+
+test("effort facade keeps completions eager-light and shares one lazy handler across aliases", async () => {
+	const pi = createPiHarness();
+	let loadCount = 0;
+	const runtime = { activePrimaryAgentPrompt: () => ({ name: "architect", minThinking: "medium" }) };
+	registerEffortCommand(pi, runtime, {
+		loadModule: async () => {
+			loadCount += 1;
+			return {
+				handleThinkingLevelCommand: async (_pi, _args, ctx) => {
+					ctx.ui.notify("handled", "info");
+				},
+			};
+		},
+	});
+	assert.deepEqual(
+		pi.commands.get("effort").getArgumentCompletions("").map((item) => item.value),
+		["medium", "high", "xhigh", "max"],
+	);
+	assert.equal(loadCount, 0);
+	const effortRun = createCtx();
+	await pi.commands.get("effort").handler("medium", effortRun.ctx);
+	const thinkingRun = createCtx();
+	await pi.commands.get("thinking").handler("high", thinkingRun.ctx);
+	assert.equal(loadCount, 1);
+	assert.deepEqual(effortRun.notifications, [{ message: "handled", type: "info" }]);
+	assert.deepEqual(thinkingRun.notifications, [{ message: "handled", type: "info" }]);
+});
+
+test("experimental facade keeps command completions without loading the heavy command implementation", async () => {
+	const pi = createPiHarness();
+	let loadCount = 0;
+	registerExperimentalCommand(pi, {
+		loadModule: async () => {
+			loadCount += 1;
+			return {
+				handleExperimentalCommand: async (_pi, _args, ctx) => {
+					ctx.ui.notify("experimental handled", "info");
+				},
+			};
+		},
+	});
+	const command = pi.commands.get("experimental");
+	assert.equal(loadCount, 0);
+	assert.ok(command.getArgumentCompletions(`toggle ${TICKET_WORKFLOW_UI_FEATURE}`)?.some((item) => item.value === `toggle ${TICKET_WORKFLOW_UI_FEATURE}`));
+	assert.equal(loadCount, 0);
+	const run = createCtx();
+	await command.handler(`status ${TICKET_WORKFLOW_UI_FEATURE}`, run.ctx);
+	assert.equal(loadCount, 1);
+	assert.deepEqual(run.notifications, [{ message: "experimental handled", type: "info" }]);
+});
+
+test("usage facade keeps weekly completions without loading the write path until execution", async () => {
+	const pi = createPiHarness();
+	let loadCount = 0;
+	registerUsageCommand(pi, {
+		loadModule: async () => {
+			loadCount += 1;
+			return {
+				handleUsageCommand: async (_args, ctx) => {
+					ctx.ui.notify("usage handled", "info");
+				},
+			};
+		},
+	});
+	const command = pi.commands.get("usage");
+	assert.ok(command.getArgumentCompletions("weekly")?.some((item) => item.value === "weekly toggle"));
+	assert.equal(loadCount, 0);
+	const run = createCtx();
+	await command.handler("status", run.ctx);
+	assert.equal(loadCount, 1);
+	assert.deepEqual(run.notifications, [{ message: "usage handled", type: "info" }]);
+});

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -18,17 +18,21 @@ const annotateGitDiffSource = readFileSync(new URL("../extensions/annotate-git-d
 const annotateGitDiffAppSource = readFileSync(new URL("../extensions/annotate-git-diff/web/app.js", import.meta.url), "utf8");
 const annotateGitDiffHtmlSource = readFileSync(new URL("../extensions/annotate-git-diff/web/index.html", import.meta.url), "utf8");
 const attributionSource = readFileSync(new URL("../extensions/the-last-harness/attribution.ts", import.meta.url), "utf8");
+const attributionCommandSource = readFileSync(new URL("../extensions/the-last-harness/attribution-command.ts", import.meta.url), "utf8");
 const changelogSource = readFileSync(new URL("../extensions/the-last-harness/changelog.ts", import.meta.url), "utf8");
 const experimentalSource = readFileSync(new URL("../extensions/the-last-harness/experimental.ts", import.meta.url), "utf8");
+const experimentalCommandSource = readFileSync(new URL("../extensions/the-last-harness/experimental-command.ts", import.meta.url), "utf8");
 const ticketWorkflowUiFacadeSource = readFileSync(new URL("../extensions/the-last-harness/ticket-workflow-ui-facade.ts", import.meta.url), "utf8");
 const footerFirstLineSource = readFileSync(new URL("../extensions/the-last-harness/footer-first-line.ts", import.meta.url), "utf8");
 const footerGitCacheSource = readFileSync(new URL("../extensions/the-last-harness/footer-git-cache.ts", import.meta.url), "utf8");
 const subscriptionUsageFacadeSource = readFileSync(new URL("../extensions/the-last-harness/subscription-usage-facade.ts", import.meta.url), "utf8");
 const primaryRuntimeSource = readFileSync(new URL("../extensions/the-last-harness/primary-agent-runtime.ts", import.meta.url), "utf8");
 const effortSource = readFileSync(new URL("../extensions/the-last-harness/effort.ts", import.meta.url), "utf8");
+const effortCommandSource = readFileSync(new URL("../extensions/the-last-harness/effort-command.ts", import.meta.url), "utf8");
 const promptsSource = readFileSync(new URL("../extensions/the-last-harness/prompts.ts", import.meta.url), "utf8");
 const tokensSource = readFileSync(new URL("../extensions/the-last-harness/tokens.ts", import.meta.url), "utf8");
 const usageLimitsSource = readFileSync(new URL("../extensions/the-last-harness/usage-limits.ts", import.meta.url), "utf8");
+const usageLimitsCommandSource = readFileSync(new URL("../extensions/the-last-harness/usage-limits-command.ts", import.meta.url), "utf8");
 const profileStateSource = readFileSync(new URL("../extensions/the-last-harness/profile-state.ts", import.meta.url), "utf8");
 const typesSource = readFileSync(new URL("../extensions/the-last-harness/types.ts", import.meta.url), "utf8");
 const jiti = createJiti(import.meta.url);
@@ -510,13 +514,26 @@ test("extension lazy-loads review, tokens, annotate-last-message, and tlh-change
 	assert.doesNotMatch(extensionSource, /import\("\.\/the-last-harness\/(?:effort|thinking|experimental|version|attribution)\.js"\)/);
 });
 
+test("header, footer, and update-check stay on the eager startup path pending benchmark-proven deferment", () => {
+	const sessionStart = sourceSection(extensionSource, 'pi.on("session_start"', "\n\t});\n}");
+
+	assert.match(extensionSource, /from "\.\/the-last-harness\/footer\.js"/);
+	assert.match(extensionSource, /from "\.\/the-last-harness\/footer-git-cache\.js"/);
+	assert.match(extensionSource, /from "\.\/the-last-harness\/header\.js"/);
+	assert.match(extensionSource, /from "\.\/the-last-harness\/update-check\.js"/);
+	assert.doesNotMatch(extensionSource, /import\("\.\/the-last-harness\/(?:footer|footer-git-cache|header|update-check)\.js"\)/);
+	assert.match(sessionStart, /const headerUpdate = getTlhHeaderUpdate\(\);/);
+	assert.match(sessionStart, /void maybeNotifyAvailableTlhUpdate\(ctx\)\.catch\(\(\) => undefined\);/);
+});
+
 test("thinking alias shares the effort command thinking-level behavior", () => {
 	assert.match(effortSource, /\["effort", "thinking"\] as const/);
 	assert.match(effortSource, /description: "Pick the model thinking level"/);
-	assert.match(effortSource, /Unknown thinking level/);
-	assert.match(effortSource, /Thinking level set to/);
-	assert.match(effortSource, /Available thinking levels/);
-	assert.match(effortSource, /Pick thinking level/);
+	assert.match(effortSource, /import\("\.\/effort-command\.js"\)/);
+	assert.match(effortCommandSource, /Unknown thinking level/);
+	assert.match(effortCommandSource, /Thinking level set to/);
+	assert.match(effortCommandSource, /Available thinking levels/);
+	assert.match(effortCommandSource, /Pick thinking level/);
 });
 
 test("extension delegates launch update and telemetry services to feature modules", () => {
@@ -530,7 +547,8 @@ test("extension delegates launch update and telemetry services to feature module
 		/if \(event\.reason === "startup"\) \{[\s\S]*void import\("\.\/the-last-harness\/launch-telemetry\.js"\)[\s\S]*scheduleTlhLaunchTelemetry\(ctx\)[\s\S]*\.catch\(\(\) => undefined\);[\s\S]*\}/,
 	);
 	assert.match(sessionStart, /if \(!ctx\.hasUI\) \{[\s\S]*return;[\s\S]*if \(event\.reason === "startup"\)/);
-	assert.match(sessionStart, /maybeNotifyAvailableTlhUpdate\(ctx\)/);
+	assert.match(sessionStart, /const headerUpdate = getTlhHeaderUpdate\(\);/);
+	assert.match(sessionStart, /void maybeNotifyAvailableTlhUpdate\(ctx\)\.catch\(\(\) => undefined\);/);
 	assert.doesNotMatch(extensionSource, /function maybeSendTlhLaunchTelemetry/);
 	assert.doesNotMatch(extensionSource, /function fetchLatestTlhRelease/);
 });
@@ -659,6 +677,7 @@ test("extension keeps TLH experimental command wiring with registered ticket, ci
 	assert.match(ticketWorkflowUiFacadeSource, /import\("\.\/ticket-workflow-ui\.js"\)/);
 	assert.match(ticketWorkflowUiFacadeSource, /createRetryableLazyImport/);
 	assert.match(experimentalSource, /pi\.registerCommand\("experimental"/);
+	assert.match(experimentalSource, /import\("\.\/experimental-command\.js"\)/);
 	assert.match(experimentalSource, /delta-follow-up-reviews/);
 	assert.match(experimentalSource, /ci-failure-investigation/);
 	assert.match(experimentalSource, /ticket-workflow-ui/);
@@ -666,12 +685,12 @@ test("extension keeps TLH experimental command wiring with registered ticket, ci
 	assert.doesNotMatch(experimentalSource, /Enables the contrarian minor agent and primary-agent guidance/);
 	assert.doesNotMatch(experimentalSource, /run-tests-last/);
 	assert.match(
-		experimentalSource,
+		experimentalCommandSource,
 		/withLockedTlhSettingsWrite\(cwd, "Refusing to write experimental settings outside the isolated TLH profile\./,
 	);
-	assert.doesNotMatch(experimentalSource, /tlhSettingsPathForWrite\(\)/);
-	assert.doesNotMatch(experimentalSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
-	assert.match(experimentalSource, /settings\.tlh\.experimental\.enabledFeatures = nextEnabledFeatures/);
+	assert.doesNotMatch(experimentalCommandSource, /tlhSettingsPathForWrite\(\)/);
+	assert.doesNotMatch(experimentalCommandSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
+	assert.match(experimentalCommandSource, /settings\.tlh\.experimental\.enabledFeatures = nextEnabledFeatures/);
 	assert.match(typesSource, /experimental\?: TlhExperimentalConfig;/);
 	assert.match(typesSource, /enabledFeatures\?: string\[];/);
 	assert.match(typesSource, /export type TlhExperimentalFeatureId = string;/);
@@ -679,45 +698,45 @@ test("extension keeps TLH experimental command wiring with registered ticket, ci
 	assert.match(primaryRuntimeSource, /buildPrimaryExperimentalPrompt\(activePrimaryAgent\(\), settings\.tlh\?\.experimental\)/);
 	assert.doesNotMatch(extensionSource, /registerTlhCommitAttributionRuntime\(pi\)/);
 	assert.match(extensionSource, /registerToggleTlhGitAttributionCommand\(pi\)/);
-	assert.match(attributionSource, /from "\.\/profile-state\.js"/);
+	assert.match(attributionSource, /import\("\.\/attribution-command\.js"\)/);
 	assert.doesNotMatch(attributionSource, /pi\.on\("before_agent_start"/);
 	assert.doesNotMatch(attributionSource, /pi\.on\("tool_call"/);
 	assert.doesNotMatch(attributionSource, /user_bash/);
 	assert.match(attributionSource, /pi\.registerCommand\("toggle-tlh-git-attribution"/);
 	assert.doesNotMatch(attributionSource, /pi\.registerCommand\("attribution"/);
 	assert.doesNotMatch(attributionSource, /value: "toggle"/);
-	assert.match(attributionSource, /Usage: \/toggle-tlh-git-attribution/);
+	assert.match(attributionCommandSource, /Usage: \/toggle-tlh-git-attribution/);
 	assert.match(
-		attributionSource,
+		attributionCommandSource,
 		/withLockedTlhSettingsWrite\(cwd, "Refusing to write attribution settings outside the isolated TLH profile\./,
 	);
-	assert.doesNotMatch(attributionSource, /tlhSettingsPathForWrite\(\)/);
-	assert.doesNotMatch(attributionSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
+	assert.doesNotMatch(attributionCommandSource, /tlhSettingsPathForWrite\(\)/);
+	assert.doesNotMatch(attributionCommandSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
 	assert.match(attributionSource, /TLH_DEFAULT_COMMIT_ATTRIBUTION/);
-	assert.match(attributionSource, /settings\.tlh\.attribution = \{ commit: nextEnabled \}/);
-	assert.match(attributionSource, /typeof commit !== "boolean"/);
+	assert.match(attributionCommandSource, /settings\.tlh\.attribution = \{ commit: nextEnabled \}/);
+	assert.match(attributionCommandSource, /typeof commit !== "boolean"/);
 	assert.match(typesSource, /commit\?: boolean;/);
 	assert.match(extensionSource, /pi\.registerCommand\("tokens", \{/);
 	assert.match(extensionSource, /const handler = await getTokensCommandHandler\(\);/);
 	assert.match(tokensSource, /pi\.registerCommand\("tokens"/);
 	assert.match(tokensSource, /Usage: \/tokens/);
 	assert.match(extensionSource, /registerUsageCommand\(pi\)/);
-	assert.match(usageLimitsSource, /from "\.\/profile-state\.js"/);
+	assert.match(usageLimitsSource, /import\("\.\/usage-limits-command\.js"\)/);
 	assert.match(usageLimitsSource, /pi\.registerCommand\("usage"/);
 	assert.match(usageLimitsSource, /value: "weekly on"/);
 	assert.match(usageLimitsSource, /value: "weekly off"/);
 	assert.match(usageLimitsSource, /value: "weekly toggle"/);
 	assert.match(
-		usageLimitsSource,
+		usageLimitsCommandSource,
 		/withLockedTlhSettingsWrite\(cwd, "Refusing to write usage-limit settings outside the isolated TLH profile\./,
 	);
-	assert.doesNotMatch(usageLimitsSource, /tlhSettingsPathForWrite\(\)/);
-	assert.doesNotMatch(usageLimitsSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
+	assert.doesNotMatch(usageLimitsCommandSource, /tlhSettingsPathForWrite\(\)/);
+	assert.doesNotMatch(usageLimitsCommandSource, /assertSafeTlhSettingsPath\(settingsPath\)/);
 	assert.match(lockedWriteHelper, /const settingsPath = tlhSettingsPathForWrite\(\);/);
 	assert.match(lockedWriteHelper, /assertSafeTlhSettingsPath\(settingsPath\);/);
 	assert.match(lockedWriteHelper, /if \(current\) \{/);
 	assert.match(lockedWriteHelper, /const backupPath = `\$\{settingsPath\}\.bak-\$\{settingsBackupTimestamp\(\)\}`;/);
 	assert.match(lockedWriteHelper, /writeFileSync\(backupPath, current, \{ encoding: "utf8", flag: "wx", mode: 0o600 \}\);/);
-	assert.match(usageLimitsSource, /settings\.tlh\.usageLimits\.showWeekly = showWeekly/);
-	assert.match(usageLimitsSource, /showWeekly === true/);
+	assert.match(usageLimitsCommandSource, /settings\.tlh\.usageLimits\.showWeekly = showWeekly/);
+	assert.match(usageLimitsCommandSource, /showWeekly === true/);
 });


### PR DESCRIPTION
## Summary

- Open PR for ticket `tlhm-p6uv` to lazy-load the TLH core command implementations for attribution, effort/thinking, experimental, and usage commands.
- Split heavyweight command handlers into dedicated `*-command.ts` modules while keeping lightweight registration/completion facades eager.
- Add facade-focused regression tests and update startup-performance coverage so the default `tlh` path is measured via a temporary managed wrapper.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Other

## Validation

_Describe the checks you ran. Delete paths that do not apply._

**Standard validation (most changes):**

```sh
npm run validate
```

_Paste the relevant output or a summary here:_

- `npm run validate` was run end-to-end until `npm run lint:sh`.
- Passed before the environment block: `npm run check:package-versions`, `npm run typecheck`, `npm run typecheck:runtime`, `npm run check:runtime`, `bash scripts/check-installer-smoke.sh`, `npm test`, `npm run lint`.
- Local environment exception: `npm run lint:sh` failed with `xargs: shellcheck: No such file or directory` (exit 127) because `shellcheck` is not installed in this session.
- Per follow-up validation, remaining post-`lint:sh` steps passed: `node scripts/merge-settings.mjs --dry-run`, `npm pack --dry-run`.
- Focused regression/performance evidence: `node --test tests/the-last-harness-command-facades.test.mjs tests/check-startup-performance.test.mjs tests/the-last-harness-extension-static.test.mjs` passed (31/31).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [ ] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/perf/lazy-load-core-commands/install.sh | bash -s -- --ref perf/lazy-load-core-commands --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to toggle Git commit attribution, adjust thinking levels, manage experimental features, and control weekly usage visibility.
  * Added interactive selection and command completion support where applicable.
* **Bug Fixes**
  * Improved startup performance detection for additional header and footer output formats.
  * Added safer settings updates with user notifications and backup details.
* **Tests**
  * Expanded coverage for command loading, retries, completions, startup timing, and extension wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->