### PR TITLE
Pin pi-subagents to 0.31.5 (v0.32.0+v0.34.0 intakes, RPC default-off hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the bundled critical pi-subagents default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.4` to `npm:@diegopetrucci/pi-subagents@0.31.5` (v0.32.0+v0.34.0 upstream intakes and RPC bridge default-off hardening).
+
 ### Added
 
 - Install and update now prune stale settings/keybindings backups (`settings.json.backup-*`, `keybindings.json.backup-*`) from the isolated profile. Backups older than ~28 days are removed, but the two newest are always kept regardless of age. Pruning is scoped strictly to `~/.the-last-harness/agent` and never touches `~/.pi`. To keep a backup indefinitely, copy it outside the isolated profile before it ages out.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -62,7 +62,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.4",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.5",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1101,7 +1101,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.4");
+	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.5");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [
@@ -1144,7 +1144,7 @@ test("bundled merge migrates legacy upstream and TLH subagents installs to the s
 	const settings = readJson(fixture.settings);
 	assert.deepEqual(
 		settings.packages.filter((entry) => packageIdentity(entry) === "npm:@diegopetrucci/pi-subagents"),
-		["npm:@diegopetrucci/pi-subagents@0.31.4"],
+		["npm:@diegopetrucci/pi-subagents@0.31.5"],
 	);
 	assert.equal(
 		settings.packages.some((entry) => packageIdentity(entry) === "git:github.com/nicobailon/pi-subagents"),


### PR DESCRIPTION
## Summary

Bump the bundled critical `pi-subagents` default-extension pin from `@0.31.4` to `@0.31.5`. The new fork release adopts upstream through v0.34.0 (two merge intakes) and adds a security hardening (RPC bridge default-off).

## Change type

- [x] Pin PR (update a `config/default-extensions.json` fork tag)

## Validation

```sh
npm run validate      # pass (Node 26.4.0): tests (dot reporter, all green), eslint, shellcheck,
                      # installer dry-run (→ @0.31.5), package dry-run (the-last-harness-0.29.0.tgz)
node --test tests/default-extensions.test.mjs   # 43/43 pass
```

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (pin string only; installer dry-run unchanged behavior, still scoped to the isolated profile)
- [x] Relevant tests pass (`tests/default-extensions.test.mjs` 43/43; full `npm run validate` green)
- [x] `CHANGELOG.md` updated (`[Unreleased] → Changed`)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR

**What the new fork tag / pin includes:**
`@diegopetrucci/pi-subagents@0.31.5` — adopts upstream through **v0.34.0** via merge intakes (v0.32.0 and v0.34.0): native supervisor coordination, fleet view + `/subagents-fleet`, opt-in per-agent memory, compact/custom tool-description modes, scheduled runs, completion batching, turn/tool budgets, `/subagent-cost`. Plus a **security hardening**: the in-process subagent RPC bridge is now gated **default-off** (`rpc.enabled`) so its spawn path can't bypass TLH's tool-call allow-list; TLH leaves it off.

**Link to merged fork PRs:**
- Intake v0.34.0: diegopetrucci/pi-subagents#58
- RPC default-off hardening: diegopetrucci/pi-subagents#59
- Release: `@diegopetrucci/pi-subagents@0.31.5` (git tag `v0.31.5`)

**Before → after pin:**
`npm:@diegopetrucci/pi-subagents@0.31.4` → `npm:@diegopetrucci/pi-subagents@0.31.5`

**`npm run validate` result:** pass (see Validation above).

---

## Post-merge verification

Runtime behaviors that were only unit/statically verified are tracked for a one-pass check in diegopetrucci/the-last-harness#346 (`docs/pin-bump-verification.md`): compact tool description, RPC-off confirmation, native supervisor escalation, management-verb blocks, general delegation smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled subagents extension to version 0.31.5, including upstream intake and RPC bridge hardening improvements.

* **Tests**
  * Updated bundled extension and migration checks to reflect the new subagents version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->