### PR TITLE
Trim generated extension runtime

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,13 @@ import tseslint from "typescript-eslint";
 
 const targetFiles = ["scripts/**/*.{js,mjs,ts,mts}", "tests/**/*.{js,mjs,ts,mts}", "extensions/**/*.{js,mjs,ts,mts}"];
 const typescriptFiles = ["scripts/**/*.{ts,mts}", "tests/**/*.{ts,mts}", "extensions/**/*.{ts,mts}"];
+const generatedExtensionJavaScriptFiles = [
+	"extensions/*.js",
+	"extensions/annotate-git-diff/*.js",
+	"extensions/shared/*.js",
+	"extensions/the-last-harness/*.js",
+	"extensions/the-last-harness/annotate-last-message/*.js",
+];
 
 const unusedArgsOptions = { argsIgnorePattern: "^_" };
 
@@ -33,6 +40,13 @@ export default tseslint.config(
 		},
 	},
 	...tseslint.configs.recommended.map(withFiles),
+	{
+		name: "tlh/generated-extension-javascript-empty-catch",
+		files: generatedExtensionJavaScriptFiles,
+		rules: {
+			"no-empty": ["error", { allowEmptyCatch: true }],
+		},
+	},
 	{
 		name: "tlh/typescript-unused-args",
 		files: typescriptFiles,

--- a/extensions/annotate-git-diff/index.js
+++ b/extensions/annotate-git-diff/index.js
@@ -58,7 +58,6 @@ export default function (pi) {
             windowToClose.close();
         }
         catch {
-            // Window is already closing; ignore shutdown races.
         }
     }
     async function reviewRepository(ctx) {

--- a/extensions/annotate-git-diff/ui.js
+++ b/extensions/annotate-git-diff/ui.js
@@ -98,9 +98,6 @@ export function buildReviewHtml(data) {
     const assetConfig = escapeForInlineScript(JSON.stringify({
         bootstrapError: assets.bootstrapError,
     }));
-    // Use function-form replacements throughout so that `$` in the replacement text
-    // is treated as a literal character rather than a special `String.replace` pattern
-    // (e.g. `$&`, `$'`, `$``, `$1` are all live in minified Monaco JS).
     const safeReplace = (source, marker, replacement) => source.replace(marker, () => replacement);
     let html = templateHtml;
     html = safeReplace(html, '"__INLINE_DATA__"', payload);

--- a/extensions/annotate-git-diff/watch.js
+++ b/extensions/annotate-git-diff/watch.js
@@ -77,7 +77,6 @@ export function createRepoChangeWatcher(repoRoot, onChange, options = {}) {
                 watcher?.close();
             }
             catch {
-                // Ignore watcher shutdown races.
             }
             watcher = null;
         },

--- a/extensions/rtk.js
+++ b/extensions/rtk.js
@@ -1,29 +1,8 @@
-// Vendored from rtk-ai/rtk v0.42.4 (hooks/pi/rtk.ts), Apache-2.0.
-// See ./rtk.APACHE-2.0.txt for the upstream license text and provenance.
-// See ../docs/upstream-sync-inventory.md for TLH sync/review guidance.
-// TLH adaptations:
-// - keep native RTK rewrite-only with no /rtk command UI
-// - prefer normal PATH lookup, then fall back to the managed <agent>/bin/rtk when needed
-// - respect RTK_DISABLED=1 and the isolated-profile setting tlh.rtk.disabled
-// - avoid duplicate handler registration when the extension is loaded twice for the same session
-//
-// RTK Pi extension — rewrites bash commands to use rtk for token savings.
-// Requires: rtk >= 0.23.0 in PATH or at the managed isolated fallback path.
-//
-// This is a thin delegating extension: all rewrite logic lives in `rtk rewrite`,
-// which is the single source of truth (src/discover/registry.rs).
-// To add or change rewrite rules, edit the Rust registry — not this file.
-//
-// Exit code contract for `rtk rewrite`:
-//   0 + stdout  Rewrite found → mutate command
-//   1           No RTK equivalent → pass through unchanged
-//   3 + stdout  Rewrite (advisory) → mutate command
 import { join } from "node:path";
 import { SettingsManager, getAgentDir, isToolCallEventType } from "@earendil-works/pi-coding-agent";
 const REWRITE_TIMEOUT_MS = 2_000;
 const MIN_SUPPORTED_RTK_MINOR = 23;
 const TLH_RTK_EXTENSION_STATE = Symbol.for("tlh.rtkExtensionState");
-// Parse "X.Y.Z" semver, return [major, minor, patch] or null.
 function parseSemver(raw) {
     const match = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/);
     if (!match)
@@ -82,7 +61,6 @@ async function resolveRtkCommand(pi) {
     console.warn(`[rtk] ${describeUnusableRtk(pathProbe, "rtk in PATH")} and ${describeUnusableRtk(managedProbe, `managed fallback ${managedCommand}`)} — extension disabled`);
     return null;
 }
-// Calls `rtk rewrite`; returns the rewritten command or null (pass through).
 async function rewriteCommand(pi, rtkCommand, cmd, signal) {
     const result = await pi.exec(rtkCommand, ["rewrite", cmd], {
         timeout: REWRITE_TIMEOUT_MS,
@@ -123,14 +101,12 @@ export default async function rtk(pi) {
                     return;
                 if (isRtkSettingDisabled(ctx.cwd))
                     return;
-                // Delegate to RTK.
                 const rewritten = await rewriteCommand(pi, rtkCommand, cmd, ctx.signal);
                 if (rewritten && rewritten !== cmd) {
                     event.input.command = rewritten;
                 }
             }
             catch (error) {
-                // Fail open: never block execution on an unexpected error.
                 console.warn("[rtk] unexpected error in tool_call handler; passing through command", error);
                 return;
             }

--- a/extensions/shared/quiet-glimpse.js
+++ b/extensions/shared/quiet-glimpse.js
@@ -1,5 +1,3 @@
-// Adapted with the annotate-git-diff derived family.
-// See ../../docs/upstream-sync-inventory.md for reconstructed provenance and sync guidance.
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";

--- a/extensions/the-last-harness.js
+++ b/extensions/the-last-harness.js
@@ -1,4 +1,3 @@
-import {} from "@earendil-works/pi-coding-agent";
 import { registerTlhActivityReporters } from "./the-last-harness/activity-reporters.js";
 import { registerTlhEffectiveActivityTracker } from "./the-last-harness/activity-tracker.js";
 import { registerToggleTlhGitAttributionCommand } from "./the-last-harness/attribution.js";
@@ -122,7 +121,6 @@ export default function theLastHarness(pi) {
             command.handleSessionShutdown();
         }
         catch {
-            // Swallow prior lazy-import/build failures during shutdown.
         }
     });
     registerEffortCommand(pi, primaryAgentRuntime);
@@ -195,7 +193,6 @@ export default function theLastHarness(pi) {
             });
         }
         catch {
-            // Keep startup resilient. The header can still render without resource details.
         }
         const headerUpdate = getTlhHeaderUpdate();
         const installNotice = event.reason === "startup" ? readTlhInstallNotice() : undefined;

--- a/extensions/the-last-harness.ts
+++ b/extensions/the-last-harness.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import { registerTlhActivityReporters } from "./the-last-harness/activity-reporters.js";
 import { registerTlhEffectiveActivityTracker } from "./the-last-harness/activity-tracker.js";

--- a/extensions/the-last-harness/activity-reporters.js
+++ b/extensions/the-last-harness/activity-reporters.js
@@ -59,7 +59,6 @@ function createQueuedStateReporter(sendState, options = {}) {
                     await sendState(nextState);
                 }
                 catch {
-                    // Reporter failures must never block or crash TLH.
                 }
             }
         }
@@ -140,7 +139,6 @@ function defaultHerdrRequestSender(env) {
                     socket?.destroy();
                 }
                 catch {
-                    // Ignore teardown failures.
                 }
                 resolve();
             };
@@ -293,7 +291,6 @@ function getCmuxStatusKey(env, ctx) {
         }
     }
     catch {
-        // Ignore session id lookup failures and fall back to the global key.
     }
     return CMUX_STATUS_KEY;
 }

--- a/extensions/the-last-harness/activity-tracker.js
+++ b/extensions/the-last-harness/activity-tracker.js
@@ -29,7 +29,6 @@ function resolvePiSubagentsTempScopeId() {
             return `user-${sanitizeTempScopeSegment(username)}`;
     }
     catch {
-        // Fall through to home-directory-based scoping.
     }
     const homedir = process.env.USERPROFILE ?? process.env.HOME;
     if (homedir)
@@ -40,7 +39,6 @@ function resolvePiSubagentsTempScopeId() {
             return `home-${sanitizeTempScopeSegment(fallbackHomedir)}`;
     }
     catch {
-        // Fall through to the shared scope.
     }
     return "shared";
 }
@@ -203,7 +201,6 @@ export function createTlhEffectiveActivityTracker(options = {}) {
                 listener(snapshot);
             }
             catch {
-                // Subscribers must not crash tracker updates.
             }
         }
     };
@@ -232,8 +229,6 @@ export function createTlhEffectiveActivityTracker(options = {}) {
                     if (isRecord(error) && error.code === "ENOENT") {
                         return undefined;
                     }
-                    // Fail closed: this ticket only rehydrates from the stable top-level async status.json layout.
-                    // If pi-subagents changes its registry shape or the runtime dir is unavailable, leave async jobs empty.
                     return undefined;
                 }
             })();
@@ -256,7 +251,6 @@ export function createTlhEffectiveActivityTracker(options = {}) {
                     setAsyncJobActive(status.runId, { asyncDir: candidateAsyncDir, source: "rehydrated" });
                 }
                 catch {
-                    // Fail closed on malformed or partially-written async artifacts.
                 }
             }
             notifyIfChanged();
@@ -397,7 +391,6 @@ export function registerTlhEffectiveActivityTracker(pi) {
                 unsubscribe();
             }
             catch {
-                // Best-effort event-bus cleanup during shutdown.
             }
         }
         tracker.dispose();

--- a/extensions/the-last-harness/annotate-last-message.js
+++ b/extensions/the-last-harness/annotate-last-message.js
@@ -28,7 +28,6 @@ export function buildAnnotateLastMessageCommand() {
             windowToClose.close();
         }
         catch {
-            // Ignore races when the native window is already closing.
         }
     }
     async function openAnnotationWindow(ctx) {

--- a/extensions/the-last-harness/changelog.js
+++ b/extensions/the-last-harness/changelog.js
@@ -49,9 +49,6 @@ export async function handleTlhChangelogCommand(pi, _args, ctx) {
     if (await showTlhChangelogUi(changelog, ctx)) {
         return;
     }
-    // RPC/print modes cannot host a custom markdown component. Fall back to a displayed
-    // custom message without triggering a turn, which keeps the release notes visible but
-    // also persists the changelog text in session history/context until it is compacted away.
     pi.sendMessage({
         customType: TLH_RELEASE_NOTES_LABEL,
         content: changelog,

--- a/extensions/the-last-harness/constants.js
+++ b/extensions/the-last-harness/constants.js
@@ -5,8 +5,6 @@ export const TLH_RELEASES_URL = `https://github.com/${TLH_REPO}/releases`;
 export const TLH_LATEST_RELEASE_API_URL = `https://api.github.com/repos/${TLH_REPO}/releases/latest`;
 export const TLH_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export const TLH_UPDATE_CHECK_TIMEOUT_MS = 3000;
-// TelemetryDeck appID/namespace are public client analytics identifiers, not secrets.
-// Env overrides support local verification against mock TelemetryDeck endpoints.
 export const TLH_TELEMETRY_NAMESPACE = "com.gordicorp";
 export const TLH_TELEMETRY_APP_ID = "A4B1E0A4-E03B-450A-B0FA-2ED9895353F3";
 export const TLH_TELEMETRY_INGEST_BASE_URL = "https://nom.telemetrydeck.com/v2/namespace";
@@ -15,8 +13,6 @@ export const TLH_TELEMETRY_TIMEOUT_MS = 1500;
 export const TLH_TELEMETRY_STATE_SCHEMA_VERSION = 1;
 export const DUMB_ZONE_THRESHOLD_TOKENS = 200_000;
 export const DUMB_ZONE_LABEL = "DUMB ZONE";
-// Pi prefixes package-backed commands with provenance tags like [u:git:github.com/org/repo@ref].
-// tlh keeps autocomplete focused on the command description instead.
 export const AUTOCOMPLETE_SOURCE_TAG_PATTERN = /(^|—\s*)\[(?:u|p|t)(?::(?:npm|git):[^\]]+)?\]\s*/g;
 export const PRIMARY_AGENT_CYCLE_SHORTCUT = "shift+tab";
 export const TLH_HEADER_TOGGLE_SHORTCUT = "ctrl+shift+e";

--- a/extensions/the-last-harness/context-cap.js
+++ b/extensions/the-last-harness/context-cap.js
@@ -2,14 +2,8 @@ import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { formatHomePath } from "./common.js";
 import { DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
 import { withLockedTlhSettingsWrite } from "./profile-state.js";
-// Re-exported alias so callers can reference the cap value without coupling to
-// the "dumb zone" label used in footer rendering. Both names point to the same
-// compile-time constant; 200_000 is defined exactly once in constants.ts.
 export const DEFAULT_CONTEXT_CAP_TOKENS = DUMB_ZONE_THRESHOLD_TOKENS;
 const TOGGLE_CONTEXT_CAP_COMMAND_HELP = "Usage: /toggle-context-cap";
-// WeakMap stores the original contextWindow before we capped it.
-// Keyed by model object identity so each Pi model instance is tracked
-// independently across multiple concurrent sessions.
 const originalContextWindows = new WeakMap();
 function getOriginalContextWindow(model) {
     const stored = originalContextWindows.get(model);
@@ -46,7 +40,6 @@ function forEachRegistryModel(ctx, callback) {
         }
     }
     catch {
-        // Best effort. The active ctx.model is handled separately.
     }
 }
 function applyContextCapToSession(ctx) {

--- a/extensions/the-last-harness/effort-command.js
+++ b/extensions/the-last-harness/effort-command.js
@@ -1,4 +1,3 @@
-import {} from "@earendil-works/pi-coding-agent";
 import { selectProviderAwareAgentDefaults } from "./model-defaults.js";
 import { formatThinkingLevelOption, getAvailableThinkingLevels, isThinkingLevel, parseThinkingLevelOption, setExtensionThinkingLevel, thinkingLevelAtLeast, } from "./thinking.js";
 export async function handleThinkingLevelCommand(pi, args, ctx, runtime) {

--- a/extensions/the-last-harness/effort-command.ts
+++ b/extensions/the-last-harness/effort-command.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { selectProviderAwareAgentDefaults } from "./model-defaults.js";
 import type { TlhPrimaryAgentRuntime } from "./primary-agent-runtime.js";

--- a/extensions/the-last-harness/effort.js
+++ b/extensions/the-last-harness/effort.js
@@ -1,4 +1,3 @@
-import {} from "@earendil-works/pi-coding-agent";
 import { THINKING_LEVEL_DESCRIPTIONS, THINKING_LEVELS } from "./constants.js";
 import { thinkingLevelAtLeast } from "./thinking.js";
 function createRetryableLazyImport(loader) {

--- a/extensions/the-last-harness/effort.ts
+++ b/extensions/the-last-harness/effort.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { THINKING_LEVEL_DESCRIPTIONS, THINKING_LEVELS } from "./constants.js";
 import type { TlhPrimaryAgentRuntime } from "./primary-agent-runtime.js";

--- a/extensions/the-last-harness/footer-first-line.js
+++ b/extensions/the-last-harness/footer-first-line.js
@@ -1,17 +1,5 @@
 import { formatTlhGitFooterSegments } from "./footer-git.js";
-/** Bullet divider used between segments on the TLH footer's first line. */
 export const FOOTER_FIRST_LINE_SEPARATOR = " • ";
-/**
- * Pure composer for the TLH footer's first line. Joins cwd, cached git
- * segments (branch + status indicators + PR), and the session name with the
- * existing bullet divider.
- *
- * Falls back to `fallbackBranch` (typically `footerData.getGitBranch()`) only
- * when the cached status snapshot is `undefined`, i.e. the git cache has not
- * been wired or its first refresh has not completed yet. The legacy
- * parenthesized `(branch)` format is intentionally gone — the bullet style is
- * the new canonical look.
- */
 export function composeTlhFooterFirstLine(input) {
     const segments = [input.cwd];
     if (input.status !== undefined) {

--- a/extensions/the-last-harness/footer-git-cache.js
+++ b/extensions/the-last-harness/footer-git-cache.js
@@ -39,14 +39,9 @@ function defaultRunner(command, args, options) {
                 child.kill("SIGTERM");
             }
             catch {
-                // Ignore: process may already be gone.
             }
             finish(new Error("aborted"));
         };
-        // Attach child listeners before checking a pre-aborted signal so a
-        // delayed ENOENT/close cannot escape as an uncaught exception that
-        // would terminate the host Pi process. The `settled` guard inside
-        // `finish()` makes any post-abort close/error a safe no-op.
         child.stdout?.on("data", (chunk) => {
             stdout += typeof chunk === "string" ? chunk : chunk.toString("utf8");
         });
@@ -128,11 +123,6 @@ function pullRequestSnapshotsEqual(left, right) {
         && left?.url === right?.url
         && left?.title === right?.title);
 }
-/**
- * Background cache for the TLH footer's git status and (best-effort) GitHub PR
- * metadata. Refreshes asynchronously and exposes synchronous snapshot getters
- * so footer `render()` never spawns subprocesses.
- */
 export class FooterGitCache {
     cwd;
     runner;
@@ -163,9 +153,6 @@ export class FooterGitCache {
         if (!options.skipInitialRefresh) {
             void this.refresh();
         }
-        // Subscribe to external branch-change notifications, if any. Each
-        // callback invocation schedules a refresh; the existing in-flight
-        // promise sharing automatically dedupes overlapping callbacks.
         if (options.onBranchChangeSource) {
             this.branchChangeUnsubscribe = options.onBranchChangeSource(() => {
                 void this.refresh();
@@ -178,10 +165,6 @@ export class FooterGitCache {
     getPullRequestSnapshot() {
         return this.pullRequestSnapshot;
     }
-    /**
-     * Trigger a refresh. Concurrent calls share the in-flight promise. Safe to
-     * call after `dispose()` (resolves immediately as a no-op).
-     */
     refresh() {
         if (this.disposed) {
             return Promise.resolve();
@@ -189,10 +172,6 @@ export class FooterGitCache {
         if (this.refreshInFlight) {
             return this.refreshInFlight;
         }
-        // Refresh is best-effort; swallow rejections at the cache boundary so
-        // `void this.refresh()` callers (interval tick, branch-change, initial
-        // kick) never produce unhandled rejections that could terminate the
-        // host Pi process under Node's default unhandled-rejection policy.
         const run = this.runRefresh()
             .finally(() => {
             this.refreshInFlight = undefined;
@@ -209,14 +188,9 @@ export class FooterGitCache {
             return;
         }
         if (result.kind === "transient") {
-            // Timeout, spawn error, or exit-0-but-unparseable. Likely transient;
-            // keep last-known snapshots and retry on the next tick.
             return;
         }
         if (result.kind === "not-a-repo") {
-            // cwd is no longer inside a git worktree (e.g. user cd'd to /tmp).
-            // Drop stale state so the footer renders just the path; otherwise the
-            // 8s poll would never recover because exit 128 is persistent.
             this.statusSnapshot = undefined;
             this.pullRequestSnapshot = undefined;
             this.lastSeenBranch = undefined;
@@ -229,8 +203,6 @@ export class FooterGitCache {
         const isValidBranch = !!branch && branch !== "detached";
         const branchChanged = branch !== this.lastSeenBranch;
         if (branchChanged) {
-            // Stale PR data belongs to the previous branch; clear it before
-            // attempting a fresh lookup for the new branch.
             this.pullRequestSnapshot = undefined;
         }
         this.lastSeenBranch = branch;
@@ -247,10 +219,8 @@ export class FooterGitCache {
             this.pullRequestSnapshot = pr;
         }
         else if (branchChanged) {
-            // Branch changed and PR lookup failed; leave snapshot cleared above.
             this.pullRequestSnapshot = undefined;
         }
-        // Otherwise (same branch, gh failed): keep prior PR snapshot.
         this.emitChangeIfSnapshotsChanged(previousStatusSnapshot, previousPullRequestSnapshot);
     }
     emitChangeIfSnapshotsChanged(previousStatusSnapshot, previousPullRequestSnapshot) {
@@ -265,14 +235,8 @@ export class FooterGitCache {
             this.onChange?.();
         }
         catch {
-            // Silent: rendering hooks must not break refreshes.
         }
     }
-    // Three-way split so runRefresh can distinguish persistent "not a repo"
-    // failures (cwd left the worktree, exit 128) from transient ones (timeout,
-    // spawn error, or exit-0-but-unparseable). Collapsing them caused the
-    // footer to keep showing the previous repo's branch/PR forever after cd'ing
-    // out of a git directory.
     async fetchGitStatus() {
         const result = await this.runCommandSafely("git", GIT_STATUS_ARGS, this.gitTimeoutMs);
         if (!result) {
@@ -307,7 +271,6 @@ export class FooterGitCache {
             return await this.runner(command, args, { cwd: this.cwd(), signal: controller.signal });
         }
         catch {
-            // Silent: missing binary, abort, spawn error, non-zero stderr, etc.
             return undefined;
         }
         finally {
@@ -315,11 +278,6 @@ export class FooterGitCache {
             this.inflightControllers.delete(controller);
         }
     }
-    /**
-     * Stop background refreshes and cancel any in-flight subprocesses.
-     * Idempotent. After disposal the snapshot getters keep returning the
-     * last-known values but no further refreshes occur.
-     */
     dispose() {
         if (this.disposed) {
             return;
@@ -334,7 +292,6 @@ export class FooterGitCache {
                 this.branchChangeUnsubscribe();
             }
             catch {
-                // Ignore: a misbehaving notifier must not block disposal.
             }
             this.branchChangeUnsubscribe = undefined;
         }

--- a/extensions/the-last-harness/footer-subscription-usage.js
+++ b/extensions/the-last-harness/footer-subscription-usage.js
@@ -47,7 +47,6 @@ function formatResetCountdown(resetsAt, nowMs, windowType) {
         const remainingHours = Math.floor((deltaMs - totalDays * DAY_MS) / HOUR_MS);
         return `${totalDays}d ${remainingHours}h`;
     }
-    // Session-style format (also used as weekly fallback when delta < 1 day)
     if (totalMinutes < 1) {
         return "<1m";
     }

--- a/extensions/the-last-harness/footer.js
+++ b/extensions/the-last-harness/footer.js
@@ -41,7 +41,6 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
             const contextWindow = contextUsage?.contextWindow ?? model?.contextWindow ?? 0;
             const contextPercentValue = contextUsage?.percent ?? 0;
             const contextPercent = contextUsage?.percent !== null ? contextPercentValue.toFixed(1) : "?";
-            // Line 1: cwd • branch • git-status • PR • sessionName (unchanged)
             const pwd = composeTlhFooterFirstLine({
                 cwd: formatHomePath(ctx.sessionManager.getCwd()),
                 sessionName: ctx.sessionManager.getSessionName(),
@@ -50,10 +49,6 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
                 fallbackBranch: footerData?.getGitBranch?.(),
             });
             const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
-            // Line 2 (single flowing left-justified line):
-            //   agent: <primaryName> • <model|no-model> [• thinking] • context% [• DUMB ZONE]
-            // Each segment is explicitly themed to avoid ANSI foreground-reset bleed from nested
-            // theme.fg() calls. Non-default agent names are highlighted with the accent color.
             const modelOrNoModel = model?.id ?? "no-model";
             const modelPart = modelOrNoModel;
             const primaryName = getPrimaryName();
@@ -82,8 +77,6 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
                 agentLine2Str += dimSep + theme.fg("error", DUMB_ZONE_LABEL);
             }
             const agentLine2 = truncateToWidth(agentLine2Str, width, theme.fg("dim", "..."));
-            // Line 3 (optional): [<cost> · ]<subscription usage segment>
-            // Omitted entirely when both parts are absent.
             const subscriptionUsageState = getTlhSubscriptionUsageFooterState(ctx, model, usageOptions);
             const costStr = totals.cost > 0 && !subscriptionUsageState.suppressCost ? formatCost(totals.cost) : undefined;
             const line3Parts = [];
@@ -107,7 +100,6 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
             if (line3 !== undefined) {
                 lines.push(truncateToWidth(theme.fg("dim", line3), width, theme.fg("dim", "...")));
             }
-            // Hint line (conditional on pending editor text during an active turn)
             const editorText = ctx.ui.getEditorText();
             if (editorText.length > 0 && !ctx.isIdle()) {
                 const steerKey = keyText("tui.input.submit") || "enter";
@@ -116,7 +108,6 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
                 const queueHint = `${theme.fg("dim", queueKey)}${theme.fg("muted", " queue follow-up")}`;
                 lines.push(truncateToWidth(`${steeringHint}${theme.fg("muted", " · ")}${queueHint}`, width, theme.fg("dim", "...")));
             }
-            // Extension status line (conditional on registered extension statuses)
             if (extensionStatuses && extensionStatuses.size > 0) {
                 const visibleStatuses = Array.from(extensionStatuses.entries())
                     .filter(([key]) => key !== TK_WORKFLOW_STATUS_KEY)

--- a/extensions/the-last-harness/header.js
+++ b/extensions/the-last-harness/header.js
@@ -18,7 +18,6 @@ export function createTlhHeader(theme, resources, headerUpdate, installNotice, o
             return [];
         }
         const heading = truncateToWidth(color.heading(`[${name}]`), width, color.dim("..."));
-        // Wrap items across multiple lines, splitting on ", " boundaries (never mid-item).
         const prefix = "  ";
         const wrappedLines = [];
         let currentLine = prefix;
@@ -29,9 +28,6 @@ export function createTlhHeader(theme, resources, headerUpdate, installNotice, o
                 currentLine = candidate;
             }
             else {
-                // Non-final line: append ", " separator if it fits, otherwise push bare.
-                // The isFirstOnLine force-accept can leave currentLine near or at `width`,
-                // so appending ", " would overflow the terminal width.
                 if (visibleWidth(currentLine + ", ") > width) {
                     wrappedLines.push(color.dim(currentLine));
                 }
@@ -41,7 +37,6 @@ export function createTlhHeader(theme, resources, headerUpdate, installNotice, o
                 currentLine = prefix + item;
             }
         }
-        // Final line: no trailing ", ".
         wrappedLines.push(color.dim(currentLine));
         return [heading, ...wrappedLines];
     };

--- a/extensions/the-last-harness/launch-telemetry.js
+++ b/extensions/the-last-harness/launch-telemetry.js
@@ -243,7 +243,6 @@ export async function sendTlhLaunchTelemetry(snapshot) {
         });
     }
     catch {
-        // Launch telemetry is best-effort; never block or notify during startup.
     }
 }
 export function scheduleTlhLaunchTelemetry(ctx) {

--- a/extensions/the-last-harness/model-visibility.js
+++ b/extensions/the-last-harness/model-visibility.js
@@ -1,5 +1,3 @@
-// Pi compatibility shim for TLH model visibility/filtering behavior.
-// See ../../docs/upstream-sync-inventory.md for sync/review guidance.
 import { InteractiveMode, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { isRecord, readText, uniqueSorted } from "./common.js";
 import { safeTlhProfileFilePath } from "./profile-state.js";

--- a/extensions/the-last-harness/new-version-notice.js
+++ b/extensions/the-last-harness/new-version-notice.js
@@ -1,20 +1,5 @@
-/**
- * Suppresses the upstream Pi "Update Available — Run `pi update`" banner at launch.
- * See ../../docs/upstream-sync-inventory.md for sync/review guidance.
- *
- * WHY: TLH pins Pi to a supported version window, so the upstream update prompt is
- * misleading noise — the correct update path is `tlh update`, not `pi update`.
- *
- * HOW TO UNDO: remove the `installTlhNewVersionNotificationOverride()` call from
- * `extensions/the-last-harness.ts`.
- *
- * PI_SKIP_VERSION_CHECK semantics are intentionally unchanged: it remains a TLH
- * update-check opt-out; the upstream Pi version fetch still runs harmlessly.
- */
 import { InteractiveMode } from "@earendil-works/pi-coding-agent";
 const TLH_NEW_VERSION_NOTICE_PATCHED = Symbol.for("tlh.newVersionNoticePatched");
-// Intentional no-op: TLH pins Pi to a supported version window, so the upstream
-// "Update Available — Run `pi update`" banner shown at launch is misleading noise.
 function noOpShowNewVersionNotification() { }
 export function installTlhNewVersionNotificationOverride() {
     const interactiveModePrototype = InteractiveMode.prototype;
@@ -22,8 +7,6 @@ export function installTlhNewVersionNotificationOverride() {
         return;
     }
     if (typeof interactiveModePrototype.showNewVersionNotification !== "function") {
-        // Fail-open: if the upstream method is absent or not a function (e.g. API changed),
-        // skip the patch with a non-fatal warning instead of throwing.
         console.warn("[TLH] installTlhNewVersionNotificationOverride: InteractiveMode.prototype.showNewVersionNotification is not a function; skipping patch.");
         return;
     }

--- a/extensions/the-last-harness/package-update-notice.js
+++ b/extensions/the-last-harness/package-update-notice.js
@@ -1,5 +1,3 @@
-// Pi compatibility shim for TLH-specific package-update copy.
-// See ../../docs/upstream-sync-inventory.md for sync/review guidance.
 import { DynamicBorder, InteractiveMode } from "@earendil-works/pi-coding-agent";
 import { Spacer, Text } from "@earendil-works/pi-tui";
 const TLH_PACKAGE_UPDATE_NOTICE_PATCHED = Symbol.for("tlh.packageUpdateNoticePatched");

--- a/extensions/the-last-harness/primary-agent-runtime.js
+++ b/extensions/the-last-harness/primary-agent-runtime.js
@@ -97,7 +97,6 @@ function writeTlhPrimaryAgentModelOverride(cwd, primary, modelKey) {
             }
             modelOverrides[primary] = modelKey;
         }
-        // Clean up empty modelOverrides object
         if (Object.keys(modelOverrides).length === 0) {
             delete primaryAgent.modelOverrides;
         }
@@ -238,8 +237,6 @@ function registerChildSubagentRuntime(pi, buildChildPrompt, env) {
         if (event.toolName !== "bash") {
             return undefined;
         }
-        // `toolName` narrows the branch, but not the shared mutable `input` payload.
-        // Keep a runtime guard so direct/custom tool-call objects cannot pass a non-string command.
         if (typeof event.input.command !== "string") {
             return undefined;
         }
@@ -413,7 +410,6 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
         const availableModels = getUnfilteredAvailableModels(ctx.modelRegistry);
         const primaryDefaults = selectProviderAwareAgentDefaults(primary, availableModels, ctx.model?.provider);
         const currentProviderDefaults = selectProviderAwareAgentDefaults(primary, [], ctx.model?.provider);
-        // Resolve model: stored override (if still available in registry) takes precedence over frontmatter default
         let resolvedModel = primaryDefaults.model;
         if (!forceApply) {
             const storedOverride = primaryConfig?.modelOverrides?.[selection];
@@ -422,7 +418,6 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
                 if (overrideRef) {
                     resolvedModel = overrideRef;
                 }
-                // If override is unavailable, fall through to primaryDefaults.model (no error)
             }
         }
         const activePrimaryModel = shouldApplyModel ? await applyPrimaryModel(ctx, primary, resolvedModel) : undefined;
@@ -578,11 +573,9 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
     }
     function registerLifecycleHooks() {
         pi.on("model_select", async (event, ctx) => {
-            // Ignore events emitted by TLH's own applyPrimaryModel to avoid a feedback loop.
             if (tlhApplyingModel) {
                 return;
             }
-            // Only handle user-initiated model selections (source "set" is emitted by /model and pi.setModel alike).
             if (event.source !== "set") {
                 return;
             }
@@ -595,21 +588,17 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
             if (!primary) {
                 return;
             }
-            // Locked primaries (e.g. rush) keep their fixed provider defaults and do not persist user model overrides.
             if (shouldForceApplyForLock(primary)) {
                 return;
             }
             const chosenKey = `${event.model.provider}/${event.model.id}`;
-            // Determine the primary's bundled default model to know whether to clear the override.
             const primaryDefaults = selectProviderAwareAgentDefaults(primary, getUnfilteredAvailableModels(ctx.modelRegistry), event.model.provider);
             const bundledKey = primaryDefaults.model ? `${primaryDefaults.model.provider}/${primaryDefaults.model.id}` : undefined;
-            // If user picked the bundled default, clear the override; otherwise record it.
             const nextOverride = chosenKey === bundledKey ? undefined : chosenKey;
             try {
                 writeTlhPrimaryAgentModelOverride(ctx.cwd, selection, nextOverride);
             }
             catch {
-                // Best-effort: model override persistence is non-blocking.
             }
         });
         pi.on("session_tree", async (_event, ctx) => {
@@ -640,8 +629,6 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
         });
         pi.on("tool_call", async (event, ctx) => {
             if (event.toolName === "bash") {
-                // `toolName` narrows this branch, but not the shared mutable `input` payload.
-                // Keep a runtime guard so direct/custom tool-call objects cannot pass a non-string command.
                 if (typeof event.input.command !== "string") {
                     return undefined;
                 }

--- a/extensions/the-last-harness/profile-state.js
+++ b/extensions/the-last-harness/profile-state.js
@@ -1,5 +1,3 @@
-// TLH-private settings/state write guards layered on top of Pi settings storage.
-// See ../../docs/upstream-sync-inventory.md for sync/review guidance.
 import { closeSync, constants, lstatSync, mkdirSync, openSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
@@ -49,9 +47,6 @@ export function tlhStatePath(fileName) {
     return safeTlhProfileFilePath(join("tlh", fileName));
 }
 export function tlhStartupStatePath() {
-    // Only persist state when the wrapper has selected an isolated profile and
-    // the TLH support path resolves inside that profile. This avoids mutating
-    // normal Pi config through a symlinked `${AGENT_DIR}/tlh` directory.
     return tlhStatePath("startup-state.json");
 }
 export function tlhTelemetryStatePath() {
@@ -124,9 +119,6 @@ function canReplaceTlhStartupStateFile(statePath) {
 }
 function writeTlhStartupStateAtomically(statePath, content) {
     const nofollowFlag = constants.O_NOFOLLOW;
-    // Startup state is best-effort. If this platform cannot protect the temp
-    // file's final component from symlinks, fail closed instead of weakening the
-    // atomic replacement by silently dropping O_NOFOLLOW.
     if (typeof nofollowFlag !== "number" || nofollowFlag === 0) {
         return;
     }
@@ -168,7 +160,6 @@ export function writeTlhStartupState(state) {
         writeTlhStartupStateAtomically(statePath, `${JSON.stringify(state, null, 2)}\n`);
     }
     catch {
-        // Startup state is best-effort; never block launch.
     }
 }
 export function updateTlhStartupState(updates) {

--- a/extensions/the-last-harness/resources.js
+++ b/extensions/the-last-harness/resources.js
@@ -1,5 +1,3 @@
-// Mirrors Pi project-trust/resource visibility for TLH startup summaries.
-// See ../../docs/upstream-sync-inventory.md for sync/review guidance.
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { DefaultPackageManager, SettingsManager, getAgentDir, loadProjectContextFiles, } from "@earendil-works/pi-coding-agent";
@@ -41,7 +39,6 @@ function labelTheme(resource) {
         }
     }
     catch {
-        // fall through to filename
     }
     return basename(resource.path, extname(resource.path));
 }

--- a/extensions/the-last-harness/review.js
+++ b/extensions/the-last-harness/review.js
@@ -3,17 +3,12 @@ import { join, relative, resolve } from "node:path";
 import { DynamicBorder, getAgentDir, getSelectListTheme, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { Container, matchesKey, SelectList, Text } from "@earendil-works/pi-tui";
 import { primaryAgentSelectionFromBranch, resolvePrimaryAgentConfig } from "../the-last-harness-primary-agent.mjs";
-// --- Constants ---
 const REVIEW_TITLE = "Choose a review mode";
 const REVIEW_PICKER_HINT = "↑/↓ to move  Enter to confirm  Esc to cancel";
 const REVIEW_DEFAULT_BRANCH_BASE = "main";
 const REVIEW_PICKER_ONLY_GUIDANCE = "/review is picker-only. Run /review with no arguments, then choose a mode in the picker. Typed shortcuts like `/review pr 123` and `--extra` are no longer supported.";
 const REVIEW_TUI_REQUIRED_MESSAGE = "/review requires the interactive TUI picker. Re-run /review in the TLH UI.";
 const REVIEW_REQUIRED_PRIMARY = "architect";
-// Intentionally not imported from "./common.js" (see issue #296): review.ts is loaded
-// in tests via a native Node strip-types `import`, which — unlike the jiti.import()
-// loader used by other extension tests — does not remap "./common.js" to "./common.ts",
-// so that import would fail with ERR_MODULE_NOT_FOUND.
 function isRecord(value) {
     return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -45,12 +40,6 @@ const REVIEW_MODE_DESCRIPTIONS = {
 };
 const REVIEW_UNTRACKED_BEGIN_DELIMITER = "--- begin untracked files ---";
 const REVIEW_UNTRACKED_END_DELIMITER = "--- end untracked files ---";
-// --- Pure helpers ---
-/**
- * Pure branch-mismatch decision function for PR mode.
- * Maps the current state + user confirmation to an action.
- * Has no knowledge of git, gh, or any I/O.
- */
 export function decideBranchAction(params) {
     const { currentBranch, prHead, isDirty, userConfirm } = params;
     if (currentBranch === prHead)
@@ -59,11 +48,6 @@ export function decideBranchAction(params) {
         return "abort-dirty";
     return userConfirm ? "switch" : "abort-cancelled";
 }
-/**
- * Tokenise a raw args string from the command handler, respecting single- and
- * double-quoted groups so that quoted picker follow-up input stays grouped.
- * Unquoted whitespace, including newlines from editor prompts, splits tokens.
- */
 function tokenizeArgs(raw) {
     if (!raw.trim())
         return [];
@@ -93,11 +77,6 @@ function tokenizeArgs(raw) {
     }
     return tokens;
 }
-/**
- * /review is picker-only. Bare /review requests the picker; any typed
- * arguments are rejected with explicit guidance so users do not think the
- * command silently ignored meaningful input.
- */
 export function parseReviewArgs(argv) {
     if (argv.length === 0) {
         return { pickerRequested: true };
@@ -107,24 +86,11 @@ export function parseReviewArgs(argv) {
         message: REVIEW_PICKER_ONLY_GUIDANCE,
     };
 }
-/**
- * Build the canonical [/review] envelope string to send as a user message.
- *
- * The first line is always exactly `[/review]` so the architect can detect it.
- * Structured metadata follows, then the `extra` block, then a fenced section
- * holding the diff or snapshot body.
- *
- * T2 populates `ctx.body` / `ctx.bodyKind` for local modes; T3 does the same
- * for PR mode and also fills `ctx.checkout` when it switches branches.
- */
 export function buildReviewEnvelope(parsed, ctx) {
     const { mode, extra } = parsed;
     const lines = [];
-    // ── Line 1: hard-coded trigger token ──────────────────────────────────────
     lines.push("[/review]");
-    // ── Metadata ──────────────────────────────────────────────────────────────
     lines.push(`mode: ${mode}`);
-    // Mode-specific refs
     if (parsed.mode === "branch" && parsed.base) {
         lines.push(`base: ${parsed.base}`);
     }
@@ -137,16 +103,13 @@ export function buildReviewEnvelope(parsed, ctx) {
     else if (parsed.mode === "folder" && parsed.paths.length > 0) {
         lines.push(`paths: ${parsed.paths.join(" ")}`);
     }
-    // Branch context
     if (ctx?.currentBranch !== undefined) {
         lines.push(`current-branch: ${ctx.currentBranch}`);
     }
-    // Checkout notice (set by T3 when it had to switch branches)
     if (ctx?.checkout?.performed) {
         lines.push(`checkout: switched-from ${ctx.checkout.priorBranch}`);
         lines.push(`note: previously on ${ctx.checkout.priorBranch}; run \`git checkout -\` to return.`);
     }
-    // ── Extra block ───────────────────────────────────────────────────────────
     if (extra === undefined) {
         lines.push("extra: (none)");
     }
@@ -154,7 +117,6 @@ export function buildReviewEnvelope(parsed, ctx) {
         lines.push("extra:");
         lines.push(extra);
     }
-    // ── Body fenced section ───────────────────────────────────────────────────
     const hasBody = ctx?.body !== undefined;
     const fenceKind = hasBody ? (ctx?.bodyKind ?? "diff") : "(pending)";
     const bodyText = hasBody ? escapeEnvelopeFenceLines(ctx?.body, fenceKind) : "(no body gathered)";
@@ -163,8 +125,6 @@ export function buildReviewEnvelope(parsed, ctx) {
     lines.push(`--- end ${fenceKind} ---`);
     return lines.join("\n");
 }
-// --- Helpers for picker integration ---
-/** Construct full dispatch args for a mode chosen interactively with defaults applied. */
 function makePickedArgs(mode) {
     return { mode, extra: undefined };
 }
@@ -204,7 +164,6 @@ async function completePickedArgs(ctx, mode) {
     const paths = tokenizeArgs(rawPaths);
     return paths.length > 0 ? { mode: "folder", paths, extra: undefined } : undefined;
 }
-// --- Interactive picker ---
 async function showReviewPicker(ctx) {
     if (!ctx.hasUI) {
         return undefined;
@@ -255,12 +214,6 @@ async function resolveRepoRoot(pi, cwd, context) {
     }
     return { ok: true, root: repoRootResult.stdout.trim() };
 }
-/**
- * Reject values that look like git/gh flags (start with '-').
- * pi.exec is argv-based (no shell injection), but a leading dash could still
- * cause the value to be interpreted as a git or gh option rather than a ref,
- * SHA, or PR identifier.
- */
 function rejectFlagLike(value, fieldName) {
     if (value.startsWith("-")) {
         return { ok: false, message: `${fieldName} cannot start with '-' (got '${value}'). If this is intentional, run the underlying command manually.` };
@@ -416,13 +369,8 @@ async function fetchPrDiffViaRest(pi, cwd, prRef) {
     }
     return { ok: true, diff: result.stdout };
 }
-/**
- * Gather staged + unstaged changes vs HEAD for the uncommitted mode.
- * Also appends untracked, non-gitignored file contents so brand-new files are reviewable.
- */
 async function gatherUncommitted(pi, cmdCtx) {
     const cwd = cmdCtx.cwd;
-    // Resolve current branch (also validates we are inside a git repo)
     const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
     if (branchResult.code !== 0) {
         const message = detectNotGitRepo(branchResult.stderr)
@@ -431,7 +379,6 @@ async function gatherUncommitted(pi, cmdCtx) {
         return { ok: false, message };
     }
     const currentBranch = branchResult.stdout.trim();
-    // Gather full diff (staged + unstaged vs HEAD)
     const diffResult = await pi.exec("git", ["diff", "HEAD"], { cwd });
     if (diffResult.code !== 0) {
         const message = detectNotGitRepo(diffResult.stderr)
@@ -443,7 +390,6 @@ async function gatherUncommitted(pi, cmdCtx) {
     if (repoRootResult.ok === false) {
         return { ok: false, message: repoRootResult.message };
     }
-    // Include untracked, non-gitignored files so the reviewer can see newly added content.
     const untrackedResult = await pi.exec("git", ["ls-files", "-z", "--others", "--exclude-standard", "--", "."], { cwd: repoRootResult.root });
     if (untrackedResult.code !== 0) {
         const message = detectNotGitRepo(untrackedResult.stderr)
@@ -460,18 +406,13 @@ async function gatherUncommitted(pi, cmdCtx) {
         ctx: { currentBranch, body, bodyKind: "diff" },
     };
 }
-/**
- * Gather git diff <base>...HEAD (three-dot, vs merge-base) for the branch mode.
- */
 async function gatherBranch(pi, cmdCtx, base) {
     const effectiveBase = base?.trim() || REVIEW_DEFAULT_BRANCH_BASE;
-    // Reject flag-like values before passing anything to git.
     const baseCheck = rejectFlagLike(effectiveBase, "base");
     if (baseCheck.ok === false) {
         return { ok: false, message: baseCheck.message };
     }
     const cwd = cmdCtx.cwd;
-    // Refuse if HEAD is detached
     const symRefResult = await pi.exec("git", ["symbolic-ref", "-q", "HEAD"], { cwd });
     if (symRefResult.code !== 0) {
         if (detectNotGitRepo(symRefResult.stderr)) {
@@ -485,10 +426,8 @@ async function gatherBranch(pi, cmdCtx, base) {
             message: "HEAD is detached. Check out a branch before running /review.",
         };
     }
-    // Resolve current branch
     const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
     const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
-    // Validate that the base ref resolves
     const verifyResult = await pi.exec("git", ["rev-parse", "--verify", effectiveBase], { cwd });
     if (verifyResult.code !== 0) {
         return {
@@ -496,7 +435,6 @@ async function gatherBranch(pi, cmdCtx, base) {
             message: `Branch base '${effectiveBase}' does not resolve to a valid ref. Make sure the branch or commit exists locally.`,
         };
     }
-    // Compute three-dot diff vs merge-base
     const diffResult = await pi.exec("git", ["diff", `${effectiveBase}...HEAD`], { cwd });
     if (diffResult.code !== 0) {
         return {
@@ -509,9 +447,6 @@ async function gatherBranch(pi, cmdCtx, base) {
         ctx: { currentBranch, body: diffResult.stdout, bodyKind: "diff" },
     };
 }
-/**
- * Gather git show --format=fuller <sha> (commit header + diff) for the commit mode.
- */
 async function gatherCommit(pi, cmdCtx, sha) {
     if (!sha) {
         return {
@@ -520,12 +455,10 @@ async function gatherCommit(pi, cmdCtx, sha) {
         };
     }
     const cwd = cmdCtx.cwd;
-    // Reject flag-like values before passing to git
     const shaCheck = rejectFlagLike(sha, "sha");
     if (shaCheck.ok === false) {
         return { ok: false, message: shaCheck.message };
     }
-    // Validate that the ref resolves to an actual commit object
     const verifyResult = await pi.exec("git", ["rev-parse", "--verify", `${sha}^{commit}`], { cwd });
     if (verifyResult.code !== 0) {
         if (detectNotGitRepo(verifyResult.stderr)) {
@@ -539,7 +472,6 @@ async function gatherCommit(pi, cmdCtx, sha) {
             message: `Commit '${sha}' does not resolve to a valid commit. Check that the SHA is correct and reachable.`,
         };
     }
-    // Gather the full commit diff including the message header
     const showResult = await pi.exec("git", ["show", "--format=fuller", sha], { cwd });
     if (showResult.code !== 0) {
         return {
@@ -547,7 +479,6 @@ async function gatherCommit(pi, cmdCtx, sha) {
             message: `git show failed for '${sha}': ${showResult.stderr.trim()}`,
         };
     }
-    // Resolve current branch (best-effort; irrelevant if we are reviewing an old commit)
     const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
     const currentBranch = branchResult.code === 0 ? branchResult.stdout.trim() : undefined;
     return {
@@ -555,10 +486,6 @@ async function gatherCommit(pi, cmdCtx, sha) {
         ctx: { currentBranch, body: showResult.stdout, bodyKind: "diff" },
     };
 }
-/**
- * Return true when a file is likely binary.
- * Heuristic: read the first 8 KB and check for a NUL (0x00) byte.
- */
 async function isBinaryFile(filePath) {
     let handle;
     try {
@@ -571,21 +498,12 @@ async function isBinaryFile(filePath) {
         await handle?.close();
     }
 }
-/**
- * Recursively collect all non-directory entries under a directory.
- *
- * Subdirectories named `node_modules` or starting with `.` are skipped
- * to avoid generating useless snapshots from tooling/VCS directories.
- * This filter applies only to entries discovered during recursion — the
- * user-specified top-level path is always walked regardless of its name.
- */
 async function walkDir(dir) {
     const entries = await readdir(dir, { withFileTypes: true });
     const files = [];
     for (const entry of entries) {
         const full = join(dir, entry.name);
         if (entry.isDirectory()) {
-            // Skip well-known noisy directories during recursion.
             if (entry.name === "node_modules" || entry.name.startsWith(".")) {
                 continue;
             }
@@ -645,10 +563,6 @@ function getNonRegularSnapshotMarker(relPath, pathStat) {
     }
     return undefined;
 }
-/**
- * Build snapshot entries for a set of file paths.
- * Binary files are skipped with an annotation instead of inline content.
- */
 async function buildSnapshotParts(cwd, filePaths, label) {
     const parts = [];
     for (const filePath of filePaths) {
@@ -696,10 +610,6 @@ function appendUntrackedSnapshot(diffBody, untrackedParts) {
     const untrackedBody = [REVIEW_UNTRACKED_BEGIN_DELIMITER, ...untrackedParts, REVIEW_UNTRACKED_END_DELIMITER].join("\n");
     return diffBody.trim().length > 0 ? `${diffBody}\n\n${untrackedBody}` : untrackedBody;
 }
-/**
- * Build a snapshot payload from the given paths for the folder mode.
- * Directories are walked; binary files are skipped with an annotation.
- */
 async function gatherFolder(pi, cmdCtx, paths) {
     if (paths.length === 0) {
         return {
@@ -709,7 +619,6 @@ async function gatherFolder(pi, cmdCtx, paths) {
     }
     const cwd = cmdCtx.cwd;
     const absPaths = paths.map((p) => resolve(cwd, p));
-    // Validate all paths exist before doing any work
     for (let i = 0; i < absPaths.length; i++) {
         try {
             await lstat(absPaths[i]);
@@ -721,7 +630,6 @@ async function gatherFolder(pi, cmdCtx, paths) {
             };
         }
     }
-    // Resolve current branch (best-effort; folder mode may be used outside a git repo)
     let currentBranch;
     const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
     if (branchResult.code === 0) {
@@ -733,17 +641,12 @@ async function gatherFolder(pi, cmdCtx, paths) {
         const pathStat = await lstat(absPath);
         let filePaths;
         if (pathStat.isDirectory()) {
-            // Prefer git ls-files to respect .gitignore naturally;
-            // --others --exclude-standard includes untracked-but-not-gitignored files.
-            // If git reports zero files for this directory, keep that empty result instead of
-            // walking the tree and accidentally snapshotting ignored files.
             const lsResult = await pi.exec("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", "."], { cwd: absPath });
             if (lsResult.code === 0) {
                 filePaths = parseNullDelimitedGitPaths(lsResult.stdout)
                     .map((filePath) => join(absPath, filePath));
             }
             else if (detectNotGitRepo(lsResult.stderr)) {
-                // Fall back to a plain recursive walk only when outside git entirely.
                 filePaths = await walkDir(absPath);
             }
             else {
@@ -767,10 +670,6 @@ async function gatherFolder(pi, cmdCtx, paths) {
         },
     };
 }
-/**
- * Show a confirm prompt asking the user whether to switch to the PR head branch.
- * Returns true if confirmed, false if cancelled.
- */
 async function showBranchSwitchConfirm(cmdCtx, currentBranch, headRefName, baseRefName) {
     const confirmed = await cmdCtx.ui.custom((_tui, theme, _kb, done) => {
         const container = new Container();
@@ -799,33 +698,18 @@ async function showBranchSwitchConfirm(cmdCtx, currentBranch, headRefName, baseR
     });
     return confirmed;
 }
-/**
- * Gather PR diff for the pr mode.
- *
- * Steps:
- * 1. Validate nOrUrl argument.
- * 2. Reject flag-like nOrUrl.
- * 3. Check gh CLI availability.
- * 4. Resolve PR metadata with `gh pr view`.
- * 5. Resolve current branch.
- * 6. Branch-mismatch decision tree.
- * 7. Gather diff with `gh pr diff`.
- */
 async function gatherPr(pi, cmdCtx, nOrUrl) {
     const cwd = cmdCtx.cwd;
-    // 1. Argument validation
     if (!nOrUrl || !nOrUrl.trim()) {
         return {
             ok: false,
             message: "PR review requires a PR number or URL. Re-run /review and choose PR.",
         };
     }
-    // 2. Reject flag-like nOrUrl
     const nOrUrlCheck = rejectFlagLike(nOrUrl, "pr");
     if (nOrUrlCheck.ok === false) {
         return { ok: false, message: nOrUrlCheck.message };
     }
-    // 3. gh CLI availability check
     const ghCheckResult = await pi.exec("gh", ["--version"], { cwd });
     if (ghCheckResult.code !== 0) {
         return {
@@ -833,7 +717,6 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
             message: "PR mode requires the GitHub CLI. Install: https://cli.github.com — then run `gh auth login`.",
         };
     }
-    // 4. PR metadata resolution
     const prViewResult = await pi.exec("gh", ["pr", "view", nOrUrl, "--json", "number,headRefName,baseRefName,isCrossRepository,headRepository"], { cwd });
     let prRef;
     let prData;
@@ -881,7 +764,6 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
         };
     }
     const { number: prNumber, headRefName, baseRefName } = prData;
-    // 5. Current branch resolution
     const branchResult = await pi.exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
     if (branchResult.code !== 0) {
         return {
@@ -890,11 +772,9 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
         };
     }
     const currentBranch = branchResult.stdout.trim();
-    // 6. Branch-mismatch decision tree
     let effectiveBranch = currentBranch;
     let checkoutCtx;
     if (currentBranch !== headRefName) {
-        // Check whether the working tree is dirty
         const statusResult = await pi.exec("git", ["status", "--porcelain"], { cwd });
         if (statusResult.code !== 0) {
             const firstLine = statusResult.stderr.split("\n")[0]?.trim() ?? "git status failed";
@@ -904,7 +784,6 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
             };
         }
         const isDirty = statusResult.stdout.trim().length > 0;
-        // Working tree is clean — confirm before switching
         let userConfirm = false;
         if (!isDirty) {
             if (!cmdCtx.hasUI) {
@@ -925,7 +804,6 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
         if (action === "abort-cancelled") {
             return { ok: false, message: "Review cancelled — branch was not switched." };
         }
-        // action === "switch" — perform the checkout
         const checkoutResult = await pi.exec("gh", ["pr", "checkout", String(prNumber)], { cwd });
         if (checkoutResult.code !== 0) {
             const firstLine = checkoutResult.stderr.split("\n")[0]?.trim() ?? "";
@@ -937,7 +815,6 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
         effectiveBranch = headRefName;
         checkoutCtx = { performed: true, priorBranch: currentBranch };
     }
-    // 7. Diff gathering
     const diffResult = await pi.exec("gh", ["pr", "diff", String(prNumber)], { cwd });
     let diffBody;
     if (diffResult.code !== 0) {
@@ -980,9 +857,7 @@ async function gatherPr(pi, cmdCtx, nOrUrl) {
     }
     return { ok: true, ctx };
 }
-// --- Mode handler ---
 async function dispatchReviewMode(pi, cmdCtx, parsed) {
-    // --- Gather phase (all modes) ---
     let result;
     if (parsed.mode === "pr") {
         result = await gatherPr(pi, cmdCtx, parsed.nOrUrl);
@@ -1003,20 +878,16 @@ async function dispatchReviewMode(pi, cmdCtx, parsed) {
                 break;
         }
     }
-    // --- Uniform error handling ---
     if (result.ok === false) {
         cmdCtx.ui.notify(result.message, "error");
         return;
     }
-    // --- PR-specific post-gather notification ---
     if (parsed.mode === "pr" && result.ctx.checkout?.performed) {
         cmdCtx.ui.notify(`Switched from '${result.ctx.checkout.priorBranch}' to '${result.ctx.currentBranch}'. Use \`git checkout -\` to return.`, "info");
     }
-    // --- Send envelope ---
     const envelope = buildReviewEnvelope(parsed, result.ctx);
     pi.sendUserMessage(envelope);
 }
-// --- Argument completions ---
 export const REVIEW_COMMAND_DESCRIPTION = "Review code changes via an interactive mode picker";
 export function getReviewArgumentCompletions() {
     return null;
@@ -1040,18 +911,15 @@ export function createReviewCommandHandler(pi) {
         }
         const mode = await showReviewPicker(ctx);
         if (mode === undefined) {
-            // User cancelled — clean no-op.
             return;
         }
         const completedArgs = await completePickedArgs(ctx, mode);
         if (completedArgs === undefined) {
-            // User cancelled or left required follow-up input blank.
             return;
         }
         await dispatchReviewMode(pi, ctx, completedArgs);
     };
 }
-// --- Command registration ---
 export function registerReviewCommand(pi) {
     pi.registerCommand("review", {
         description: REVIEW_COMMAND_DESCRIPTION,

--- a/extensions/the-last-harness/shell-parser.js
+++ b/extensions/the-last-harness/shell-parser.js
@@ -1,6 +1,3 @@
-// Pure shell-parsing helpers, constants, and types.
-// This module has no dependency on git-attribution concepts; the seam is
-// one-directional: attribution.ts imports from here, never the reverse.
 export const ENV_SHORT_OPTIONS_WITH_VALUES = new Set(["-C", "-P", "-a", "-u"]);
 export const ENV_LONG_OPTIONS_WITH_VALUES = new Set(["--argv0", "--chdir", "--unset"]);
 export const ENV_SHORT_OPTIONS_WITHOUT_VALUES = new Set(["-0", "-i", "-v"]);

--- a/extensions/the-last-harness/subscription-usage.js
+++ b/extensions/the-last-harness/subscription-usage.js
@@ -53,9 +53,6 @@ function pickString(source, keys) {
     }
     return undefined;
 }
-// Stable, one-way fingerprint of a bearer access token. Used in cache keys
-// only when no account id is available; raw bearer material is never stored in
-// usage service state or returned in snapshots.
 function accessTokenFingerprint(accessToken) {
     if (typeof accessToken !== "string" || !accessToken) {
         return undefined;

--- a/extensions/the-last-harness/tokens-analyzer.js
+++ b/extensions/the-last-harness/tokens-analyzer.js
@@ -1,10 +1,5 @@
-// Cache-miss detection ported from pi-coding-agent@0.80.6 core/cache-stats.
-// See ../../docs/upstream-sync-inventory.md for sync/review guidance.
 const NOISE_FLOOR_TOKENS = 1024;
-// The upstream provider prompt-cache TTL is ~5 minutes; large idle gaps between turns tend
-// to cause cache misses because entries expire. Detection reports idleMs but does not gate on the TTL.
 const BUILT_IN_TOOL_NAMES = new Set(["bash", "read", "edit", "write", "grep", "find", "ls"]);
-/** Approximate characters per token used for tool-payload size estimates. */
 const CHARS_PER_TOKEN = 4;
 const SKIP_DISCOVERY_KEYS = new Set([
     "content",
@@ -65,13 +60,11 @@ export function analyzeSessionEntries(entries, { sessionId, sessionName, started
     let mcpProxyCalls = 0;
     let mcpDirectCalls = 0;
     let cacheMissPrev;
-    /** 0-based index incremented for every primary assistant message processed. */
     let assistantTurnIndex = 0;
     const cacheMissEvents = [];
     let totalMissedTokens = 0;
     let totalMissedCost = 0;
     for (const entry of entries) {
-        // Cache-miss detection: compaction and branch_summary legitimately change context — clear prev.
         if (entry.type === "compaction" || entry.type === "branch_summary") {
             cacheMissPrev = undefined;
         }
@@ -110,10 +103,6 @@ export function analyzeSessionEntries(entries, { sessionId, sessionName, started
                 primaryTotals.turns += 1;
                 primaryTotals.assistantMessages += 1;
             }
-            // Cache-miss detection (primary session only; subagent runs are excluded).
-            // Ported from pi-coding-agent@0.80.6 core/cache-stats.
-            // Raw per-message cost breakdown is read directly here; normalizeUsage collapses
-            // cost to a single total and is NOT sufficient for the per-component rate math.
             const rawMsgUsage = isRecord(message.usage) ? message.usage : undefined;
             const cmInput = numberFromUnknown(rawMsgUsage?.input ?? rawMsgUsage?.inputTokens) ?? 0;
             const cmCacheRead = numberFromUnknown(rawMsgUsage?.cacheRead ?? rawMsgUsage?.cacheReadTokens ?? rawMsgUsage?.cache_read_input_tokens ?? rawMsgUsage?.cacheReadInputTokens) ?? 0;
@@ -128,7 +117,6 @@ export function analyzeSessionEntries(entries, { sessionId, sessionName, started
             const cmModelKey = `${cmProvider}/${cmModel}`;
             const cmTimestampMs = Date.parse(entry.timestamp);
             const cmTimestamp = Number.isFinite(cmTimestampMs) ? cmTimestampMs : 0;
-            // Evaluate miss: skip when no prev, zero promptTokens, or no cache activity ever seen.
             if (cacheMissPrev !== undefined &&
                 cmPromptTokens > 0 &&
                 !(cmCacheRead + cmCacheWrite === 0 && !cacheMissPrev.reportedCache)) {
@@ -147,13 +135,11 @@ export function analyzeSessionEntries(entries, { sessionId, sessionName, started
                     totalMissedCost += missedCost;
                 }
             }
-            // Update prev for next iteration (only when promptTokens > 0).
             if (cmPromptTokens > 0) {
                 cacheMissPrev = {
                     promptTokens: cmPromptTokens,
                     timestamp: cmTimestamp,
                     modelKey: cmModelKey,
-                    // Carry forward: once any message reported cache activity, the flag stays true.
                     reportedCache: (cacheMissPrev?.reportedCache ?? false) || cmCacheRead + cmCacheWrite > 0,
                 };
             }
@@ -487,14 +473,6 @@ function costFromUnknown(value) {
 function numberFromUnknown(value) {
     return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
-// Intentionally includes arrays (unlike common.ts isPlainObject which excludes them).
-// artifactPaths can arrive as an array in the wild; the two call sites that handle it
-// (in collectArtifactReferences and the standalone artifact-entry sanitizer) iterate
-// Object.values(artifactPaths), which works correctly for both plain objects and arrays.
-// Replacing this with the shared common.ts isRecord/isPlainObject would silently skip
-// array-valued artifactPaths at those call sites.
-// If the schema for artifactPaths is ever narrowed to plain-object-only, audit those
-// call sites first and confirm no callers pass an array before switching.
 function isRecord(value) {
     return typeof value === "object" && value !== null;
 }
@@ -921,11 +899,6 @@ function splitProviderModel(value) {
         modelId: value.slice(slashIndex + 1),
     };
 }
-/**
- * Serialize tool-call arguments to JSON and return the character length.
- * Returns 0 if arguments are absent or not serializable.
- * Only the character count is used — raw payload text is never stored.
- */
 function safeArgChars(args) {
     if (args == null) {
         return 0;
@@ -937,10 +910,6 @@ function safeArgChars(args) {
         return 0;
     }
 }
-/**
- * Sum the character length of all text items in a tool-result content array.
- * Image and other non-text items are excluded — only derived counts are used.
- */
 function resultContentChars(content) {
     if (!Array.isArray(content)) {
         return 0;

--- a/extensions/the-last-harness/tokens.js
+++ b/extensions/the-last-harness/tokens.js
@@ -37,7 +37,6 @@ export function createTokensCommandHandler(pi, dependencies = {}) {
                 primaryAgentLabel = getPrimaryAgentLabel?.();
             }
             catch {
-                // Fall back to default label if the source throws.
             }
             const html = buildTokensReportHtml(analysis, { generatedAt: now().toISOString(), primaryAgentLabel });
             const report = writeLocalTokensReport(ctx.sessionManager, html);
@@ -434,7 +433,6 @@ function setPrivateMode(path, mode) {
         chmodSync(path, mode);
     }
     catch {
-        // Best effort only. The file contents remain local even if chmod is unsupported.
     }
 }
 function dedupeParents(values) {

--- a/extensions/the-last-harness/version.js
+++ b/extensions/the-last-harness/version.js
@@ -1,9 +1,5 @@
 import { VERSION } from "@earendil-works/pi-coding-agent";
 import { getTlhVersion } from "./package-version.js";
-/**
- * Format a concise plain-text version string for both TLH and Pi.
- * Exported for unit testing without side effects.
- */
 export function formatVersionOutput(tlhVersion, piVersion) {
     return `tlh: ${tlhVersion}  |  pi: ${piVersion}`;
 }

--- a/tests/runtime-typescript-infra.test.mjs
+++ b/tests/runtime-typescript-infra.test.mjs
@@ -24,6 +24,7 @@ function createRuntimeFixture({
 	sourceExtension,
 	outputExtension,
 	generatedRegistryEntries,
+	compilerOptions = {},
 }) {
 	const fixtureRoot = mkdtempSync(join(tmpdir(), "tlh-runtime-typescript-fixture-"));
 	const sourceRoot = join(fixtureRoot, sourceRootName);
@@ -47,6 +48,7 @@ function createRuntimeFixture({
 					isolatedModules: true,
 					verbatimModuleSyntax: true,
 					skipLibCheck: true,
+					...compilerOptions,
 				},
 				include: [includeGlob],
 				exclude: ["node_modules/**"],
@@ -101,6 +103,7 @@ function createExtensionsFixture(sourceContent, options = {}) {
 		sourceExtension: ".ts",
 		outputExtension: ".js",
 		generatedRegistryEntries: options.generatedRegistryEntries,
+		compilerOptions: options.compilerOptions,
 	});
 }
 
@@ -203,7 +206,7 @@ test("runtime TypeScript helper tracks generated extension runtime modules", () 
 });
 
 test("runtime TypeScript helper builds, checks, and typechecks temporary script fixtures", () => {
-	const fixture = createScriptsFixture('export function greet(name: string) {\n\treturn `hello ${name}`;\n}\n');
+	const fixture = createScriptsFixture('// script fixture comment should remain\nexport function greet(name: string) {\n\treturn `hello ${name}`;\n}\n');
 
 	try {
 		assert.equal(existsSync(fixture.outputPath), false);
@@ -211,7 +214,9 @@ test("runtime TypeScript helper builds, checks, and typechecks temporary script 
 		const buildResult = runRuntimeTypescript("build", fixture);
 		assert.equal(buildResult.status, 0, buildResult.stderr || buildResult.stdout);
 		assert.equal(existsSync(fixture.outputPath), true);
-		assert.match(readFileSync(fixture.outputPath, "utf8"), /export function greet\(name\)/);
+		const outputContent = readFileSync(fixture.outputPath, "utf8");
+		assert.match(outputContent, /script fixture comment should remain/);
+		assert.match(outputContent, /export function greet\(name\)/);
 
 		const checkResult = runRuntimeTypescript("check", fixture);
 		assert.equal(checkResult.status, 0, checkResult.stderr || checkResult.stdout);
@@ -225,8 +230,10 @@ test("runtime TypeScript helper builds, checks, and typechecks temporary script 
 	}
 });
 
-test("runtime TypeScript helper builds and checks temporary extension fixtures", () => {
-	const fixture = createExtensionsFixture('export function assetHref() {\n\treturn new URL("./note.txt", import.meta.url).href;\n}\n');
+test("runtime TypeScript helper builds and checks temporary extension fixtures while omitting comments", () => {
+	const fixture = createExtensionsFixture('// extension fixture comment should be removed\nexport function assetHref() {\n\treturn new URL("./note.txt", import.meta.url).href;\n}\n', {
+		compilerOptions: { removeComments: true },
+	});
 	writeFileSync(join(fixture.sourceRoot, "fixture/note.txt"), "hello from asset\n");
 
 	try {
@@ -235,7 +242,9 @@ test("runtime TypeScript helper builds and checks temporary extension fixtures",
 		const buildResult = runRuntimeTypescript("build", fixture);
 		assert.equal(buildResult.status, 0, buildResult.stderr || buildResult.stdout);
 		assert.equal(existsSync(fixture.outputPath), true);
-		assert.match(readFileSync(fixture.outputPath, "utf8"), /import\.meta\.url/);
+		const outputContent = readFileSync(fixture.outputPath, "utf8");
+		assert.doesNotMatch(outputContent, /extension fixture comment should be removed/);
+		assert.match(outputContent, /import\.meta\.url/);
 
 		const checkResult = runRuntimeTypescript("check", fixture);
 		assert.equal(checkResult.status, 0, checkResult.stderr || checkResult.stdout);
@@ -346,6 +355,20 @@ test("runtime TypeScript check cleans temporary outputs when TypeScript compilat
 		assertNoTemporaryCheckOutputs(fixture.tempDir);
 	} finally {
 		fixture.cleanup();
+	}
+});
+
+test("generated extension outputs omit empty Pi runtime imports for type-only entrypoint dependencies", () => {
+	for (const path of [
+		"extensions/the-last-harness.js",
+		"extensions/the-last-harness/effort.js",
+		"extensions/the-last-harness/effort-command.js",
+	]) {
+		assert.doesNotMatch(
+			readFileSync(join(repoRoot, path), "utf8"),
+			/import\s*\{\s*\}\s*from\s*"@earendil-works\/pi-coding-agent";/,
+			`${path} should not contain an empty Pi runtime import`,
+		);
 	}
 });
 

--- a/tsconfig.runtime-extensions.json
+++ b/tsconfig.runtime-extensions.json
@@ -8,6 +8,7 @@
     "strict": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
+    "removeComments": true,
     "skipLibCheck": true,
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary

- emit true type-only Pi imports for three extension modules
- strip comments from deterministic generated extension JavaScript while keeping TypeScript authoritative
- add focused emission safeguards and a generated-output-only empty-catch lint allowance

Generated extension JavaScript shrinks from 511,545 to 490,115 bytes (-21,430 bytes / 4.19%). The packed package shrinks from 598,587 to 590,777 bytes (-7,810 bytes / 1.30%). This PR makes no startup-performance claim and changes no runtime behavior.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Additional checks:

```sh
npm run check:runtime
git diff --check
```

Package/runtime smoke confirmed the three ordered JavaScript entrypoints, all 63 generated extension modules, and `extensions/rtk.APACHE-2.0.txt`. Independent review found no semantic difference beyond comment removal and the three eliminated empty imports.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted: generated-output maintenance only)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/perf/trim-generated-extension-runtime/install.sh | bash -s -- --ref perf/trim-generated-extension-runtime --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/review` now uses a streamlined picker workflow with clearer prompts, improved context, and stronger validation across review modes.
  * Primary-agent model selections are now remembered and reapplied when applicable.
  * The update-available banner is no longer displayed automatically.

* **Bug Fixes**
  * Improved handling of review branches, commits, folders, pull requests, and checkout notifications.
  * Strengthened shutdown and cleanup behavior when processes or watchers are already closing.

* **Chores**
  * Improved extension build and validation checks, including comment handling and import cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->