### PR TITLE
Format seven-day usage as weekly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Fixed
 
+- Fixed OpenAI subscription usage footer presentation so an exact normalized seven-day primary window now renders as `weekly` and uses day/hour reset countdowns, without changing weekly-slot visibility semantics.
 - Fixed same-millisecond isolated `settings.json` backup collisions in TLH's shared settings writer by keeping the first timestamp-only backup name, then retrying exclusive `settings.json.bak-<timestamp>-<n>` suffixes under the existing Pi settings lock.
 
 ## [0.29.0] - 2026-07-12

--- a/extensions/the-last-harness/footer-subscription-usage.js
+++ b/extensions/the-last-harness/footer-subscription-usage.js
@@ -3,6 +3,7 @@ const TLH_SUBSCRIPTION_USAGE_PROVIDERS = new Set(["openai-codex", "anthropic"]);
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
 function finiteNumber(value) {
     return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -59,8 +60,12 @@ function formatResetCountdown(resetsAt, nowMs, windowType) {
 function normalizedUsageLabel(value) {
     return value?.trim().toLowerCase().replaceAll("_", "-").replaceAll(" ", "-") ?? "";
 }
+function formatUsageWindowPresentation(window, windowType) {
+    return window.durationMs === WEEK_MS ? "weekly" : windowType;
+}
 function formatUsageWindowLabel(provider, window, windowType) {
-    if (windowType === "weekly") {
+    const presentation = formatUsageWindowPresentation(window, windowType);
+    if (presentation === "weekly") {
         return "weekly";
     }
     const duration = formatUsageDuration(window.durationMs);
@@ -78,6 +83,7 @@ function formatUsageWindow(provider, window, windowType, nowMs) {
     if (!window) {
         return undefined;
     }
+    const presentation = formatUsageWindowPresentation(window, windowType);
     const label = formatUsageWindowLabel(provider, window, windowType);
     const percent = finiteNumber(window.percent);
     let base;
@@ -98,7 +104,7 @@ function formatUsageWindow(provider, window, windowType, nowMs) {
     if (!base) {
         return undefined;
     }
-    const countdown = formatResetCountdown(window.resetsAt, nowMs, windowType);
+    const countdown = formatResetCountdown(window.resetsAt, nowMs, presentation);
     return countdown ? `${base}, resets in ${countdown}` : base;
 }
 export function formatTlhSubscriptionUsageFooterSegment(snapshot, options = {}) {

--- a/extensions/the-last-harness/footer-subscription-usage.ts
+++ b/extensions/the-last-harness/footer-subscription-usage.ts
@@ -10,6 +10,7 @@ const TLH_SUBSCRIPTION_USAGE_PROVIDERS = new Set(["openai-codex", "anthropic"]);
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
 
 export type TlhFooterSubscriptionUsageOptions = {
 	subscriptionUsage?: TlhSubscriptionUsageSnapshotProvider;
@@ -89,12 +90,17 @@ function normalizedUsageLabel(value: string | undefined): string {
 	return value?.trim().toLowerCase().replaceAll("_", "-").replaceAll(" ", "-") ?? "";
 }
 
+function formatUsageWindowPresentation(window: TlhSubscriptionUsageWindow, windowType: "session" | "weekly"): "session" | "weekly" {
+	return window.durationMs === WEEK_MS ? "weekly" : windowType;
+}
+
 function formatUsageWindowLabel(
 	provider: string,
 	window: TlhSubscriptionUsageWindow,
 	windowType: "session" | "weekly",
 ): string {
-	if (windowType === "weekly") {
+	const presentation = formatUsageWindowPresentation(window, windowType);
+	if (presentation === "weekly") {
 		return "weekly";
 	}
 
@@ -122,6 +128,7 @@ function formatUsageWindow(
 		return undefined;
 	}
 
+	const presentation = formatUsageWindowPresentation(window, windowType);
 	const label = formatUsageWindowLabel(provider, window, windowType);
 	const percent = finiteNumber(window.percent);
 
@@ -144,7 +151,7 @@ function formatUsageWindow(
 		return undefined;
 	}
 
-	const countdown = formatResetCountdown(window.resetsAt, nowMs, windowType);
+	const countdown = formatResetCountdown(window.resetsAt, nowMs, presentation);
 	return countdown ? `${base}, resets in ${countdown}` : base;
 }
 

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -58,6 +58,22 @@ function openAiSnapshot(weekly = { percent: 21.5 }) {
 	};
 }
 
+function openAiPrimaryWeeklySnapshot({ percent = 42, resetsAt } = {}) {
+	return {
+		provider: "openai-codex",
+		fetchedAt: NOW_MS,
+		windows: {
+			session: {
+				key: "primary_window",
+				label: "session",
+				percent,
+				durationMs: 7 * 24 * 60 * 60 * 1000,
+				...(resetsAt ? { resetsAt } : {}),
+			},
+		},
+	};
+}
+
 function anthropicSnapshot(weekly = { percent: 88.9 }) {
 	return {
 		provider: "anthropic",
@@ -157,6 +173,19 @@ test("footer renders OpenAI/Codex session usage and hides weekly by default", ()
 	assert.doesNotMatch(sessionLine, /weekly/);
 	assert.doesNotMatch(sessionLine, /\$/);
 	assert.match(agentLine, /12\.3%\/200k/);
+});
+
+
+test("footer formats an exact seven-day OpenAI primary window as weekly without showing secondary usage", () => {
+	const snapshot = openAiPrimaryWeeklySnapshot({ resetsAt: "2026-05-24T01:00:00.000Z" });
+	const ctx = createCtx({ provider: "openai-codex" });
+	const sessionLine = renderSessionStatsLine(ctx, {
+		subscriptionUsage: usageProvider(snapshot),
+		shouldShowWeekly: () => false,
+	});
+
+	assert.equal(formatTlhSubscriptionUsageFooterSegment(snapshot, { nowMs: NOW_MS }), "weekly 42% used, resets in 4d 6h");
+	assert.equal(sessionLine, "weekly 42% used");
 });
 
 test("footer includes Anthropic weekly usage only when the preference enables it", () => {


### PR DESCRIPTION
## Summary

Fix OpenAI subscription usage footer presentation when the API returns an exact seven-day primary window. TLH now labels it as `weekly` and formats its reset countdown in days and hours while preserving existing weekly-slot visibility behavior.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed after refreshing the local dependency installation with `npm ci` to match the lockfile's Pi `0.80.6` pin.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/weekly-reset-footer/install.sh | bash -s -- --ref fix/weekly-reset-footer --track ref
```
