### PR TITLE
Fix trace-policy fixture imports and redaction

### DIFF
--- a/tests/evals/trace-policy/trace-policy-fixture-importer.mjs
+++ b/tests/evals/trace-policy/trace-policy-fixture-importer.mjs
@@ -370,8 +370,8 @@ function extractAgent(source, fallbackAgent, options = {}) {
 	return normalizeString(fallbackAgent || "developer");
 }
 
-function isStandaloneTraceRecord(parsed) {
-	return isRecord(parsed) && normalizeTraceSteps([parsed]).length > 0;
+function isStandaloneTraceRecord(record) {
+	return isRecord(record) && normalizeTraceSteps([record]).length > 0;
 }
 
 function extractStepRecords(parsed) {
@@ -396,11 +396,16 @@ function extractStepRecords(parsed) {
 	throw new Error("trace input does not include a recognizable steps/events/messages array");
 }
 
+function isStandaloneTraceSelection(parsed, records) {
+	return isRecord(parsed) && records.length === 1 && records[0] === parsed;
+}
+
 export function importTracePolicyFixtureFromText(text, options = {}) {
 	const parsed = parseTraceInput(text);
-	const standaloneTraceRecord = isStandaloneTraceRecord(parsed);
+	const stepRecords = extractStepRecords(parsed);
+	const standaloneTraceRecord = isStandaloneTraceSelection(parsed, stepRecords);
 	const transcriptSource = isRecord(parsed?.transcript) ? parsed.transcript : parsed;
-	const steps = normalizeTraceSteps(extractStepRecords(parsed)).filter(Boolean);
+	const steps = normalizeTraceSteps(stepRecords).filter(Boolean);
 	if (steps.length === 0) {
 		throw new Error("trace input did not yield any assistant/user/tool steps");
 	}

--- a/tests/evals/trace-policy/trace-policy-fixture-importer.mjs
+++ b/tests/evals/trace-policy/trace-policy-fixture-importer.mjs
@@ -24,7 +24,7 @@ function titleFromFixtureId(value) {
 }
 
 function isSensitiveKey(key) {
-	return /(?:token|secret|password|passwd|api[_-]?keys?|auth(?:orization)?|cookie|session)/i.test(normalizeText(key));
+	return /(?:token|secret|password|passwd|api[_-]?keys?|auth(?:orization)?|bearer|cookie|session)/i.test(normalizeText(key));
 }
 
 const ISO_TIMESTAMP_PATTERN = /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g;
@@ -32,7 +32,7 @@ const UUID_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{
 const GENERATED_ID_PATTERN = /\b(?:(?:call|msg|req|run|toolu|trace)_(?=[a-z0-9_-]*\d)[a-z0-9_-]{6,}|(?:req|session|trace)-(?=[a-z0-9_-]*\d)[a-z0-9_-]{6,})\b/gi;
 const LONG_HEX_ID_PATTERN = /\b[0-9a-f]{16,}\b/gi;
 const BEARER_PATTERN = /\bBearer\s+[^\s"']+/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|AUTH)[A-Z0-9_]*)=([^\s"']+|"[^"]*"|'[^']*')/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|AUTH|BEARER)[A-Z0-9_]*)=([^\s"']+|"[^"]*"|'[^']*')/gi;
 const WINDOWS_HOME_PATTERN = /[A-Za-z]:\\Users\\[^\\/:\s]+(?:\\[^\\\s"')\]]+)*/g;
 const WINDOWS_TEMP_PATTERN = /[A-Za-z]:\\(?:Users\\[^\\/:\s]+\\AppData\\Local\\Temp|Temp)(?:\\[^\\\s"')\]]+)*/g;
 const POSIX_HOME_PATTERN = /\/(?:Users|home)\/[^/:\s"')\]]+(?:\/[^\s"')\]]+)*/g;
@@ -360,12 +360,18 @@ function parseTraceInput(text) {
 	return parseJsonLines(normalized);
 }
 
-function extractAgent(source, fallbackAgent) {
-	const directAgent = normalizeText(source?.agent || source?.role || source?.actor);
+function extractAgent(source, fallbackAgent, options = {}) {
+	const directAgent = options.allowRoleFallback
+		? normalizeText(source?.agent || source?.role || source?.actor)
+		: normalizeText(source?.agent);
 	if (directAgent) {
 		return normalizeString(directAgent);
 	}
 	return normalizeString(fallbackAgent || "developer");
+}
+
+function isStandaloneTraceRecord(parsed) {
+	return isRecord(parsed) && normalizeTraceSteps([parsed]).length > 0;
 }
 
 function extractStepRecords(parsed) {
@@ -384,11 +390,15 @@ function extractStepRecords(parsed) {
 	if (Array.isArray(parsed?.messages)) {
 		return parsed.messages;
 	}
+	if (isStandaloneTraceRecord(parsed)) {
+		return [parsed];
+	}
 	throw new Error("trace input does not include a recognizable steps/events/messages array");
 }
 
 export function importTracePolicyFixtureFromText(text, options = {}) {
 	const parsed = parseTraceInput(text);
+	const standaloneTraceRecord = isStandaloneTraceRecord(parsed);
 	const transcriptSource = isRecord(parsed?.transcript) ? parsed.transcript : parsed;
 	const steps = normalizeTraceSteps(extractStepRecords(parsed)).filter(Boolean);
 	if (steps.length === 0) {
@@ -398,7 +408,7 @@ export function importTracePolicyFixtureFromText(text, options = {}) {
 	const fixtureSource = options.id || options.inputPath || "imported-trace";
 	const fixtureSourceName = basename(fixtureSource, extname(fixtureSource));
 	const fixtureId = sanitizeFixtureId(fixtureSourceName);
-	const agent = extractAgent(transcriptSource, options.agent);
+	const agent = extractAgent(transcriptSource, options.agent, { allowRoleFallback: !standaloneTraceRecord });
 	return {
 		id: fixtureId,
 		name: normalizeString(options.name || `imported ${titleFromFixtureId(fixtureId)}`),

--- a/tests/evals/trace-policy/trace-policy-fixture-importer.test.mjs
+++ b/tests/evals/trace-policy/trace-policy-fixture-importer.test.mjs
@@ -57,7 +57,7 @@ test("trace-policy fixture importer redacts volatile paths ids timestamps and se
 	assert.deepEqual(fixture.transcript.steps[1], {
 		type: "tool",
 		tool: "bash",
-		command: "OPENAI_API_KEY=<REDACTED> password=<REDACTED> api_key=<REDACTED> bearer=unused printenv HOME && cat <TMP>/session-123/output.log && echo Bearer <REDACTED>",
+		command: "OPENAI_API_KEY=<REDACTED> password=<REDACTED> api_key=<REDACTED> bearer=<REDACTED> printenv HOME && cat <TMP>/session-123/output.log && echo Bearer <REDACTED>",
 		path: "<HOME>/project/tests/evals/trace-policy/fixture.json",
 		input: {
 			env: {
@@ -123,6 +123,7 @@ test("trace-policy fixture importer redacts nested sensitive values", () => {
 				input: {
 					apiKeys: ["sk-one", { backup: "sk-two" }],
 					auth: { bearer: "token", nested: { refresh: "secret" } },
+					bearer: "direct-token",
 					cookie: ["a=b", "c=d"],
 					session: { id: "session_abcdef123456", file: "/Users/alice/session.json" },
 					nonSensitive: { path: "/Users/alice/project" },
@@ -134,10 +135,30 @@ test("trace-policy fixture importer redacts nested sensitive values", () => {
 	assert.deepEqual(fixture.transcript.steps[0].input, {
 		apiKeys: "<REDACTED>",
 		auth: "<REDACTED>",
+		bearer: "<REDACTED>",
 		cookie: "<REDACTED>",
 		session: "<REDACTED>",
 		nonSensitive: { path: "<HOME>/project" },
 	});
+});
+
+test("trace-policy fixture importer redacts bearer assignments in normalized strings", () => {
+	const fixture = importTracePolicyFixtureFromText(JSON.stringify({
+		agent: "developer",
+		steps: [
+			{
+				type: "assistant",
+				text: "Set bearer=plain-token and Bearer='quoted-token' before echo Bearer session-token",
+			},
+		],
+	}));
+
+	assert.deepEqual(fixture.transcript.steps, [
+		{
+			type: "assistant",
+			text: "Set bearer=<REDACTED> and Bearer=<REDACTED> before echo Bearer <REDACTED>",
+		},
+	]);
 });
 
 test("trace-policy fixture importer drops snake_case volatile fields and normalizes generated ids", () => {
@@ -163,6 +184,60 @@ test("trace-policy fixture importer drops snake_case volatile fields and normali
 		keptText: "request <ID> and trace <ID> finished",
 	});
 });
+
+test("trace-policy fixture importer accepts standalone assistant, user, and tool records", () => {
+	const cases = [
+		{
+			name: "assistant",
+			input: { type: "assistant", text: "I read /Users/alice/project at 2026-07-07T17:11:04Z" },
+			expectedAgent: "developer",
+			expectedSteps: [{ type: "assistant", text: "I read <HOME>/project at <TIMESTAMP>" }],
+		},
+		{
+			name: "user",
+			input: { role: "user", content: "Please inspect /Users/alice/project" },
+			expectedAgent: "developer",
+			expectedSteps: [{ type: "user", text: "Please inspect <HOME>/project" }],
+		},
+		{
+			name: "tool",
+			input: { type: "tool", tool: "read", path: "/tmp/tlh-live-evals-123/input.json" },
+			expectedAgent: "developer",
+			expectedSteps: [{ type: "tool", tool: "read", path: "<TMP>/tlh-live-evals-123/input.json" }],
+		},
+		{
+			name: "agent override",
+			input: { role: "assistant", agent: "architect", content: "Please inspect /Users/alice/project" },
+			expectedAgent: "architect",
+			expectedSteps: [{ type: "assistant", text: "Please inspect <HOME>/project" }],
+		},
+	];
+
+	for (const { name, input, expectedAgent, expectedSteps } of cases) {
+		const fixture = importTracePolicyFixtureFromText(JSON.stringify(input), { agent: "developer" });
+		assert.equal(fixture.transcript.agent, expectedAgent, `${name} agent`);
+		assert.deepEqual(fixture.transcript.steps, expectedSteps, name);
+	}
+});
+
+
+test("trace-policy fixture importer preserves wrapper-object role-based agent extraction", () => {
+	const fixture = importTracePolicyFixtureFromText(JSON.stringify({
+		transcript: {
+			role: "architect",
+			steps: [{ role: "assistant", content: "Ready" }],
+		},
+	}), { agent: "developer" });
+
+	assert.equal(fixture.transcript.agent, "architect");
+	assert.deepEqual(fixture.transcript.steps, [
+		{
+			type: "assistant",
+			text: "Ready",
+		},
+	]);
+});
+
 
 test("trace-policy fixture importer keeps named assistant messages as assistant steps", () => {
 	const fixture = importTracePolicyFixtureFromText(JSON.stringify({

--- a/tests/evals/trace-policy/trace-policy-fixture-importer.test.mjs
+++ b/tests/evals/trace-policy/trace-policy-fixture-importer.test.mjs
@@ -221,22 +221,56 @@ test("trace-policy fixture importer accepts standalone assistant, user, and tool
 });
 
 
-test("trace-policy fixture importer preserves wrapper-object role-based agent extraction", () => {
-	const fixture = importTracePolicyFixtureFromText(JSON.stringify({
-		transcript: {
-			role: "architect",
-			steps: [{ role: "assistant", content: "Ready" }],
-		},
-	}), { agent: "developer" });
-
-	assert.equal(fixture.transcript.agent, "architect");
-	assert.deepEqual(fixture.transcript.steps, [
+test("trace-policy fixture importer preserves named wrapper role-based agent extraction", () => {
+	const cases = [
 		{
-			type: "assistant",
-			text: "Ready",
+			name: "steps wrapper",
+			input: {
+				role: "architect",
+				name: "wrapper-agent",
+				steps: [{ role: "assistant", content: "Ready" }],
+			},
 		},
-	]);
+		{
+			name: "events wrapper",
+			input: {
+				role: "architect",
+				name: "wrapper-agent",
+				events: [{ role: "assistant", content: "Ready" }],
+			},
+		},
+		{
+			name: "messages wrapper",
+			input: {
+				role: "architect",
+				name: "wrapper-agent",
+				messages: [{ message: { role: "assistant", content: "Ready" } }],
+			},
+		},
+		{
+			name: "transcript steps wrapper",
+			input: {
+				transcript: {
+					role: "architect",
+					name: "wrapper-agent",
+					steps: [{ role: "assistant", content: "Ready" }],
+				},
+			},
+		},
+	];
+
+	for (const { name, input } of cases) {
+		const fixture = importTracePolicyFixtureFromText(JSON.stringify(input), { agent: "developer" });
+		assert.equal(fixture.transcript.agent, "architect", `${name} agent`);
+		assert.deepEqual(fixture.transcript.steps, [
+			{
+				type: "assistant",
+				text: "Ready",
+			},
+		], name);
+	}
 });
+
 
 
 test("trace-policy fixture importer keeps named assistant messages as assistant steps", () => {


### PR DESCRIPTION
## Summary

- accept standalone assistant, user, and tool records as one-line JSON/JSONL trace inputs
- redact bearer object fields and `bearer=...` assignments
- preserve wrapper agent extraction while preventing standalone step roles from becoming the transcript agent

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

```sh
npm run validate
```

Passed. Targeted trace-policy validation also passed with 116 tests and 0 failures.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this contributor-only importer fix)
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of bearer tokens and other sensitive values in imported traces.
  * Added support for importing standalone assistant, user, and tool trace records.
  * Improved agent identification across standalone and wrapped trace formats.
  * Expanded normalization coverage for paths, timestamps, and nested sensitive fields.

* **Tests**
  * Added coverage for bearer-token redaction and additional trace input structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->