### PR TITLE
Pin pi-subagents to 0.31.7 (native async completions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Changed
 
-- Bumped bundled default extension pins to the reviewed current releases: `mcporter` `npm:@diegopetrucci/pi-mcp-adapter@2.10.2`, `pi-openai-fast` `npm:@diegopetrucci/pi-openai-fast@0.1.9`, `pi-notify` `npm:@diegopetrucci/pi-notify@0.1.10`, `pi-context-inspector` `npm:@diegopetrucci/pi-context-inspector@0.1.6`, critical `pi-subagents` `npm:@diegopetrucci/pi-subagents@0.31.6`, and critical `pi-intercom` `npm:@diegopetrucci/pi-intercom@0.8.0`.
+- Bumped bundled default extension pins to the reviewed current releases: `mcporter` `npm:@diegopetrucci/pi-mcp-adapter@2.10.2`, `pi-openai-fast` `npm:@diegopetrucci/pi-openai-fast@0.1.9`, `pi-notify` `npm:@diegopetrucci/pi-notify@0.1.10`, `pi-context-inspector` `npm:@diegopetrucci/pi-context-inspector@0.1.6`, critical `pi-subagents` `npm:@diegopetrucci/pi-subagents@0.31.7`, and critical `pi-intercom` `npm:@diegopetrucci/pi-intercom@0.8.0`.
 - Aligned TLH’s subagent safety and provider-aware model injection with the `pi-subagents` `0.31.6` single/parallel contract: safe management actions now include `models`, TLH no longer traverses legacy `chain` payloads in its model-facing hooks, and hidden autocomplete/docs references to `/skill:pi-subagents` were removed.
 - Refreshed the remaining safely updatable direct npm dependencies to `monaco-editor` `0.55.1`, `eslint` `10.7.0`, and `typescript-eslint` `8.64.0`, while keeping `typescript` pinned at `6.0.3` to stay within the supported peer range.
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -62,7 +62,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.6",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.7",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/tests/default-extensions.test.mjs
+++ b/tests/default-extensions.test.mjs
@@ -1193,7 +1193,7 @@ test("bundled manifest contains subagents and intercom entries with correct crit
 	const intercom = bundled.find(({ id }) => id === "intercom");
 
 	assert.ok(subagents, "bundled subagents entry should exist");
-	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.6");
+	assert.equal(subagents.source, "npm:@diegopetrucci/pi-subagents@0.31.7");
 	assert.equal(subagents.critical, true, "subagents must stay critical");
 	assert.deepEqual(subagents.aliases, ["pi-subagents"]);
 	assert.deepEqual(subagents.replaces, [
@@ -1236,7 +1236,7 @@ test("bundled merge migrates legacy upstream and TLH subagents installs to the s
 	const settings = readJson(fixture.settings);
 	assert.deepEqual(
 		settings.packages.filter((entry) => packageIdentity(entry) === "npm:@diegopetrucci/pi-subagents"),
-		["npm:@diegopetrucci/pi-subagents@0.31.6"],
+		["npm:@diegopetrucci/pi-subagents@0.31.7"],
 	);
 	assert.equal(
 		settings.packages.some((entry) => packageIdentity(entry) === "git:github.com/nicobailon/pi-subagents"),


### PR DESCRIPTION
## Summary

Bump TLH's critical bundled `pi-subagents` package from `0.31.6` to `0.31.7` so new and updated isolated profiles receive native async completion delivery and its failure/share hardening.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed end-to-end, including typechecks, generated-output freshness, installer smoke tests, test suite, lint, ShellCheck, merge dry-run, and package dry-run.

Targeted validation also passed:

- `npm run check:package-versions`
- `node --test tests/default-extensions.test.mjs` — 44 passed, 0 failed
- `git diff --check`
- TLH repository hygiene checklist
- independent diff review — no findings

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR

**What the new fork tag / pin includes:** Native async completion delivery for detached/background subagents, hardened watcher/result handling, and preserved failure/share outcomes.

**Link to merged fork PRs:** [#64](https://github.com/diegopetrucci/pi-subagents/pull/64), [#71](https://github.com/diegopetrucci/pi-subagents/pull/71), [#72](https://github.com/diegopetrucci/pi-subagents/pull/72), release [#73](https://github.com/diegopetrucci/pi-subagents/pull/73)

**Before → after pin:** `npm:@diegopetrucci/pi-subagents@0.31.6` → `npm:@diegopetrucci/pi-subagents@0.31.7`

**`npm run validate` result:** Passed.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/pi-subagents-0.31.7/install.sh | bash -s -- --ref chore/pi-subagents-0.31.7 --track ref
```
