### PR TITLE
Pin pi-subagents to 0.31.8 (phase-2a: fail-closed executor + steer restored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 - You can now add custom (non built-in) subagents. Ask TLH how to.
 
+### Changed
+
+- Bumped the critical `pi-subagents` pin to `npm:@diegopetrucci/pi-subagents@0.31.8`: the subagent tool is now fail-closed to the 8 TLH actions for every caller, `steer` is restored as the supported parent→child guidance action (groundwork for retiring `pi-intercom`), and the unused scheduler is unwired from startup.
+
 ### Fixed
 
 - OpenAI weekly/daily usage now shows days, not just hours.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -62,7 +62,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.7",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.8",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {


### PR DESCRIPTION
## Summary

Bump the critical `pi-subagents` pin to `0.31.8` — the phase‑2a trim release: the subagent tool is fail-closed to the 8 TLH actions for every caller (model, RPC, internal), `steer` is restored as the supported parent→child guidance action (groundwork for retiring `pi-intercom`), and the unused scheduler is unwired from extension startup.

## Change type

- [x] Pin PR (update a `config/default-extensions.json` fork tag)

## Validation

**Standard validation:**

```sh
npm run validate
```

Full chain green: package-version check, `tsc --noEmit`, runtime typecheck, generated-output freshness, installer smoke, tests, lint, ShellCheck, merge-settings dry-run (correctly previews `npm:@diegopetrucci/pi-subagents@0.31.7 -> 0.31.8`), and `npm pack --dry-run`.

Note: required a fresh `npm ci` first — the local `node_modules` had `@earendil-works/pi-coding-agent@0.80.6` vs the declared `0.81.1`, producing a pre-existing `tsc` error on clean `main` (`ModelRuntime` not exported). Not related to this change.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (config-only pin bump; merge-settings dry-run verified conservative update path)
- [x] Relevant tests or smoke checks pass (`npm run validate`)
- [x] Docs and `CHANGELOG.md` updated (Unreleased → Changed bullet)
- [x] Diff contains no secrets, local paths, or unintended generated files (2 files: `config/default-extensions.json`, `CHANGELOG.md`)

---

## Pin PR

**What the new fork tag / pin includes:**

- `SUBAGENT_ACTIONS` trimmed 20 → 8 (`list, get, models, status, interrupt, resume, steer, doctor`); executor fail-closed for every caller; agent-mutation / `append-step` / `schedule*` actions uniformly rejected.
- `steer` restored to the model-facing contract (schema enum, FULL/COMPACT/SAFETY descriptions, fanout-child parity) — the parent→child native slice complementing the native async-completion delivery (fork #64/#71/#72) toward the `pi-intercom` exit.
- Scheduled-run manager unwired from extension startup; `scheduledRuns` config inert (runtime module retained for phase‑3 deletion).
- Contract sizes: schema 3,131 B; FULL 3,392 / COMPACT 1,507 chars.

**Link to merged fork PR:** diegopetrucci/pi-subagents#70 (feature) and diegopetrucci/pi-subagents#74 (release `v0.31.8`, tag `tlh-v0.31.8`, npm published with provenance)

**Before → after pin:** `npm:@diegopetrucci/pi-subagents@0.31.7` → `npm:@diegopetrucci/pi-subagents@0.31.8`

**`npm run validate` result:** green (see Validation above)
