### PR TITLE
Add fork pin-bump verification tally doc

### DIFF
--- a/docs/pin-bump-verification.md
+++ b/docs/pin-bump-verification.md
@@ -9,7 +9,7 @@ during the `@diegopetrucci/pi-subagents` v0.34.0 intake and its follow-ups, and 
 still need a **live-session runtime check** on the bumped pin.
 
 The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.8`)
-with mirroring assertions in `tests/default-extensions.test.mjs`. The pin has already been bumped
+with manifest-consistency/migration assertions in `tests/default-extensions.test.mjs` (the test derives its expected value from the manifest, so it would still pass if only the manifest changed). The pin has already been bumped
 (PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8); the live-session pass is what remains.
 
 Mark each item `[x]` once verified in a real TLH session on the bumped pin.

--- a/docs/pin-bump-verification.md
+++ b/docs/pin-bump-verification.md
@@ -1,0 +1,52 @@
+# Fork pin-bump verification tally
+
+> **Live tracker:** completion is tracked in GitHub issue
+> [#346](https://github.com/diegopetrucci/the-last-harness/issues/346).
+> This doc is the reference detail; tick items off in the issue.
+
+Running checklist of behaviors that could **only be unit-tested / statically verified**
+during the `@diegopetrucci/pi-subagents` v0.34.0 intake and its follow-ups, and therefore
+still need a **live-session runtime check** on the bumped pin.
+
+The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.8`)
+with mirroring assertions in `tests/default-extensions.test.mjs`. The pin has already been bumped
+(PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8); the live-session pass is what remains.
+
+Mark each item `[x]` once verified in a real TLH session on the bumped pin.
+
+## Pending post-pin verification
+
+- [ ] **Compact subagent tool description (`ps-fo50`)** — a live session shows the parent-facing
+  subagent tool description in **compact** form while retaining safety-critical delegation
+  guidance; an invalid/unknown `toolDescriptionMode` value falls back to `full`.
+  _Static status:_ installer provisioning in PR #374; unit-tested in
+  `tests/install-libs.test.mjs`. Runtime rendering deferred (requires the bumped pin).
+
+- [ ] **RPC bridge default-off (`ps-5n7r`, fork PR #59)** — confirm the subagent RPC bridge is
+  **not active** by default: no `subagents:rpc:v1:ready` emitted, and an RPC `spawn` request is
+  ignored. TLH must leave `rpc.enabled` off.
+  _Static status:_ gated + unit-tested in the fork (`test/unit/rpc-gate.test.ts`).
+
+- [ ] **Native supervisor coordination (v0.34.0 Option A)** — `contact_supervisor` escalations
+  from minor agents reach the architect via the **native supervisor channel** (the fork's
+  pi-intercom discovery delta was retired). This is a behavioral cutover worth a live check.
+
+- [ ] **New management verbs blocked at runtime (`ps-c901`)** — `eject`, `disable`, `enable`,
+  `reset` are rejected for primary agents in a live session.
+  _Static status:_ pinned by `validateSubagentToolInput` regression test in
+  `tests/tlh-subagent-safety.test.mjs` (tool_call path). RPC path covered by the default-off gate.
+  Phase-2a in 0.31.8 additionally fail-closes the executor for all callers (fork
+  `test/unit/executor-action-trim.test.ts` trims `SUBAGENT_ACTIONS` to the 8 supported actions),
+  strengthening the original tool_call-path-only coverage.
+
+- [ ] **General intake smoke** — core TLH subagent flows still work on the new version:
+  delegation to the 8 allowed minor agents; a non-allow-listed target is blocked; forced
+  `agentScope: user` + `context: fresh`; async run + `status`/`resume`.
+
+## Notes
+
+- Slash / prompt-template executor-path bypass was audited (`ps-azwi`) and **accepted, not gated**
+  (low/zero real exposure); documented in the fork's `docs/tlh-patch-inventory.md`. Re-evaluate
+  only if a new slash command delegates a user-supplied `agent`/`task`, or `pi-prompt-template-model`
+  is installed.
+- Windows-only behaviors (e.g. the fork's win32 E2E skip) are out of scope — TLH targets macOS/Linux.


### PR DESCRIPTION
## Summary

Add `docs/pin-bump-verification.md`, the reference detail behind the post-pin verification tally tracked in #346. The issue links to this doc, but it was never merged to `main` (it lived only on a local branch), leaving the issue's link dangling.

This lands the doc with **minimal factual corrections** to reflect current state.

## Change type

- [x] Docs

## Validation

```sh
npm run validate   # pass (docs-only)
```

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (docs-only; no code/installer changes)
- [x] Relevant checks pass (`npm run validate` green)
- [x] No CHANGELOG entry — matches repo convention for internal docs-only additions (e.g. prior `docs/` commits did not touch `CHANGELOG.md`)
- [x] Diff contains no secrets, local paths, or unintended generated files (single new file)

## Factual corrections vs. the original draft

1. **Pin reference** — now `@0.31.8`, and the "bump is the trigger" framing is updated to acknowledge the bump already happened (PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8); the live-session pass is what remains.
2. **`ps-fo50` (compact tool description)** — static status now references PR #374 (the installer provisioning) instead of implying it already shipped.
3. **`ps-c901` (management verbs)** — notes that phase-2a in 0.31.8 additionally fail-closes the executor for all callers (fork `executor-action-trim.test.ts` trims `SUBAGENT_ACTIONS` to the 8 supported actions), strengthening the original tool_call-path-only coverage.

Depends on #374 (referenced by the `ps-fo50` item).

Co-authored-by: The Last Harness <hi@thelastharness.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a verification checklist for fork-pin updates.
  * Documented runtime checks covering subagent tools, RPC behavior, supervisor coordination, management command blocking, and delegation flows.
  * Recorded accepted executor-path behavior and clarified that Windows-only behavior is out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->