### PR TITLE
Remove model attribution from provider totals

### DIFF
--- a/extensions/the-last-harness/session-limit-report.js
+++ b/extensions/the-last-harness/session-limit-report.js
@@ -220,7 +220,6 @@ function renderProviderTotalsTable(result) {
     const rows = [
         ...perProviderTotals.map((pt) => [
             pt.provider,
-            pt.modelId ?? "—",
             formatInteger(pt.usage.inputTokens),
             formatInteger(pt.usage.outputTokens),
             formatInteger(pt.usage.cacheReadTokens),
@@ -231,7 +230,6 @@ function renderProviderTotalsTable(result) {
         ]),
         [
             "All providers",
-            "—",
             formatInteger(grandTotals.inputTokens),
             formatInteger(grandTotals.outputTokens),
             formatInteger(grandTotals.cacheReadTokens),
@@ -241,7 +239,7 @@ function renderProviderTotalsTable(result) {
             formatInteger(grandTotals.turns),
         ],
     ];
-    return renderTable(["Provider", "Model", "Input", "Output", "Cache read", "Cache write", "Total", "Cost (USD)", "Turns"], rows, "No provider usage data.");
+    return renderTable(["Provider", "Input", "Output", "Cache read", "Cache write", "Total", "Cost (USD)", "Turns"], rows, "No provider usage data.");
 }
 function formatInteger(value) {
     return INTEGER_FORMATTER.format(value);

--- a/extensions/the-last-harness/session-limit-report.ts
+++ b/extensions/the-last-harness/session-limit-report.ts
@@ -327,7 +327,6 @@ function renderProviderTotalsTable(result: SessionAggregateResult): string {
 	const rows: string[][] = [
 		...perProviderTotals.map((pt) => [
 			pt.provider,
-			pt.modelId ?? "—",
 			formatInteger(pt.usage.inputTokens),
 			formatInteger(pt.usage.outputTokens),
 			formatInteger(pt.usage.cacheReadTokens),
@@ -339,7 +338,6 @@ function renderProviderTotalsTable(result: SessionAggregateResult): string {
 		// Grand totals row
 		[
 			"All providers",
-			"—",
 			formatInteger(grandTotals.inputTokens),
 			formatInteger(grandTotals.outputTokens),
 			formatInteger(grandTotals.cacheReadTokens),
@@ -350,7 +348,7 @@ function renderProviderTotalsTable(result: SessionAggregateResult): string {
 		],
 	];
 	return renderTable(
-		["Provider", "Model", "Input", "Output", "Cache read", "Cache write", "Total", "Cost (USD)", "Turns"],
+		["Provider", "Input", "Output", "Cache read", "Cache write", "Total", "Cost (USD)", "Turns"],
 		rows,
 		"No provider usage data.",
 	);

--- a/tests/the-last-harness-session-limit-command.test.mjs
+++ b/tests/the-last-harness-session-limit-command.test.mjs
@@ -638,6 +638,33 @@ test("buildSessionLimitReportHtml renders sessions table with token breakdown an
 	assert.match(html, /Cost \(USD\)/);
 });
 
+test("buildSessionLimitReportHtml omits model attribution from provider totals while preserving mixed-model provider totals", () => {
+	const window = { startMs: 0, endMs: Date.now() + 1_000_000, source: "snapshot" };
+	const result = {
+		rows: [],
+		perProviderTotals: [
+			{
+				provider: "anthropic",
+				modelId: "claude-opus-4-1",
+				usage: { inputTokens: 1200, outputTokens: 300, cacheReadTokens: 40, cacheWriteTokens: 10, totalTokens: 1550, costUsd: 0.0456, turns: 7, assistantMessages: 7 },
+			},
+		],
+		grandTotals: { inputTokens: 1200, outputTokens: 300, cacheReadTokens: 40, cacheWriteTokens: 10, totalTokens: 1550, costUsd: 0.0456, turns: 7, assistantMessages: 7 },
+		caveats: [],
+	};
+	const html = buildSessionLimitReportHtml(window, result, makeSnapshot(), Date.now(), {
+		generatedAt: "2026-05-01T00:00:00Z",
+	});
+
+	assert.match(html, /<h2>Per-provider totals<\/h2>/);
+	assert.match(html, /<th>Provider<\/th>/);
+	assert.doesNotMatch(html, /<th>Model<\/th>/);
+	assert.match(html, />anthropic</);
+	assert.match(html, /1,550/);
+	assert.match(html, /\$0\.0456/);
+	assert.doesNotMatch(html, /claude-opus-4-1/);
+});
+
 test("buildSessionLimitReportHtml renders session rows ranked by total tokens", () => {
 	const window = { startMs: 0, endMs: Date.now() + 1_000_000, source: "snapshot" };
 	// rows are passed in descending order (as aggregateSessionUsage would produce them)


### PR DESCRIPTION
## Summary

- Remove the misleading Model column from session-limit provider totals, which aggregate usage across every model for a provider.
- Preserve provider-level aggregation and numeric totals, regenerate the runtime JavaScript mirror, and add report-rendering regression coverage.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed end to end, including runtime TypeScript typechecking, generated-output freshness, installer smoke checks, tests, ESLint, ShellCheck, and package dry-run.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unnecessary **Model** column from the Per-provider totals report.
  * Provider totals now display only relevant token, cost, and turn metrics.

* **Tests**
  * Added coverage confirming model identifiers are not shown while provider totals and costs remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->