### PR TITLE
Use npm ci with the tracked lockfile in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '22.19.0'
 
       - name: Install dependencies
-        run: npm install --no-package-lock --legacy-peer-deps
+        run: npm ci
 
       - name: Run validation checks
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Install test dependencies
-        run: npm install --no-package-lock --legacy-peer-deps
+        run: npm ci
 
       - name: Run release checks
         run: npm run validate


### PR DESCRIPTION
## Summary

Use lockfile-backed `npm ci` installs in CI and release validation instead of resolving dependencies dynamically with legacy peer-dependency overrides.

Closes #317.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm ci
env -u TICKETS_DIR npm run validate
```

A clean `npm ci` completed without peer-dependency overrides, and the full validation suite passed. `TICKETS_DIR` was unset only to prevent tlh session-ticket metadata from leaking into isolated ticket-workflow test fixtures.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants
- [x] Relevant tests and smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where warranted (not applicable for this CI-only change)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/317-use-npm-ci/install.sh | bash -s -- --ref fix/317-use-npm-ci --track ref
```
