### PR TITLE
Fix interleaved ticket scope restoration

### DIFF
--- a/extensions/the-last-harness/primary-agent-runtime.js
+++ b/extensions/the-last-harness/primary-agent-runtime.js
@@ -227,7 +227,7 @@ function embeddedDelegationBlockedReason(selection, input) {
 }
 function registerChildSubagentRuntime(pi, buildChildPrompt, env) {
     pi.on("session_start", async (_event, ctx) => {
-        activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+        activateTlhTicketSessionScope(ctx.cwd);
     });
     pi.on("before_agent_start", async (event, ctx) => {
         const settings = getTlhGlobalSettings(ctx.cwd);
@@ -580,7 +580,7 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
         });
     }
     async function applySessionStart(ctx) {
-        activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+        activateTlhTicketSessionScope(ctx.cwd);
         sessionExperimentalSnapshot = getTlhGlobalSettings(ctx.cwd).tlh?.experimental;
         syncPrimaryAgentState(ctx);
         await applyPrimaryDefaults(ctx);

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -311,7 +311,7 @@ function registerChildSubagentRuntime(
 	env: Record<string, string | undefined>,
 ): void {
 	pi.on("session_start", async (_event, ctx) => {
-		activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+		activateTlhTicketSessionScope(ctx.cwd);
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
@@ -746,7 +746,7 @@ function createTlhPrimaryAgentRuntime(
 	}
 
 	async function applySessionStart(ctx: ExtensionContext): Promise<void> {
-		activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+		activateTlhTicketSessionScope(ctx.cwd);
 		sessionExperimentalSnapshot = getTlhGlobalSettings(ctx.cwd).tlh?.experimental;
 		syncPrimaryAgentState(ctx);
 		await applyPrimaryDefaults(ctx);

--- a/extensions/the-last-harness/ticket-workflow-ui-facade.js
+++ b/extensions/the-last-harness/ticket-workflow-ui-facade.js
@@ -88,9 +88,17 @@ export function registerLazyTlhTicketWorkflowUi(pi, options = {}) {
         runtime?.handleExperimentalFeatureChange(event);
     });
     pi.on("session_start", async (_event, ctx) => {
-        activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+        activateTlhTicketSessionScope(ctx.cwd);
         activeContext = ctx;
         applyCurrentSettings(ctx);
+    });
+    pi.on("session_shutdown", () => {
+        activeContext = undefined;
+        if (runtime) {
+            runtime.handleSessionShutdown();
+            return;
+        }
+        void runtimePromise?.then((loadedRuntime) => loadedRuntime.handleSessionShutdown()).catch(() => undefined);
     });
     pi.on("user_bash", (event, ctx) => {
         if (runtime) {

--- a/extensions/the-last-harness/ticket-workflow-ui-facade.ts
+++ b/extensions/the-last-harness/ticket-workflow-ui-facade.ts
@@ -113,9 +113,18 @@ export function registerLazyTlhTicketWorkflowUi(pi: ExtensionAPI, options: TlhTi
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
-		activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+		activateTlhTicketSessionScope(ctx.cwd);
 		activeContext = ctx;
 		applyCurrentSettings(ctx);
+	});
+
+	pi.on("session_shutdown", () => {
+		activeContext = undefined;
+		if (runtime) {
+			runtime.handleSessionShutdown();
+			return;
+		}
+		void runtimePromise?.then((loadedRuntime) => loadedRuntime.handleSessionShutdown()).catch(() => undefined);
 	});
 
 	pi.on("user_bash", (event, ctx) => {

--- a/extensions/the-last-harness/ticket-workflow-ui.js
+++ b/extensions/the-last-harness/ticket-workflow-ui.js
@@ -267,6 +267,7 @@ function shouldRefreshFromBashCommand(command) {
 export function createTlhTicketWorkflowUiRuntime(pi) {
     let commandRegistered = false;
     let activeContext;
+    const pendingUserBashRefreshes = new Set();
     const refresh = (ctx) => {
         if (!ctx.hasUI) {
             return;
@@ -309,11 +310,22 @@ export function createTlhTicketWorkflowUiRuntime(pi) {
             }
             applyCurrentSettings(activeContext);
         },
+        handleSessionShutdown() {
+            for (const timeout of pendingUserBashRefreshes) {
+                clearTimeout(timeout);
+            }
+            pendingUserBashRefreshes.clear();
+            activeContext = undefined;
+        },
         handleUserBash(event, ctx) {
             if (!ctx.hasUI || !isTicketWorkflowUiEnabled(ctx.cwd) || !shouldRefreshFromBashCommand(event.command)) {
                 return;
             }
-            const timeout = setTimeout(() => refresh(ctx), TK_USER_BASH_REFRESH_DELAY_MS);
+            const timeout = setTimeout(() => {
+                pendingUserBashRefreshes.delete(timeout);
+                refresh(ctx);
+            }, TK_USER_BASH_REFRESH_DELAY_MS);
+            pendingUserBashRefreshes.add(timeout);
             timeout.unref?.();
         },
         handleToolResult(event, ctx) {
@@ -334,8 +346,11 @@ export function registerTlhTicketWorkflowUi(pi) {
         runtime.handleExperimentalFeatureChange(event);
     });
     pi.on("session_start", async (_event, ctx) => {
-        activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+        activateTlhTicketSessionScope(ctx.cwd);
         runtime.applyCurrentSettings(ctx);
+    });
+    pi.on("session_shutdown", () => {
+        runtime.handleSessionShutdown();
     });
     pi.on("user_bash", (event, ctx) => {
         runtime.handleUserBash(event, ctx);

--- a/extensions/the-last-harness/ticket-workflow-ui.ts
+++ b/extensions/the-last-harness/ticket-workflow-ui.ts
@@ -323,6 +323,7 @@ function shouldRefreshFromBashCommand(command: string): boolean {
 export type TlhTicketWorkflowUiRuntime = {
 	applyCurrentSettings(ctx: ExtensionContext): void;
 	handleExperimentalFeatureChange(event: unknown): void;
+	handleSessionShutdown(): void;
 	handleUserBash(event: { command: string }, ctx: ExtensionContext): void;
 	handleToolResult(event: { toolName: string; input: { command?: unknown } }, ctx: ExtensionContext): void;
 };
@@ -330,6 +331,7 @@ export type TlhTicketWorkflowUiRuntime = {
 export function createTlhTicketWorkflowUiRuntime(pi: ExtensionAPI): TlhTicketWorkflowUiRuntime {
 	let commandRegistered = false;
 	let activeContext: ExtensionContext | undefined;
+	const pendingUserBashRefreshes = new Set<ReturnType<typeof setTimeout>>();
 
 	const refresh = (ctx: ExtensionContext) => {
 		if (!ctx.hasUI) {
@@ -376,11 +378,22 @@ export function createTlhTicketWorkflowUiRuntime(pi: ExtensionAPI): TlhTicketWor
 			}
 			applyCurrentSettings(activeContext);
 		},
+		handleSessionShutdown() {
+			for (const timeout of pendingUserBashRefreshes) {
+				clearTimeout(timeout);
+			}
+			pendingUserBashRefreshes.clear();
+			activeContext = undefined;
+		},
 		handleUserBash(event: { command: string }, ctx: ExtensionContext) {
 			if (!ctx.hasUI || !isTicketWorkflowUiEnabled(ctx.cwd) || !shouldRefreshFromBashCommand(event.command)) {
 				return;
 			}
-			const timeout = setTimeout(() => refresh(ctx), TK_USER_BASH_REFRESH_DELAY_MS);
+			const timeout = setTimeout(() => {
+				pendingUserBashRefreshes.delete(timeout);
+				refresh(ctx);
+			}, TK_USER_BASH_REFRESH_DELAY_MS);
+			pendingUserBashRefreshes.add(timeout);
 			timeout.unref?.();
 		},
 		handleToolResult(event: { toolName: string; input: { command?: unknown } }, ctx: ExtensionContext) {
@@ -404,8 +417,12 @@ export function registerTlhTicketWorkflowUi(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
-		activateTlhTicketSessionScope(ctx.cwd, { refresh: true });
+		activateTlhTicketSessionScope(ctx.cwd);
 		runtime.applyCurrentSettings(ctx);
+	});
+
+	pi.on("session_shutdown", () => {
+		runtime.handleSessionShutdown();
 	});
 
 	pi.on("user_bash", (event, ctx) => {

--- a/extensions/the-last-harness/tickets.js
+++ b/extensions/the-last-harness/tickets.js
@@ -63,14 +63,19 @@ export function activateTlhTicketSessionScope(cwd, options = {}) {
     const normalizedCwd = resolve(cwd);
     const current = process.env.TICKETS_DIR?.trim();
     if (current) {
-        if (!options.refresh) {
-            return current;
-        }
-        if (current !== autoScopedTicketsDir) {
+        const currentIsAutoScoped = current === autoScopedTicketsDir;
+        if (!currentIsAutoScoped) {
             return current;
         }
         if (normalizedCwd === autoScopedCwd) {
             return current;
+        }
+        if (!options.refresh) {
+            const restoredScopedDir = resolveDefaultTicketsDir(normalizedCwd);
+            process.env.TICKETS_DIR = restoredScopedDir;
+            autoScopedTicketsDir = restoredScopedDir;
+            autoScopedCwd = normalizedCwd;
+            return restoredScopedDir;
         }
     }
     const scopedDir = resolveDefaultTicketsDir(normalizedCwd);

--- a/extensions/the-last-harness/tickets.js
+++ b/extensions/the-last-harness/tickets.js
@@ -59,7 +59,7 @@ function resolveGitWorktreeRoot(cwd) {
 function resolveDefaultTicketsDir(cwd) {
     return join(resolveGitWorktreeRoot(cwd) ?? resolve(cwd), ".tickets");
 }
-export function activateTlhTicketSessionScope(cwd, options = {}) {
+export function activateTlhTicketSessionScope(cwd) {
     const normalizedCwd = resolve(cwd);
     const current = process.env.TICKETS_DIR?.trim();
     if (current) {
@@ -69,13 +69,6 @@ export function activateTlhTicketSessionScope(cwd, options = {}) {
         }
         if (normalizedCwd === autoScopedCwd) {
             return current;
-        }
-        if (!options.refresh) {
-            const restoredScopedDir = resolveDefaultTicketsDir(normalizedCwd);
-            process.env.TICKETS_DIR = restoredScopedDir;
-            autoScopedTicketsDir = restoredScopedDir;
-            autoScopedCwd = normalizedCwd;
-            return restoredScopedDir;
         }
     }
     const scopedDir = resolveDefaultTicketsDir(normalizedCwd);

--- a/extensions/the-last-harness/tickets.ts
+++ b/extensions/the-last-harness/tickets.ts
@@ -73,14 +73,19 @@ export function activateTlhTicketSessionScope(cwd: string, options: { refresh?: 
 	const normalizedCwd = resolve(cwd);
 	const current = process.env.TICKETS_DIR?.trim();
 	if (current) {
-		if (!options.refresh) {
-			return current;
-		}
-		if (current !== autoScopedTicketsDir) {
+		const currentIsAutoScoped = current === autoScopedTicketsDir;
+		if (!currentIsAutoScoped) {
 			return current;
 		}
 		if (normalizedCwd === autoScopedCwd) {
 			return current;
+		}
+		if (!options.refresh) {
+			const restoredScopedDir = resolveDefaultTicketsDir(normalizedCwd);
+			process.env.TICKETS_DIR = restoredScopedDir;
+			autoScopedTicketsDir = restoredScopedDir;
+			autoScopedCwd = normalizedCwd;
+			return restoredScopedDir;
 		}
 	}
 	const scopedDir = resolveDefaultTicketsDir(normalizedCwd);

--- a/extensions/the-last-harness/tickets.ts
+++ b/extensions/the-last-harness/tickets.ts
@@ -69,7 +69,7 @@ function resolveDefaultTicketsDir(cwd: string): string {
 	return join(resolveGitWorktreeRoot(cwd) ?? resolve(cwd), ".tickets");
 }
 
-export function activateTlhTicketSessionScope(cwd: string, options: { refresh?: boolean } = {}): string {
+export function activateTlhTicketSessionScope(cwd: string): string {
 	const normalizedCwd = resolve(cwd);
 	const current = process.env.TICKETS_DIR?.trim();
 	if (current) {
@@ -79,13 +79,6 @@ export function activateTlhTicketSessionScope(cwd: string, options: { refresh?: 
 		}
 		if (normalizedCwd === autoScopedCwd) {
 			return current;
-		}
-		if (!options.refresh) {
-			const restoredScopedDir = resolveDefaultTicketsDir(normalizedCwd);
-			process.env.TICKETS_DIR = restoredScopedDir;
-			autoScopedTicketsDir = restoredScopedDir;
-			autoScopedCwd = normalizedCwd;
-			return restoredScopedDir;
 		}
 	}
 	const scopedDir = resolveDefaultTicketsDir(normalizedCwd);

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -691,7 +691,7 @@ test("extension runs primary session_start work before UI startup in one handler
 	const lifecycleHooks = sourceSection(primaryRuntimeSource, "function registerLifecycleHooks()", "\n\n\treturn { applySessionStart");
 
 	assert.match(sessionStart, /await primaryAgentRuntime\.applySessionStart\(ctx\);[\s\S]*if \(!ctx\.hasUI\)/);
-	assert.match(primaryRuntimeSource, /async function applySessionStart\(ctx: ExtensionContext\): Promise<void>[\s\S]*activateTlhTicketSessionScope\(ctx\.cwd, \{ refresh: true \}\);/);
+	assert.match(primaryRuntimeSource, /async function applySessionStart\(ctx: ExtensionContext\): Promise<void>[\s\S]*activateTlhTicketSessionScope\(ctx\.cwd\);/);
 	assert.match(primaryRuntimeSource, /return \{ applySessionStart, currentPrimaryAgentLabel, activePrimaryAgentPrompt: activePrimaryAgent, registerCommands, registerLifecycleHooks \};/);
 	assert.doesNotMatch(lifecycleHooks, /pi\.on\("session_start"/);
 });

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -55,6 +55,36 @@ test("primary runtime scopes tickets during session start before later session w
 		});
 
 		assert.equal(process.env.TICKETS_DIR, join(fixture.cwd, ".tickets"));
+	});
+});
+
+test("primary runtime before_agent_start restores the revisited session's auto-scoped tickets dir", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { test: t });
+	const repoA = join(fixture.dir, "repo-a");
+	const repoB = join(fixture.dir, "repo-b");
+	mkdirSync(repoA, { recursive: true });
+	mkdirSync(repoB, { recursive: true });
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, TICKETS_DIR: undefined }, async () => {
+		const { runtime, beforeAgentStart } = registerRuntimeHarness({ subagentMetadata: [] });
+		assert.ok(runtime, "runtime should register outside child sessions");
+
+		const createCtx = (cwd) => ({
+			cwd,
+			sessionManager: { getBranch: () => [] },
+			ui: { notify() {} },
+			modelRegistry: { getAvailable: () => [{ provider: "openai-codex", id: "gpt-5.4" }] },
+			model: { provider: "openai-codex", id: "gpt-5.4" },
+		});
+
+		await runtime.applySessionStart(createCtx(repoA));
+		assert.equal(process.env.TICKETS_DIR, join(repoA, ".tickets"));
+
+		await runtime.applySessionStart(createCtx(repoB));
+		assert.equal(process.env.TICKETS_DIR, join(repoB, ".tickets"));
+
+		await beforeAgentStart({ systemPrompt: "base prompt" }, createCtx(repoA));
+		assert.equal(process.env.TICKETS_DIR, join(repoA, ".tickets"));
 	});
 });
 

--- a/tests/tlh-ticket-runtime.test.mjs
+++ b/tests/tlh-ticket-runtime.test.mjs
@@ -9,6 +9,13 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url);
 const { activateTlhTicketRuntime, activateTlhTicketSessionScope } = await jiti.import("../extensions/the-last-harness/tickets.ts");
 
+function resetTicketRuntimeTestState() {
+	delete process.env.TICKETS_DIR;
+}
+
+test.beforeEach(resetTicketRuntimeTestState);
+test.afterEach(resetTicketRuntimeTestState);
+
 function tempFixture() {
 	const dir = mkdtempSync(join(tmpdir(), "tlh-ticket-runtime-test-"));
 	const agent = join(dir, "agent");
@@ -123,7 +130,7 @@ test("ticket session scope falls back to cwd outside git and preserves explicit 
 	});
 });
 
-test("ticket session scope refresh reuses the same cwd but updates for a different cwd", { skip: process.platform === "win32" }, () => {
+test("ticket session scope reuses the same cwd but updates for a different cwd", { skip: process.platform === "win32" }, () => {
 	const fixture = tempFixture();
 	const firstRepo = join(fixture.dir, "repo-one");
 	const secondRepo = join(fixture.dir, "repo-two");
@@ -147,17 +154,17 @@ test("ticket session scope refresh reuses the same cwd but updates for a differe
 		withPath([fakeBin, process.env.PATH || ""].filter(Boolean).join(delimiter), () => {
 			const firstRealNestedCwd = realpathSync(firstNestedCwd);
 			const secondRealNestedCwd = realpathSync(secondNestedCwd);
-			assert.equal(activateTlhTicketSessionScope(firstNestedCwd, { refresh: true }), firstExpected);
-			assert.equal(activateTlhTicketSessionScope(firstNestedCwd, { refresh: true }), firstExpected);
+			assert.equal(activateTlhTicketSessionScope(firstNestedCwd), firstExpected);
+			assert.equal(activateTlhTicketSessionScope(firstNestedCwd), firstExpected);
 			assert.deepEqual(readFileSync(gitLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [firstRealNestedCwd]);
 
-			assert.equal(activateTlhTicketSessionScope(secondNestedCwd, { refresh: true }), secondExpected);
+			assert.equal(activateTlhTicketSessionScope(secondNestedCwd), secondExpected);
 			assert.deepEqual(readFileSync(gitLog, "utf8").trim().split(/\r?\n/).filter(Boolean), [firstRealNestedCwd, secondRealNestedCwd]);
 		});
 	});
 });
 
-test("ticket session scope refresh updates prior auto-scoped dirs but preserves explicit TICKETS_DIR", { skip: process.platform === "win32" }, () => {
+test("ticket session scope updates prior auto-scoped dirs but preserves explicit TICKETS_DIR", { skip: process.platform === "win32" }, () => {
 	const fixture = tempFixture();
 	const firstRepo = join(fixture.dir, "repo-one");
 	const secondRepo = join(fixture.dir, "repo-two");
@@ -181,12 +188,12 @@ test("ticket session scope refresh updates prior auto-scoped dirs but preserves 
 		assert.equal(activateTlhTicketSessionScope(firstNestedCwd), firstExpected);
 		assert.equal(process.env.TICKETS_DIR, firstExpected);
 
-		assert.equal(activateTlhTicketSessionScope(secondNestedCwd, { refresh: true }), secondExpected);
+		assert.equal(activateTlhTicketSessionScope(secondNestedCwd), secondExpected);
 		assert.equal(process.env.TICKETS_DIR, secondExpected);
 	});
 
 	withTicketsDir(explicitTicketsDir, () => {
-		assert.equal(activateTlhTicketSessionScope(firstNestedCwd, { refresh: true }), explicitTicketsDir);
+		assert.equal(activateTlhTicketSessionScope(firstNestedCwd), explicitTicketsDir);
 		assert.equal(process.env.TICKETS_DIR, explicitTicketsDir);
 	});
 });

--- a/tests/tlh-ticket-workflow-ui-facade.test.mjs
+++ b/tests/tlh-ticket-workflow-ui-facade.test.mjs
@@ -16,6 +16,13 @@ const {
 	TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT,
 } = await jiti.import("../extensions/the-last-harness/experimental.ts");
 
+function resetTicketWorkflowFacadeTestState() {
+	delete process.env.TICKETS_DIR;
+}
+
+test.beforeEach(resetTicketWorkflowFacadeTestState);
+test.afterEach(resetTicketWorkflowFacadeTestState);
+
 function createPiHarness() {
 	const commands = new Map();
 	const handlers = new Map();
@@ -76,6 +83,9 @@ test("lazy ticket workflow facade skips runtime import by default and loads it o
 		handleExperimentalFeatureChange(event) {
 			runtimeCalls.push(["handleExperimentalFeatureChange", event.enabled]);
 		},
+		handleSessionShutdown() {
+			runtimeCalls.push(["handleSessionShutdown"]);
+		},
 		handleUserBash(event, ctx) {
 			runtimeCalls.push(["handleUserBash", event.command, ctx.cwd]);
 		},
@@ -111,9 +121,11 @@ test("lazy ticket workflow facade skips runtime import by default and loads it o
 
 		await fireAll(pi, "user_bash", { command: "tk ready" }, ctx);
 		await fireAll(pi, "tool_result", { toolName: "bash", input: { command: "tk ready" } }, ctx);
+		await fireAll(pi, "session_shutdown", {}, ctx);
 		assert.deepEqual(runtimeCalls.slice(1), [
 			["handleUserBash", "tk ready", fixture.cwd],
 			["handleToolResult", "tk ready", fixture.cwd],
+			["handleSessionShutdown"],
 		]);
 	});
 });
@@ -143,6 +155,9 @@ test("lazy ticket workflow facade refreshes a loaded runtime for later disabled 
 							},
 							handleExperimentalFeatureChange(event) {
 								runtimeCalls.push(["handleExperimentalFeatureChange", event.enabled, activeCtx?.cwd]);
+							},
+							handleSessionShutdown() {
+								runtimeCalls.push(["handleSessionShutdown"]);
 							},
 							handleUserBash() {},
 							handleToolResult() {},
@@ -200,6 +215,9 @@ test("lazy ticket workflow facade retries runtime import after a current-session
 							},
 							handleExperimentalFeatureChange(event) {
 								runtimeCalls.push(["handleExperimentalFeatureChange", event.enabled]);
+							},
+							handleSessionShutdown() {
+								runtimeCalls.push(["handleSessionShutdown"]);
 							},
 							handleUserBash() {},
 							handleToolResult() {},

--- a/tests/tlh-ticket-workflow-ui.test.mjs
+++ b/tests/tlh-ticket-workflow-ui.test.mjs
@@ -228,6 +228,58 @@ esac
 	chmodSync(tkPath, 0o755);
 }
 
+function installScopeAwareFakeTk(agentDir, repoATicketsDir, repoBTicketsDir) {
+	const binDir = join(agentDir, "bin");
+	mkdirSync(binDir, { recursive: true });
+	const tkPath = join(binDir, "tk");
+	writeFileSync(
+		tkPath,
+		`#!/usr/bin/env bash
+set -euo pipefail
+repo_a=${JSON.stringify(repoATicketsDir)}
+repo_b=${JSON.stringify(repoBTicketsDir)}
+tickets_dir="\${TICKETS_DIR:-.tickets}"
+if [[ ! -d "$tickets_dir" ]]; then
+  echo "Error: tickets directory '$tickets_dir' does not exist" >&2
+  exit 1
+fi
+case "$tickets_dir" in
+  "$repo_a")
+    ticket_id="repo-a-ticket"
+    ticket_title="Repo A ticket title"
+    ;;
+  "$repo_b")
+    ticket_id="repo-b-ticket"
+    ticket_title="Repo B ticket title"
+    ;;
+  *)
+    echo "unexpected tickets dir: $tickets_dir" >&2
+    exit 1
+    ;;
+esac
+case "\${1:-}" in
+  help|--help|-h)
+    echo "tk - test ticket system"
+    echo "Usage: tk <command> [args]"
+    echo "Tickets stored as markdown files in .tickets/"
+    ;;
+  query)
+    printf '{"id":"%s","status":"in_progress"}\n' "$ticket_id"
+    ;;
+  ready|blocked)
+    ;;
+  show)
+    printf '%s\n' '---' "id: $ticket_id" 'status: in_progress' '---' "# $ticket_title"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+	);
+	chmodSync(tkPath, 0o755);
+}
+
 test("ticket workflow UI stays completely disabled by default", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
 	writeFileSync(
@@ -246,6 +298,41 @@ test("ticket workflow UI stays completely disabled by default", async (t) => {
 		assert.equal(pi.commands.has("tk-status"), false);
 		assert.deepEqual(uiHarness.statusUpdates, [{ key: "tlh-ticket-workflow", text: undefined }]);
 		assert.deepEqual(uiHarness.widgetUpdates, [{ key: "tlh-ticket-workflow", content: undefined, options: undefined }]);
+	});
+});
+
+test("enabled ticket workflow UI restores the revisited session's auto-scoped tickets dir for status reads", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { test: t });
+	const repoA = join(fixture.dir, "repo-a");
+	const repoB = join(fixture.dir, "repo-b");
+	const repoATicketsDir = join(repoA, ".tickets");
+	const repoBTicketsDir = join(repoB, ".tickets");
+	mkdirSync(repoATicketsDir, { recursive: true });
+	mkdirSync(repoBTicketsDir, { recursive: true });
+	installScopeAwareFakeTk(fixture.agent, repoATicketsDir, repoBTicketsDir);
+	writeFileSync(
+		join(fixture.agent, "settings.json"),
+		`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [TICKET_WORKFLOW_UI_FEATURE] } } }, null, 2)}\n`,
+	);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, TICKETS_DIR: undefined }, async () => {
+		const pi = createPiHarness();
+		registerTlhTicketWorkflowUi(pi);
+		const uiHarness = createUiHarness();
+		const ctxA = createCtx(repoA, uiHarness.ui);
+		const ctxB = createCtx(repoB, uiHarness.ui);
+
+		await fireAll(pi, "session_start", { reason: "restore" }, ctxA);
+		assert.equal(process.env.TICKETS_DIR, repoATicketsDir);
+		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo A ticket title\nUse /tk-status for details.");
+
+		await fireAll(pi, "session_start", { reason: "restore" }, ctxB);
+		assert.equal(process.env.TICKETS_DIR, repoBTicketsDir);
+		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo B ticket title\nUse /tk-status for details.");
+
+		await pi.commands.get("tk-status").handler("", ctxA);
+		assert.equal(process.env.TICKETS_DIR, repoATicketsDir);
+		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /In progress: repo-a-ticket - Repo A ticket title/);
 	});
 });
 
@@ -462,7 +549,7 @@ test("enabled ticket workflow UI stays quiet without a .tickets repo while /tk-s
 		`${JSON.stringify({ tlh: { experimental: { enabledFeatures: [TICKET_WORKFLOW_UI_FEATURE] } } }, null, 2)}\n`,
 	);
 
-	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, TICKETS_DIR: undefined }, async () => {
 		const pi = createPiHarness();
 		registerTlhTicketWorkflowUi(pi);
 		const uiHarness = createUiHarness();

--- a/tests/tlh-ticket-workflow-ui.test.mjs
+++ b/tests/tlh-ticket-workflow-ui.test.mjs
@@ -11,6 +11,13 @@ const jiti = createJiti(import.meta.url);
 const { registerTlhTicketWorkflowUi } = await jiti.import("../extensions/the-last-harness/ticket-workflow-ui.ts");
 const { TICKET_WORKFLOW_UI_FEATURE } = await jiti.import("../extensions/the-last-harness/experimental.ts");
 
+function resetTicketWorkflowTestState() {
+	delete process.env.TICKETS_DIR;
+}
+
+test.beforeEach(resetTicketWorkflowTestState);
+test.afterEach(resetTicketWorkflowTestState);
+
 const IN_PROGRESS_TICKET_TITLE = "Implement scoped ticket footer selection";
 const IN_PROGRESS_TICKET_FOOTER_STATUS = `working on tk: ${IN_PROGRESS_TICKET_TITLE}\nUse /tk-status for details.`;
 
@@ -301,7 +308,7 @@ test("ticket workflow UI stays completely disabled by default", async (t) => {
 	});
 });
 
-test("enabled ticket workflow UI restores the revisited session's auto-scoped tickets dir for status reads", async (t) => {
+test("enabled ticket workflow UI ignores stale delayed refreshes from a superseded session while later restores still rescope correctly", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { test: t });
 	const repoA = join(fixture.dir, "repo-a");
 	const repoB = join(fixture.dir, "repo-b");
@@ -316,21 +323,37 @@ test("enabled ticket workflow UI restores the revisited session's auto-scoped ti
 	);
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, TICKETS_DIR: undefined }, async () => {
-		const pi = createPiHarness();
-		registerTlhTicketWorkflowUi(pi);
 		const uiHarness = createUiHarness();
 		const ctxA = createCtx(repoA, uiHarness.ui);
 		const ctxB = createCtx(repoB, uiHarness.ui);
+		const piA = createPiHarness();
+		registerTlhTicketWorkflowUi(piA);
 
-		await fireAll(pi, "session_start", { reason: "restore" }, ctxA);
+		await fireAll(piA, "session_start", { reason: "restore" }, ctxA);
 		assert.equal(process.env.TICKETS_DIR, repoATicketsDir);
 		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo A ticket title\nUse /tk-status for details.");
 
-		await fireAll(pi, "session_start", { reason: "restore" }, ctxB);
+		await fireAll(piA, "user_bash", { command: "tk ready" }, ctxA);
+		await fireAll(piA, "session_shutdown", {}, ctxA);
+
+		const piB = createPiHarness();
+		registerTlhTicketWorkflowUi(piB);
+		await fireAll(piB, "session_start", { reason: "restore" }, ctxB);
 		assert.equal(process.env.TICKETS_DIR, repoBTicketsDir);
 		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo B ticket title\nUse /tk-status for details.");
 
-		await pi.commands.get("tk-status").handler("", ctxA);
+		await delay(300);
+		assert.equal(process.env.TICKETS_DIR, repoBTicketsDir);
+		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo B ticket title\nUse /tk-status for details.");
+
+		await fireAll(piB, "session_shutdown", {}, ctxB);
+		const piARestored = createPiHarness();
+		registerTlhTicketWorkflowUi(piARestored);
+		await fireAll(piARestored, "session_start", { reason: "restore" }, ctxA);
+		assert.equal(process.env.TICKETS_DIR, repoATicketsDir);
+		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "working on tk: Repo A ticket title\nUse /tk-status for details.");
+
+		await piARestored.commands.get("tk-status").handler("", ctxA);
 		assert.equal(process.env.TICKETS_DIR, repoATicketsDir);
 		assert.match(uiHarness.notifications.at(-1)?.message ?? "", /In progress: repo-a-ticket - Repo A ticket title/);
 	});


### PR DESCRIPTION
## Summary

- Restore the current worktree's automatically scoped `TICKETS_DIR` when same-process TLH session runtimes are revisited in an A → B → A sequence.
- Preserve explicitly supplied `TICKETS_DIR` values.
- Add primary runtime and ticket workflow UI regressions for the interleaved-session path.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed, including runtime typechecking, generated-output freshness, tests, lint, installer smoke checks, and package dry-run.

Focused checks also passed:

```sh
node --test tests/tlh-ticket-runtime.test.mjs tests/the-last-harness-primary-agent-runtime.test.mjs tests/tlh-ticket-workflow-ui.test.mjs
npm run typecheck:runtime
npm run check:runtime
```

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this regression fix)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/interleaved-ticket-scope/install.sh | bash -s -- --ref fix/interleaved-ticket-scope --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the correct ticket directory when revisiting a repository, preventing ticket data from remaining scoped to a previously active repository.
  * Ensured ticket status displays and workflow commands use the active repository’s tickets.

* **Tests**
  * Added coverage for switching between repositories and restoring their ticket scopes.
  * Added validation for ticket status and workflow behavior when no tickets directory is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->