### PR TITLE
chore: bump pi-subagents default pin to 0.31.10 (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to The Last Harness will be documented in this file.
 - [Experimental] You can now add custom (non built-in) subagents. Ask TLH how to.
 - New `/what-consumed-my-session-limit-and-tokens` command that generates and opens a local, private HTML report attributing token consumption across all TLH sessions (including subagent child sessions, across every project) within the current provider session-limit window (Anthropic 5-hour or OpenAI Codex session window, resolved from the subscription usage snapshot with a trailing-5h fallback). The report ranks sessions by in-window usage with per-provider totals and privacy/accuracy caveats, and embeds no transcript text or tool payloads.
 
+### Changed
+
+- Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.9` to `npm:@diegopetrucci/pi-subagents@0.31.10`. This release adds per-agent acceptance roles (`acceptanceRole`) and a paused-resume acceptance contract, records paused/interrupted runs as `skipped` (not `rejected`) acceptance, never infers `reviewed` acceptance, gates idle "needs attention" notices on in-flight tool calls, and includes the upstream nicobailon/pi-subagents#514/#524 status-cache-invalidation and management-output-collapse intakes.
+
 ### Fixed
 
 - Restored Anthropic and OpenAI Codex subscription usage in the footer, which disappeared under Pi 0.81 when upstream removed the auth-storage API the usage service depended on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+- Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.9` to `npm:@diegopetrucci/pi-subagents@0.31.10`. This release adds per-agent acceptance roles (`acceptanceRole`) and a paused-resume acceptance contract, records paused/interrupted runs as `skipped` (not `rejected`) acceptance, never infers `reviewed` acceptance, gates idle "needs attention" notices on in-flight tool calls, and includes the upstream nicobailon/pi-subagents#514/#524 status-cache-invalidation and management-output-collapse intakes.
+
 ## [0.30.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ All notable changes to The Last Harness will be documented in this file.
 - Release telemetry now reports only the `on`/`off` state of registered TLH experimental flags; unknown or custom experimental values remain ignored and unsent.
 - TLH's architect/developer ticket workflow guidance now explicitly protects pre-existing user-owned worktree and index changes from being overwritten or discarded during scoped implementation tasks.
 
-### Changed
-
-- Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.9` to `npm:@diegopetrucci/pi-subagents@0.31.10`. This release adds per-agent acceptance roles (`acceptanceRole`) and a paused-resume acceptance contract, records paused/interrupted runs as `skipped` (not `rejected`) acceptance, never infers `reviewed` acceptance, gates idle "needs attention" notices on in-flight tool calls, and includes the upstream nicobailon/pi-subagents#514/#524 status-cache-invalidation and management-output-collapse intakes.
-
 ### Fixed
 
 - Restored Anthropic and OpenAI Codex subscription usage in the footer, which disappeared under Pi 0.81 when upstream removed the auth-storage API the usage service depended on.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -62,7 +62,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.9",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.10",
     "description": "Delegate work to isolated TLH-profile subagents."
   },
   {

--- a/docs/pin-bump-verification.md
+++ b/docs/pin-bump-verification.md
@@ -8,9 +8,9 @@ Running checklist of behaviors that could **only be unit-tested / statically ver
 during the `@diegopetrucci/pi-subagents` v0.34.0 intake and its follow-ups, and therefore
 still need a **live-session runtime check** on the bumped pin.
 
-The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.9`)
+The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.10`)
 with manifest-consistency/migration assertions in `tests/default-extensions.test.mjs` (the test derives its expected value from the manifest, so it would still pass if only the manifest changed). Previous pin bumps landed in
-PRs #347 → 0.31.5, #367 → 0.31.7, and #370 → 0.31.8. The current checkout advances the pin to 0.31.9; the live-session pass is what remains.
+PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8, and #386 → 0.31.9. The current checkout advances the pin to 0.31.10 (#390); the live-session pass is what remains.
 
 Mark each item `[x]` once verified in a real TLH session on the bumped pin.
 


### PR DESCRIPTION
Advances the bundled critical `pi-subagents` default extension pin from `0.31.9` to `0.31.10` (fork release `tlh-v0.31.10`, now live on npm).

## What 0.31.10 brings
- **#481 intake** — per-agent acceptance roles (`acceptanceRole`)
- **#93** — fork paused-resume acceptance contract (per-child `skipped` ledger + monotonic-merge resume inheritance)
- **#86/#87/#90** — never infer `reviewed`; paused/interrupted runs recorded as `skipped` not `rejected`; idle-attention gated on in-flight tool calls
- **#91** — upstream #514 (status-cache identity invalidation) + #524 (management-output collapse) intake
- **#81** — test scripts on `--experimental-strip-types`

## Changes
- `config/default-extensions.json`: pin `0.31.9` → `0.31.10`
- `docs/pin-bump-verification.md`: version ref + bump-history row (#386 → 0.31.9, #390 → 0.31.10)
- `CHANGELOG.md`: `[Unreleased]` pin-bump entry

## Validation
`npm run validate` green locally — including `check:package-versions` resolving the new 0.31.10 pin against npm, and the `default-extensions.test.mjs` manifest-consistency assertions.

ttryqv slash-command cleanup was already completed in #386; no stale refs remain (autocomplete hides the retired commands, covered by `the-last-harness-autocomplete.test.mjs`).

Co-authored-by: The Last Harness <hi@thelastharness.com>