### PR TITLE
Cap librarian subagent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TLH subagents are fresh child sessions, not a giant shared swarm. They get the t
 - `diff-summarizer` for change overviews
 - `developer` for implementation
 - `code-reviewer` for review
-- `librarian` for read-only GitHub repository research (uses `gh` CLI and `git`)
+- `librarian` for read-only GitHub repository research (uses `gh` CLI and `git`; TLH caps librarian-bearing subagent runs at five minutes unless the caller already set a stricter timeout)
 - `web-scout` for web research
 - `oracle` for a deeper second opinion
 - `contrarian` as a bundled default minor subagent for sparing adversarial stress-tests.

--- a/extensions/the-last-harness/primary-agent-runtime.js
+++ b/extensions/the-last-harness/primary-agent-runtime.js
@@ -201,11 +201,22 @@ function collectSubagentCallTargetsMatching(input, predicate) {
 function subagentCallTargetsMatching(input, predicate) {
     return collectSubagentCallTargetsMatching(input, predicate).length > 0;
 }
+const LIBRARIAN_MAX_TIMEOUT_MS = 300_000;
 function isOpaqueSubagentManagementActionInput(input) {
     if (!isRecord(input) || typeof input.action !== "string" || input.action.trim().length === 0) {
         return false;
     }
     return !isExecutionBearingResumeChain(input);
+}
+function capLibrarianSubagentTimeout(input) {
+    if (!isRecord(input) || isOpaqueSubagentManagementActionInput(input) || !subagentCallTargetsAgent(input, "librarian")) {
+        return;
+    }
+    const { timeoutMs } = input;
+    if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs <= LIBRARIAN_MAX_TIMEOUT_MS) {
+        return;
+    }
+    input.timeoutMs = LIBRARIAN_MAX_TIMEOUT_MS;
 }
 function embeddedDelegationBlockedReason(selection, input) {
     if (isOpaqueSubagentManagementActionInput(input)) {
@@ -654,6 +665,7 @@ function createTlhPrimaryAgentRuntime(pi, primaryAgents, subagentMetadata) {
                 return undefined;
             }
             applyProviderAwareSubagentModels(event.input, subagentsByName, getUnfilteredAvailableModels(ctx.modelRegistry), ctx.model?.provider, ctx.model);
+            capLibrarianSubagentTimeout(event.input);
             syncPrimaryAgentState(ctx);
             const selection = currentPrimaryAgentSelection();
             const allowedSubagents = allowedSubagentsForExperimentalConfig(getTlhGlobalSettings(ctx.cwd).tlh?.experimental);

--- a/extensions/the-last-harness/primary-agent-runtime.ts
+++ b/extensions/the-last-harness/primary-agent-runtime.ts
@@ -278,11 +278,26 @@ function subagentCallTargetsMatching(input: unknown, predicate: (agent: string) 
 	return collectSubagentCallTargetsMatching(input, predicate).length > 0;
 }
 
+const LIBRARIAN_MAX_TIMEOUT_MS = 300_000;
+
 function isOpaqueSubagentManagementActionInput(input: unknown): boolean {
 	if (!isRecord(input) || typeof input.action !== "string" || input.action.trim().length === 0) {
 		return false;
 	}
 	return !isExecutionBearingResumeChain(input);
+}
+
+function capLibrarianSubagentTimeout(input: unknown): void {
+	if (!isRecord(input) || isOpaqueSubagentManagementActionInput(input) || !subagentCallTargetsAgent(input, "librarian")) {
+		return;
+	}
+	const { timeoutMs } = input;
+	if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs <= LIBRARIAN_MAX_TIMEOUT_MS) {
+		return;
+	}
+	// The current subagent API exposes only a run-level timeout, so any batch containing
+	// librarian must cap the whole execution request.
+	input.timeoutMs = LIBRARIAN_MAX_TIMEOUT_MS;
 }
 
 function embeddedDelegationBlockedReason(selection: TlhPrimaryAgentSelection, input: unknown): string | undefined {
@@ -837,6 +852,7 @@ function createTlhPrimaryAgentRuntime(
 				return undefined;
 			}
 			applyProviderAwareSubagentModels(event.input, subagentsByName, getUnfilteredAvailableModels(ctx.modelRegistry), ctx.model?.provider, ctx.model);
+			capLibrarianSubagentTimeout(event.input);
 			syncPrimaryAgentState(ctx);
 			const selection = currentPrimaryAgentSelection();
 			const allowedSubagents = allowedSubagentsForExperimentalConfig(getTlhGlobalSettings(ctx.cwd).tlh?.experimental);

--- a/tests/the-last-harness-primary-agent-runtime-delegation.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime-delegation.test.mjs
@@ -18,6 +18,8 @@ import {
 	EMBEDDED_SUBAGENTS_FEATURE,
 } from "./the-last-harness-primary-agent-runtime-test-helpers.mjs";
 
+const LIBRARIAN_MAX_TIMEOUT_MS = 300_000;
+
 test("enabled primary mode allows approved delegation targets and forces safe top-level defaults", async () => {
 	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
 	const event = {
@@ -36,6 +38,95 @@ test("enabled primary mode allows approved delegation targets and forces safe to
 	assert.equal(await toolCall(event, ctx), undefined);
 	assert.equal(event.input.agentScope, "user");
 	assert.equal(event.input.context, "fresh");
+});
+
+test("tool_call caps librarian execution timeouts without affecting stricter or non-librarian calls", async () => {
+	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
+	const ctx = createToolCallContext([
+		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
+	]);
+	const cases = [
+		{
+			name: "missing timeout",
+			event: { toolName: "subagent", input: { agent: "librarian", task: "Research upstream docs" } },
+			expectedTimeoutMs: LIBRARIAN_MAX_TIMEOUT_MS,
+		},
+		{
+			name: "longer timeout",
+			event: { toolName: "subagent", input: { agent: "librarian", task: "Research upstream docs", timeoutMs: 360_000 } },
+			expectedTimeoutMs: LIBRARIAN_MAX_TIMEOUT_MS,
+		},
+		{
+			name: "stricter timeout",
+			event: { toolName: "subagent", input: { agent: "librarian", task: "Research upstream docs", timeoutMs: 120_000 } },
+			expectedTimeoutMs: 120_000,
+		},
+		{
+			name: "async execution",
+			event: { toolName: "subagent", input: { agent: "librarian", task: "Research upstream docs", async: true } },
+			expectedTimeoutMs: LIBRARIAN_MAX_TIMEOUT_MS,
+		},
+		{
+			name: "mixed batch containing librarian",
+			event: {
+				toolName: "subagent",
+				input: {
+					tasks: [
+						{ agent: "repo-scout", task: "Map the repo" },
+						{ agent: "librarian", task: "Research upstream docs" },
+					],
+					timeoutMs: 420_000,
+				},
+			},
+			expectedTimeoutMs: LIBRARIAN_MAX_TIMEOUT_MS,
+		},
+		{
+			name: "non-librarian execution",
+			event: { toolName: "subagent", input: { agent: "repo-scout", task: "Map the repo", timeoutMs: 420_000 } },
+			expectedTimeoutMs: 420_000,
+		},
+	];
+
+	for (const { name, event, expectedTimeoutMs } of cases) {
+		assert.equal(await toolCall(event, ctx), undefined, name);
+		assert.equal(event.input.timeoutMs, expectedTimeoutMs, name);
+	}
+});
+
+test("tool_call caps librarian resume-chain executions but leaves opaque management timeouts unchanged", async () => {
+	const { toolCall } = registerRuntimeHarness({ subagentMetadata: [] });
+	const ctx = createToolCallContext([
+		{ type: "custom", customType: PRIMARY_AGENT_SESSION_STATE_ENTRY, data: { selected: "architect" } },
+	]);
+	const resumeChainEvent = {
+		toolName: "subagent",
+		input: {
+			action: "resume",
+			id: "run-123",
+			message: "Continue the approved ticket.",
+			chain: [
+				{ agent: "repo-scout", task: "Refresh repo context" },
+				{ parallel: [{ agent: "librarian", task: "Research upstream issue history" }] },
+			],
+			timeoutMs: 420_000,
+		},
+	};
+	const listEvent = { toolName: "subagent", input: { action: "list", timeoutMs: 420_000 } };
+	const opaqueResumeEvent = {
+		toolName: "subagent",
+		input: { action: "resume", id: "run-456", message: "Continue the approved ticket.", timeoutMs: 420_000 },
+	};
+
+	assert.equal(await toolCall(resumeChainEvent, ctx), undefined);
+	assert.equal(resumeChainEvent.input.timeoutMs, LIBRARIAN_MAX_TIMEOUT_MS);
+	assert.equal(resumeChainEvent.input.agentScope, "user");
+	assert.equal(resumeChainEvent.input.context, "fresh");
+
+	assert.equal(await toolCall(listEvent, ctx), undefined);
+	assert.equal(listEvent.input.timeoutMs, 420_000);
+
+	assert.equal(await toolCall(opaqueResumeEvent, ctx), undefined);
+	assert.equal(opaqueResumeEvent.input.timeoutMs, 420_000);
 });
 
 test("enabled primary mode allows contrarian by default and stale contrarian settings stay harmless", async (t) => {


### PR DESCRIPTION
## Summary

- Enforce a five-minute maximum runtime for new `librarian` subagent executions while preserving stricter caller timeouts.
- Cover foreground, async, mixed-batch, and execution-bearing resume-chain calls; opaque management/resume calls remain unchanged.
- Document the run-level timeout behavior and add focused regression coverage.

Because the current subagent API exposes only a run-level timeout, a mixed batch containing `librarian` is capped as a whole.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/cap-librarian-runtime/install.sh | bash -s -- --ref cap-librarian-runtime --track ref
```
