### PR TITLE
Refresh managed dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.19.0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Check out tag
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.19.0'
 

--- a/.github/workflows/startup-performance.yml
+++ b/.github/workflows/startup-performance.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.19.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.9` to `npm:@diegopetrucci/pi-subagents@0.31.10`. This release adds per-agent acceptance roles (`acceptanceRole`) and a paused-resume acceptance contract, records paused/interrupted runs as `skipped` (not `rejected`) acceptance, never infers `reviewed` acceptance, gates idle "needs attention" notices on in-flight tool calls, and includes the upstream nicobailon/pi-subagents#514/#524 status-cache-invalidation and management-output-collapse intakes.
-- Bumped TLH's pinned private Pi/TUI runtime from 0.81.1 to 0.82.0, keeping debug and crash logs inside the isolated profile while picking up upstream model-matching, resource-discovery, catalog-refresh, and dependency-security fixes (including `protobufjs` 7.6.5).
+- Bumped TLH's pinned private Pi/TUI runtime from 0.81.1 to 0.82.1, keeping debug and crash logs inside the isolated profile while picking up upstream model-matching, resource-discovery, catalog-refresh, and dependency-security fixes (including `protobufjs` 7.6.5).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Backup files at the isolated-profile root (`settings.json.backup-*`, `keybinding
 
 Node.js >=22.19.0 must be available on your `PATH`.
 
-TLH runs its own pinned Pi 0.82.0 from a private runtime at `~/.the-last-harness/runtime` — a global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled.
+TLH runs its own pinned Pi 0.82.1 from a private runtime at `~/.the-last-harness/runtime` — a global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled.
 
 TLH also manages a pinned native RTK binary for shell-command rewriting at `~/.the-last-harness/agent/bin/rtk` on supported darwin/linux x64/arm64 platforms. Install and update hard-fail if that managed binary cannot be installed or validated. To disable rewriting without removing the binary, set `RTK_DISABLED=1` for a single launch or set `"tlh": { "rtk": { "disabled": true } }` in the isolated profile at `~/.the-last-harness/agent/settings.json`. To remove just the managed binary, delete `~/.the-last-harness/agent/bin/rtk`; to remove the whole isolated RTK/profile setup, remove `~/.the-last-harness` (or use the uninstall script).
 

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "openai-fast",
-    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.11",
+    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.12",
     "description": "Enable optional OpenAI Codex Fast mode commands for eligible ChatGPT-auth GPT-5.4/GPT-5.5 sessions."
   },
   {
@@ -31,29 +31,29 @@
   },
   {
     "id": "inline-bash",
-    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.6",
+    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.7",
     "description": "Expand inline bash commands in user prompts."
   },
   {
     "id": "notify",
-    "source": "npm:@diegopetrucci/pi-notify@0.1.12",
+    "source": "npm:@diegopetrucci/pi-notify@0.1.13",
     "description": "Send a notification when an agent turn finishes."
   },
   {
     "id": "context-inspector",
-    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.8",
+    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.9",
     "description": "Open a local HTML dashboard explaining where the current session context is going."
   },
   {
     "id": "quiet-tools",
     "aliases": ["compact-bash"],
     "replaces": ["npm:@diegopetrucci/pi-compact-bash"],
-    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.7",
+    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.8",
     "description": "Compact collapsed built-in tool output in the TUI without changing model-visible results."
   },
   {
     "id": "dirty-repo-guard",
-    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.6",
+    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.7",
     "description": "Prompt before session changes when the current git repo has uncommitted changes."
   },
   {

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-Requires Node.js >=22.19.0 on `PATH`. TLH always installs its own pinned Pi 0.82.0 into a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. Install or repair failures stop with an actionable error.
+Requires Node.js >=22.19.0 on `PATH`. TLH always installs its own pinned Pi 0.82.1 into a private runtime at `~/.the-last-harness/runtime` — a sibling of the isolated agent dir. A global or pre-installed `pi` on your PATH is never used or modified; tlh and any existing `pi` are fully decoupled. Install or repair failures stop with an actionable error.
 
 Run the one-liner:
 
@@ -76,7 +76,7 @@ curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v
 
 You can just run `tlh update`.
 
-This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. `tlh update` also repairs the private Pi runtime at `~/.the-last-harness/runtime` back to the pinned 0.82.0 when needed. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
+This refreshes the isolated checkout according to your update track and re-merges installer defaults. Latest-release installs move to the newest GitHub Release, pinned-tag installs stay on their pinned tag, and `main`/ref installs keep following that ref. `tlh update` also repairs the private Pi runtime at `~/.the-last-harness/runtime` back to the pinned 0.82.1 when needed. If you are updating from an older install without `tlh update`, rerun the latest-release installer once.
 
 If TLH starts with the notice ``TLH extension updates are available. Run `tlh update --extensions` to update them.``, that notice refers to isolated extension/package updates only. `tlh update --extensions` runs the upstream package refresh against the TLH profile without changing installer-managed checkout state, wrapper files, or update-track metadata. Installer-track and installer-owned options such as `--track`, `--ref`, `--repo`, `--package-source`, `--force`, `--no-settings`, and `--no-wrapper` require plain `tlh update` instead.
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ REPO="${TLH_REPO:-diegopetrucci/the-last-harness}"
 REF="${TLH_REF:-main}"
 # Keep in sync with MIN_NODE_VERSION and PINNED_PI_VERSION in scripts/tlh-install.mjs.
 TLH_MIN_NODE_VERSION="22.19.0"
-TLH_PINNED_PI_VERSION="0.82.0"
+TLH_PINNED_PI_VERSION="0.82.1"
 
 DRY_RUN=false
 NO_SETTINGS=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "monaco-editor": "0.56.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.82.0",
-        "@earendil-works/pi-tui": "0.82.0",
+        "@earendil-works/pi-coding-agent": "0.82.1",
+        "@earendil-works/pi-tui": "0.82.1",
         "@eslint/js": "10.0.1",
         "@types/node": "26.1.1",
         "eslint": "10.7.0",
@@ -29,8 +29,8 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": "0.82.0",
-        "@earendil-works/pi-tui": "0.82.0"
+        "@earendil-works/pi-coding-agent": "0.82.1",
+        "@earendil-works/pi-tui": "0.82.1"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -45,16 +45,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
-      "integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
+      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.82.0",
-        "@earendil-works/pi-ai": "^0.82.0",
-        "@earendil-works/pi-tui": "^0.82.0",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -544,12 +544,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.0",
+        "@earendil-works/pi-ai": "^0.82.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
@@ -560,8 +560,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -585,8 +585,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2004,9 +2004,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
-      "integrity": "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "0.82.0",
-    "@earendil-works/pi-tui": "0.82.0"
+    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@earendil-works/pi-tui": "0.82.1"
   },
   "dependencies": {
     "@tailwindcss/browser": "4.3.3",
@@ -82,8 +82,8 @@
     "monaco-editor": "0.56.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.82.0",
-    "@earendil-works/pi-tui": "0.82.0",
+    "@earendil-works/pi-coding-agent": "0.82.1",
+    "@earendil-works/pi-tui": "0.82.1",
     "@eslint/js": "10.0.1",
     "@types/node": "26.1.1",
     "eslint": "10.7.0",

--- a/scripts/installer-smoke/install-state-pi.sh
+++ b/scripts/installer-smoke/install-state-pi.sh
@@ -128,7 +128,7 @@ EOF_PRESENT_GIT
   # Seed a valid private runtime pi (pinned version) at the expected location.
   cat >"${present_runtime_bin}/pi" <<'EOF_PRESENT_RUNTIME_PI'
 #!/bin/sh
-if [ "${1:-}" = "--version" ]; then printf '0.82.0\n'; exit 0; fi
+if [ "${1:-}" = "--version" ]; then printf '0.82.1\n'; exit 0; fi
 printf 'fake private runtime pi invoked unexpectedly\n' >&2; exit 98
 EOF_PRESENT_RUNTIME_PI
   chmod +x "${present_runtime_bin}/pi"

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -17,7 +17,7 @@ import { formatSupportFileManifest, installableSupportFiles, supportFileManifest
 const DEFAULT_REPO = "diegopetrucci/the-last-harness";
 const DEFAULT_REF = "main";
 const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
-const PINNED_PI_VERSION = "0.82.0";
+const PINNED_PI_VERSION = "0.82.1";
 const PI_PACKAGE_SPEC = `${PI_PACKAGE_NAME}@${PINNED_PI_VERSION}`;
 // Keep in sync with TLH_MIN_NODE_VERSION and TLH_PINNED_PI_VERSION in install.sh.
 const MIN_NODE_VERSION = "22.19.0";
@@ -43,7 +43,7 @@ const VALID_UPDATE_TRACKS = ["latest-release", "pinned-tag", "ref", "custom"];
 const RUNTIME_MARKER_FILENAME = ".tlh-runtime-owned";
 const RUNTIME_MARKER_SCHEMA_VERSION = 1;
 // npm 11.x --prefix layout; empirically confirmed: npm 11.16.0 +
-// @earendil-works/pi-coding-agent@0.82.0.  Mirrors the advisory exclusivity
+// @earendil-works/pi-coding-agent@0.82.1.  Mirrors the advisory exclusivity
 // tripwire in uninstall.sh (demoted from gate): the only top-level entries a
 // TLH-owned runtime prefix should contain are those created by
 // npm install -g --ignore-scripts --prefix, plus the TLH runtime ownership
@@ -610,7 +610,7 @@ function writeRuntimeMarker(config, prefix, origin) {
     }
 }
 function assertSupportedPiVersion(config, { piCommand = "pi", sourceDescription = "existing pi on PATH", versionCommandDisplay = "pi --version", } = {}) {
-    // `pi --version` prints a bare semver (e.g. "0.82.0") on stdout. Older builds may
+    // `pi --version` prints a bare semver (e.g. "0.82.1") on stdout. Older builds may
     // differ, so we extract the first semver-shaped substring rather than match strictly.
     const result = spawnCapture(config, [piCommand, "--version"], {
         allowFailure: true,

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -75,7 +75,7 @@ import {
 const DEFAULT_REPO = "diegopetrucci/the-last-harness";
 const DEFAULT_REF = "main";
 const PI_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
-const PINNED_PI_VERSION = "0.82.0";
+const PINNED_PI_VERSION = "0.82.1";
 const PI_PACKAGE_SPEC = `${PI_PACKAGE_NAME}@${PINNED_PI_VERSION}`;
 // Keep in sync with TLH_MIN_NODE_VERSION and TLH_PINNED_PI_VERSION in install.sh.
 const MIN_NODE_VERSION = "22.19.0";
@@ -101,7 +101,7 @@ const VALID_UPDATE_TRACKS = ["latest-release", "pinned-tag", "ref", "custom"] as
 const RUNTIME_MARKER_FILENAME = ".tlh-runtime-owned";
 const RUNTIME_MARKER_SCHEMA_VERSION = 1;
 // npm 11.x --prefix layout; empirically confirmed: npm 11.16.0 +
-// @earendil-works/pi-coding-agent@0.82.0.  Mirrors the advisory exclusivity
+// @earendil-works/pi-coding-agent@0.82.1.  Mirrors the advisory exclusivity
 // tripwire in uninstall.sh (demoted from gate): the only top-level entries a
 // TLH-owned runtime prefix should contain are those created by
 // npm install -g --ignore-scripts --prefix, plus the TLH runtime ownership
@@ -803,7 +803,7 @@ function assertSupportedPiVersion(
 		versionCommandDisplay = "pi --version",
 	}: SupportedPiVersionOptions = {},
 ): void {
-	// `pi --version` prints a bare semver (e.g. "0.82.0") on stdout. Older builds may
+	// `pi --version` prints a bare semver (e.g. "0.82.1") on stdout. Older builds may
 	// differ, so we extract the first semver-shaped substring rather than match strictly.
 	const result = spawnCapture(config, [piCommand, "--version"], {
 		allowFailure: true,

--- a/tests/install-stage1-core-test-helpers.mjs
+++ b/tests/install-stage1-core-test-helpers.mjs
@@ -14,7 +14,7 @@ import { makeTempDir } from "./install-stage1-test-helpers.mjs";
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 export const repoNodeModulesBin = join(repoRoot, "node_modules", ".bin");
 export const TLH_NON_PINNED_PI_VERSION = "0.80.1";
-export const TLH_PINNED_PI_VERSION = "0.82.0";
+export const TLH_PINNED_PI_VERSION = "0.82.1";
 export const TLH_PI_PACKAGE_SPEC = `@earendil-works/pi-coding-agent@${TLH_PINNED_PI_VERSION}`;
 export const managedRtkSupportedTestPlatform =
 	["darwin", "linux"].includes(process.platform) && ["x64", "arm64"].includes(process.arch);

--- a/tests/install-stage1-runtime.test.mjs
+++ b/tests/install-stage1-runtime.test.mjs
@@ -444,7 +444,7 @@ test("stage-1 installPiIfNeeded: broken npm install (wrong pi version) throws", 
 });
 
 // Regression (tlht-5php, blocker): piInstalledByTlh=true, private runtime ABSENT at start,
-// user-owned ~/.local/bin/pi@0.82.0 present.  The installer must provision the private
+// user-owned ~/.local/bin/pi@0.82.1 present.  The installer must provision the private
 // runtime and succeed — without removing or executing ~/.local/bin/pi.
 test("stage-1 regression (tlht-5php): installer never removes or execs user-owned ~/.local/bin/pi when piInstalledByTlh=true and private runtime is absent", (t) => {
 	const root = makeTempDir();
@@ -480,7 +480,7 @@ test("stage-1 regression (tlht-5php): installer never removes or execs user-owne
 		piInstalledByTlh: true,
 	}, null, 2));
 
-	// User-owned ~/.local/bin/pi@0.82.0 — must NOT be removed or invoked by the installer.
+	// User-owned ~/.local/bin/pi@0.82.1 — must NOT be removed or invoked by the installer.
 	writeFakePi(legacyBin, [
 		`printf '%s\\n' "$*" >>"${legacyPiInvocationLog}"`,
 		`if [[ "\${1:-}" == "--version" ]]; then printf '${TLH_PINNED_PI_VERSION}\\n'; exit 0; fi`,
@@ -570,7 +570,7 @@ test("uninstall.sh does not remove legacy ~/.local/bin/pi without --force-includ
 	}, null, 2));
 
 	// User-owned legacy pi at ~/.local/bin/pi.
-	writeFileSync(join(legacyBin, "pi"), "#!/bin/sh\nprintf '0.82.0\\n'\n", "utf8");
+	writeFileSync(join(legacyBin, "pi"), "#!/bin/sh\nprintf '0.82.1\\n'\n", "utf8");
 	chmodSync(join(legacyBin, "pi"), 0o755);
 
 	// ── (d1) dry-run without --force-include-pi: hint printed, pi NOT removed ──

--- a/tests/install-stage1-wrapper-managed-bin-test-helpers.mjs
+++ b/tests/install-stage1-wrapper-managed-bin-test-helpers.mjs
@@ -61,7 +61,7 @@ export function setupTicketsEnabledWrapperFixture(t) {
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
 	writeFakePi(fakebin, [
-		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.82.0\\n'; exit 0; fi",
+		"if [[ \"${1:-}\" == \"--version\" ]]; then printf '0.82.1\\n'; exit 0; fi",
 		"printf 'path=%s\\n' \"${PATH:-}\" >\"${PI_WRAPPER_LOG}\"",
 	].join("\n"));
 

--- a/tests/install-stage1-wrapper.test.mjs
+++ b/tests/install-stage1-wrapper.test.mjs
@@ -1038,10 +1038,10 @@ test("wrapper update --extensions helper prepends the pinned private runtime dir
 	mkdirSync(cwdDir, { recursive: true });
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 
-	// Pinned pi at 0.82.0 — still prepended for --extensions.
+	// Pinned pi at 0.82.1 — still prepended for --extensions.
 	writeFakePi(pinnedPiDir, [
 		`printf '%s\\n' "$*" >>"${pinnedPiCallLog}"`,
-		`if [[ "\${1:-}" == "--version" ]]; then printf '0.82.0\\n'; exit 0; fi`,
+		`if [[ "\${1:-}" == "--version" ]]; then printf '0.82.1\\n'; exit 0; fi`,
 		"exit 85",
 	].join("\n"));
 	writeFileSync(join(agentDir, "tlh", "recover-update.mjs"), `import { spawnSync } from "node:child_process";\nimport { writeFileSync } from "node:fs";\nconst pi = spawnSync("pi", ["--version"], { encoding: "utf8" });\nwriteFileSync(process.env.TLH_UPDATE_LOG, JSON.stringify({ argv: process.argv.slice(2), env: { PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR, PATH: process.env.PATH }, pi: { status: pi.status, stdout: pi.stdout, stderr: pi.stderr, error: pi.error?.message } }));\nprocess.exit(pi.status ?? (pi.error ? 1 : 0));\n`, "utf8");

--- a/tests/package-runtime-smoke-runner.mjs
+++ b/tests/package-runtime-smoke-runner.mjs
@@ -10,7 +10,7 @@ assert.ok(packageRoot && cwd && agentDir, "usage: package-runtime-smoke-runner.m
 
 const piEntryPath = fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"));
 const piPackage = JSON.parse(readFileSync(join(dirname(piEntryPath), "..", "package.json"), "utf8"));
-assert.equal(piPackage.version, "0.82.0");
+assert.equal(piPackage.version, "0.82.1");
 
 const settingsManager = SettingsManager.create(cwd, agentDir);
 const resourceLoader = new DefaultResourceLoader({

--- a/tests/package-runtime-smoke.test.mjs
+++ b/tests/package-runtime-smoke.test.mjs
@@ -51,7 +51,7 @@ function isolatedEnv(root, agentDir) {
 	};
 }
 
-test("packed TLH generated JavaScript loads and reloads through pinned Pi 0.82.0", (t) => {
+test("packed TLH generated JavaScript loads and reloads through pinned Pi 0.82.1", (t) => {
 	const root = mkdtempSync(join(tmpdir(), "tlh-package-runtime-smoke-"));
 	const binDir = join(root, "bin");
 	const packDir = join(root, "pack");
@@ -107,8 +107,8 @@ test("packed TLH generated JavaScript loads and reloads through pinned Pi 0.82.0
 	const packageRoot = join(extractDir, "package");
 	const packedManifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
 	assert.deepEqual(packedManifest.pi.extensions, expectedEntrypoints);
-	assert.equal(packedManifest.peerDependencies["@earendil-works/pi-coding-agent"], "0.82.0");
-	assert.equal(packedManifest.peerDependencies["@earendil-works/pi-tui"], "0.82.0");
+	assert.equal(packedManifest.peerDependencies["@earendil-works/pi-coding-agent"], "0.82.1");
+	assert.equal(packedManifest.peerDependencies["@earendil-works/pi-tui"], "0.82.1");
 
 	// npm pack intentionally excludes installed dependencies. Link the checkout's already-pinned,
 	// offline node_modules into the disposable package so Pi can execute the packed artifact.
@@ -121,7 +121,7 @@ test("packed TLH generated JavaScript loads and reloads through pinned Pi 0.82.0
 	});
 	assert.equal(runtimeResult.status, 0, runtimeResult.stderr || runtimeResult.stdout);
 	const runtimeEvidence = JSON.parse(runtimeResult.stdout.trim());
-	assert.equal(runtimeEvidence.piVersion, "0.82.0");
+	assert.equal(runtimeEvidence.piVersion, "0.82.1");
 	assert.deepEqual(runtimeEvidence.entrypoints, expectedEntrypoints.map((path) => path.slice(2)));
 	assert.equal(runtimeEvidence.factoryExecutions, 2);
 	assert.ok(runtimeEvidence.changelogBytes > 1000);

--- a/tests/tlh-doctor.test.mjs
+++ b/tests/tlh-doctor.test.mjs
@@ -65,7 +65,7 @@ function configureHealthyFixture(t) {
 
 	const runtimeBin = join(fixture.runtimeDir, "bin");
 	mkdirSync(runtimeBin, { recursive: true });
-	writeExecutable(join(runtimeBin, "pi"), "#!/bin/sh\necho 'pi 0.82.0'\n");
+	writeExecutable(join(runtimeBin, "pi"), "#!/bin/sh\necho 'pi 0.82.1'\n");
 	writeFileSync(join(fixture.runtimeDir, ".tlh-runtime-owned"), JSON.stringify({
 		schemaVersion: 1,
 		packageName: "@earendil-works/pi-coding-agent",


### PR DESCRIPTION
## Summary

- bump the isolated Pi/TUI runtime and synchronized installer pins to 0.82.1
- refresh six bundled default-extension pins and update the dependency lockfile
- upgrade checkout/setup-node workflows from v5 to v7

## Change type

- [x] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed locally. Targeted package-version, runtime-freshness, installer, bundled-extension, and workflow-YAML checks also passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/refresh-managed-dependencies/install.sh | bash -s -- --ref chore/refresh-managed-dependencies --track ref
```
