### PR TITLE
Refresh newly published extension pins

### DIFF
--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "openai-fast",
-    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.12",
+    "source": "npm:@diegopetrucci/pi-openai-fast@0.1.13",
     "description": "Enable optional OpenAI Codex Fast mode commands for eligible ChatGPT-auth GPT-5.4/GPT-5.5 sessions."
   },
   {
@@ -14,7 +14,7 @@
     "aliases": ["pi-mcp-adapter", "mcp-adapter"],
     "replaces": ["npm:pi-mcp-adapter", "git:github.com/diegopetrucci/pi-mcp-adapter@tlh-v2.10.0-1"],
     "migrateReplacements": true,
-    "source": "npm:@diegopetrucci/pi-mcp-adapter@2.10.2",
+    "source": "npm:@diegopetrucci/pi-mcp-adapter@2.11.0",
     "description": "Connect tlh to MCP servers with the upstream adapter."
   },
   {
@@ -31,29 +31,29 @@
   },
   {
     "id": "inline-bash",
-    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.7",
+    "source": "npm:@diegopetrucci/pi-inline-bash@0.1.8",
     "description": "Expand inline bash commands in user prompts."
   },
   {
     "id": "notify",
-    "source": "npm:@diegopetrucci/pi-notify@0.1.13",
+    "source": "npm:@diegopetrucci/pi-notify@0.1.14",
     "description": "Send a notification when an agent turn finishes."
   },
   {
     "id": "context-inspector",
-    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.9",
+    "source": "npm:@diegopetrucci/pi-context-inspector@0.1.10",
     "description": "Open a local HTML dashboard explaining where the current session context is going."
   },
   {
     "id": "quiet-tools",
     "aliases": ["compact-bash"],
     "replaces": ["npm:@diegopetrucci/pi-compact-bash"],
-    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.8",
+    "source": "npm:@diegopetrucci/pi-quiet-tools@0.1.9",
     "description": "Compact collapsed built-in tool output in the TUI without changing model-visible results."
   },
   {
     "id": "dirty-repo-guard",
-    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.7",
+    "source": "npm:@diegopetrucci/pi-dirty-repo-guard@0.1.8",
     "description": "Prompt before session changes when the current git repo has uncommitted changes."
   },
   {


### PR DESCRIPTION
## Summary

Follow up on #399 by advancing seven bundled `@diegopetrucci/pi-*` extension pins to their newly published npm stable releases.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Result: passed locally. `npm run check:package-versions` and all 44 default-extension tests also passed. Each changed pin was verified against npm's `latest` dist-tag.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/refresh-extension-pins-follow-up/install.sh | bash -s -- --ref chore/refresh-extension-pins-follow-up --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled extension packages to newer versions.
  * Included improvements to OpenAI integration, MCP connectivity, and several UI and tooling extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->