### PR TITLE
Add tool-friction audit and guard RTK find rewrites

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ scripts/tlh-install.mjs linguist-generated=true
 scripts/tlh-recover-update.mjs linguist-generated=true
 scripts/tlh-rtk.mjs linguist-generated=true
 scripts/tlh-tickets.mjs linguist-generated=true
+scripts/tlh-tool-friction-audit.mjs linguist-generated=true
 scripts/tlh-update.mjs linguist-generated=true
 scripts/tlh-wrapper.mjs linguist-generated=true
 extensions/annotate-git-diff/clipboard.js linguist-generated=true

--- a/extensions/rtk.js
+++ b/extensions/rtk.js
@@ -48,6 +48,20 @@ function describeUnusableRtk(probe, label) {
     }
     return `${label} is unavailable`;
 }
+function containsNativeFindCommandToken(cmd) {
+    return /(?:^|[\s;&|])find(?=\s|$)/.test(cmd);
+}
+function hasUnsupportedNativeFindConstruct(cmd) {
+    if (!containsNativeFindCommandToken(cmd))
+        return false;
+    return [
+        /(?:^|\s)-(?:a|and|not|o|or)(?=\s|$)/,
+        /(?:^|\s)!(?=\s|$)/,
+        /(?:^|\s),(?=\s|$)/,
+        /(?:^|\s)(?:\\\(|\\\)|\(|\))(?=\s|$)/,
+        /(?:^|\s)-(?:delete|exec|execdir|fls|fprint|fprint0|fprintf|ls|ok|okdir|print|print0|printf|prune|quit)(?=\s|$)/,
+    ].some((pattern) => pattern.test(cmd));
+}
 async function resolveRtkCommand(pi) {
     const pathProbe = await probeRtkCommand(pi, "rtk");
     if (pathProbe.ok) {
@@ -100,6 +114,8 @@ export default async function rtk(pi) {
                 if (process.env.RTK_DISABLED === "1")
                     return;
                 if (isRtkSettingDisabled(ctx.cwd))
+                    return;
+                if (hasUnsupportedNativeFindConstruct(cmd))
                     return;
                 const rewritten = await rewriteCommand(pi, rtkCommand, cmd, ctx.signal);
                 if (rewritten && rewritten !== cmd) {

--- a/extensions/rtk.ts
+++ b/extensions/rtk.ts
@@ -97,6 +97,22 @@ function describeUnusableRtk(probe: FailedRtkCommandProbeResult, label: string):
 	return `${label} is unavailable`;
 }
 
+function containsNativeFindCommandToken(cmd: string): boolean {
+	return /(?:^|[\s;&|])find(?=\s|$)/.test(cmd);
+}
+
+function hasUnsupportedNativeFindConstruct(cmd: string): boolean {
+	if (!containsNativeFindCommandToken(cmd)) return false;
+
+	return [
+		/(?:^|\s)-(?:a|and|not|o|or)(?=\s|$)/,
+		/(?:^|\s)!(?=\s|$)/,
+		/(?:^|\s),(?=\s|$)/,
+		/(?:^|\s)(?:\\\(|\\\)|\(|\))(?=\s|$)/,
+		/(?:^|\s)-(?:delete|exec|execdir|fls|fprint|fprint0|fprintf|ls|ok|okdir|print|print0|printf|prune|quit)(?=\s|$)/,
+	].some((pattern) => pattern.test(cmd));
+}
+
 async function resolveRtkCommand(pi: ExtensionAPI): Promise<string | null> {
 	const pathProbe = await probeRtkCommand(pi, "rtk");
 	if (pathProbe.ok) {
@@ -160,6 +176,8 @@ export default async function rtk(pi: ExtensionAPI): Promise<void> {
 				if (cmd === "rtk" || cmd.startsWith("rtk ")) return;
 				if (process.env.RTK_DISABLED === "1") return;
 				if (isRtkSettingDisabled(ctx.cwd)) return;
+
+				if (hasUnsupportedNativeFindConstruct(cmd)) return;
 
 				// Delegate to RTK.
 				const rewritten = await rewriteCommand(pi, rtkCommand, cmd, ctx.signal);

--- a/scripts/tlh-tool-friction-audit.mjs
+++ b/scripts/tlh-tool-friction-audit.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { discoverSessionFiles, parseSessionJsonl } from "../extensions/the-last-harness/session-limit-report-scan.js";
+export const LARGE_OUTPUT_THRESHOLD_CHARACTERS = 50_000;
+const RATE_DENOMINATOR_LABEL = "per-1000-tool-results";
+const RATE_DENOMINATOR_MULTIPLIER = 1_000;
+export const PATH_MISS_ERROR_RE = /ENOENT|Path not found|Search path .* is not a directory|No such file or directory/i;
+export const EDIT_NON_UNIQUE_RE = /Found \d+ occurrences/i;
+export const EDIT_VALIDATION_RE = /Validation failed for tool "edit"/i;
+export const EDIT_NOT_FOUND_RE = /Could not find the exact text/i;
+export const MISSING_PYTHON_ERROR_RE = /python(?:3)?: (?:command )?not found|command not found: python\b/i;
+export const INVALID_REGEX_ERROR_RE = /regex parse error|invalid regex|invalid regular expression/i;
+export const UNSUPPORTED_COMPOUND_FIND_ERROR_RE = /rtk: rtk find does not support compound predicates or actions/i;
+export async function auditToolFriction(options) {
+    const window = resolveAuditWindow(options.startIso, options.endIso);
+    const sessionRoots = options.sessionRoots.map((root) => resolve(root));
+    if (sessionRoots.length === 0) {
+        throw new Error("At least one --session-root is required.");
+    }
+    const seenFingerprints = new Set();
+    const uniqueFiles = new Set();
+    const toolBreakdown = new Map();
+    const counts = {
+        pathMisses: 0,
+        editFailures: 0,
+        missingPython: 0,
+        invalidRegex: 0,
+        unsupportedCompoundFind: 0,
+        largeOutput: 0,
+    };
+    const editSubtypeCounts = {
+        "non-unique": 0,
+        validation: 0,
+        "not-found": 0,
+    };
+    let filesParsed = 0;
+    let parseFailures = 0;
+    let discoveryCaveatCount = 0;
+    let malformedLines = 0;
+    let rawInWindow = 0;
+    let uniqueInWindow = 0;
+    let errorResults = 0;
+    let duplicateLogicalResultsSkipped = 0;
+    let largeOutputTotalCharacters = 0;
+    let largeOutputTotalUtf8Bytes = 0;
+    let largeOutputMaxCharacters = 0;
+    let largeOutputMaxUtf8Bytes = 0;
+    for (const sessionRoot of sessionRoots) {
+        // Explicit ISO bounds are the source of truth for inclusion. Avoid mtime pruning so
+        // copied/exported session trees with stale mtimes are still audited deterministically.
+        const discovered = discoverSessionFiles(sessionRoot, 0);
+        discoveryCaveatCount += discovered.caveats.length;
+        for (const filePath of discovered.files) {
+            uniqueFiles.add(filePath);
+        }
+    }
+    const discoveredFiles = [...uniqueFiles].sort((a, b) => a.localeCompare(b));
+    for (const filePath of discoveredFiles) {
+        let parsed;
+        try {
+            parsed = await parseSessionJsonl(filePath);
+        }
+        catch {
+            parseFailures += 1;
+            continue;
+        }
+        filesParsed += 1;
+        malformedLines += parsed.malformedLineCount;
+        for (const entry of parsed.entries) {
+            const toolResult = getToolResultView(entry);
+            if (!toolResult) {
+                continue;
+            }
+            const entryMs = Date.parse(toolResult.timestamp);
+            if (!Number.isFinite(entryMs) || entryMs < window.startMs || entryMs > window.endMs) {
+                continue;
+            }
+            rawInWindow += 1;
+            const fingerprint = createResultFingerprint(toolResult);
+            if (seenFingerprints.has(fingerprint)) {
+                duplicateLogicalResultsSkipped += 1;
+                continue;
+            }
+            seenFingerprints.add(fingerprint);
+            uniqueInWindow += 1;
+            const toolCounts = getOrCreateToolBreakdown(toolBreakdown, toolResult.toolName);
+            toolCounts.uniqueToolResults += 1;
+            if (toolResult.isError) {
+                errorResults += 1;
+                toolCounts.errorToolResults += 1;
+            }
+            if (toolResult.isError && PATH_MISS_ERROR_RE.test(toolResult.joinedText)) {
+                counts.pathMisses += 1;
+                toolCounts.pathMisses += 1;
+            }
+            if (toolResult.isError && toolResult.toolName === "edit") {
+                const editSubtype = classifyEditFailureSubtype(toolResult.joinedText);
+                if (editSubtype) {
+                    counts.editFailures += 1;
+                    editSubtypeCounts[editSubtype] += 1;
+                    toolCounts.editFailures += 1;
+                }
+            }
+            if (toolResult.isError && MISSING_PYTHON_ERROR_RE.test(toolResult.joinedText)) {
+                counts.missingPython += 1;
+                toolCounts.missingPython += 1;
+            }
+            if (toolResult.isError && INVALID_REGEX_ERROR_RE.test(toolResult.joinedText)) {
+                counts.invalidRegex += 1;
+                toolCounts.invalidRegex += 1;
+            }
+            if (toolResult.isError && UNSUPPORTED_COMPOUND_FIND_ERROR_RE.test(toolResult.joinedText)) {
+                counts.unsupportedCompoundFind += 1;
+                toolCounts.unsupportedCompoundFind += 1;
+            }
+            const characterCount = toolResult.joinedText.length;
+            if (characterCount >= LARGE_OUTPUT_THRESHOLD_CHARACTERS) {
+                const utf8Bytes = Buffer.byteLength(toolResult.joinedText, "utf8");
+                counts.largeOutput += 1;
+                toolCounts.largeOutput += 1;
+                largeOutputTotalCharacters += characterCount;
+                largeOutputTotalUtf8Bytes += utf8Bytes;
+                largeOutputMaxCharacters = Math.max(largeOutputMaxCharacters, characterCount);
+                largeOutputMaxUtf8Bytes = Math.max(largeOutputMaxUtf8Bytes, utf8Bytes);
+            }
+        }
+    }
+    const result = {
+        schemaVersion: 1,
+        window: {
+            startIso: new Date(window.startMs).toISOString(),
+            endIso: new Date(window.endMs).toISOString(),
+            inclusive: true,
+        },
+        inputs: {
+            sessionRootCount: sessionRoots.length,
+        },
+        scan: {
+            filesDiscovered: discoveredFiles.length,
+            filesParsed,
+            parseFailures,
+            discoveryCaveatCount,
+            malformedLines,
+        },
+        toolResults: {
+            rawInWindow,
+            uniqueInWindow,
+            duplicateLogicalResultsSkipped,
+            errorResults,
+            rateDenominator: {
+                label: RATE_DENOMINATOR_LABEL,
+                multiplier: RATE_DENOMINATOR_MULTIPLIER,
+            },
+        },
+        friction: {
+            pathMisses: buildBreakdown(counts.pathMisses, uniqueInWindow),
+            editFailures: {
+                ...buildBreakdown(counts.editFailures, uniqueInWindow),
+                subtypes: {
+                    "non-unique": buildBreakdown(editSubtypeCounts["non-unique"], uniqueInWindow),
+                    validation: buildBreakdown(editSubtypeCounts.validation, uniqueInWindow),
+                    "not-found": buildBreakdown(editSubtypeCounts["not-found"], uniqueInWindow),
+                },
+            },
+            missingPython: buildBreakdown(counts.missingPython, uniqueInWindow),
+            invalidRegex: buildBreakdown(counts.invalidRegex, uniqueInWindow),
+            unsupportedCompoundFind: buildBreakdown(counts.unsupportedCompoundFind, uniqueInWindow),
+            largeOutput: {
+                ...buildBreakdown(counts.largeOutput, uniqueInWindow),
+                thresholdCharacters: LARGE_OUTPUT_THRESHOLD_CHARACTERS,
+                thresholdLabel: "50,000 characters",
+                totalCharacters: largeOutputTotalCharacters,
+                totalUtf8Bytes: largeOutputTotalUtf8Bytes,
+                maxCharacters: largeOutputMaxCharacters,
+                maxUtf8Bytes: largeOutputMaxUtf8Bytes,
+            },
+        },
+        toolBreakdown: [...toolBreakdown.values()].sort((left, right) => {
+            if (right.uniqueToolResults !== left.uniqueToolResults) {
+                return right.uniqueToolResults - left.uniqueToolResults;
+            }
+            return left.toolName.localeCompare(right.toolName);
+        }),
+    };
+    return result;
+}
+function resolveAuditWindow(startIso, endIso) {
+    const startMs = Date.parse(startIso);
+    if (!Number.isFinite(startMs)) {
+        throw new Error(`Invalid --start ISO timestamp: ${startIso}`);
+    }
+    const endMs = Date.parse(endIso);
+    if (!Number.isFinite(endMs)) {
+        throw new Error(`Invalid --end ISO timestamp: ${endIso}`);
+    }
+    if (startMs > endMs) {
+        throw new Error("--start must be less than or equal to --end.");
+    }
+    return { startMs, endMs };
+}
+function buildBreakdown(count, toolResultsDenominator) {
+    return {
+        count,
+        ratePer1000ToolResults: toolResultsDenominator > 0 ? Number(((count / toolResultsDenominator) * 1_000).toFixed(2)) : 0,
+        toolResultsDenominator,
+    };
+}
+function classifyEditFailureSubtype(joinedText) {
+    if (EDIT_NON_UNIQUE_RE.test(joinedText)) {
+        return "non-unique";
+    }
+    if (EDIT_VALIDATION_RE.test(joinedText)) {
+        return "validation";
+    }
+    if (EDIT_NOT_FOUND_RE.test(joinedText)) {
+        return "not-found";
+    }
+    return null;
+}
+function createResultFingerprint(toolResult) {
+    return createHash("sha256")
+        .update(toolResult.timestamp)
+        .update("\u0000")
+        .update(toolResult.toolName)
+        .update("\u0000")
+        .update(String(toolResult.isError))
+        .update("\u0000")
+        .update(toolResult.joinedText)
+        .digest("hex");
+}
+function getOrCreateToolBreakdown(toolBreakdown, toolName) {
+    let counts = toolBreakdown.get(toolName);
+    if (counts) {
+        return counts;
+    }
+    counts = {
+        toolName,
+        uniqueToolResults: 0,
+        errorToolResults: 0,
+        pathMisses: 0,
+        editFailures: 0,
+        missingPython: 0,
+        invalidRegex: 0,
+        unsupportedCompoundFind: 0,
+        largeOutput: 0,
+    };
+    toolBreakdown.set(toolName, counts);
+    return counts;
+}
+function getToolResultView(entry) {
+    if (entry.type !== "message") {
+        return null;
+    }
+    const message = entry.message;
+    if (!isRecord(message) || message.role !== "toolResult") {
+        return null;
+    }
+    if (typeof entry.timestamp !== "string") {
+        return null;
+    }
+    return {
+        timestamp: entry.timestamp,
+        toolName: typeof message.toolName === "string" && message.toolName.length > 0 ? message.toolName : "unknown",
+        isError: message.isError === true,
+        joinedText: joinToolResultText(message.content),
+    };
+}
+function joinToolResultText(content) {
+    if (typeof content === "string") {
+        return content;
+    }
+    if (!Array.isArray(content)) {
+        return "";
+    }
+    return content
+        .map((part) => {
+        if (typeof part === "string") {
+            return part;
+        }
+        if (isRecord(part) && typeof part.text === "string") {
+            return part.text;
+        }
+        return "";
+    })
+        .filter((part) => part.length > 0)
+        .join("\n");
+}
+function isRecord(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function usage() {
+    return [
+        "Usage: node scripts/tlh-tool-friction-audit.mjs --session-root <path> [--session-root <path> ...] --start <iso> --end <iso>",
+        "",
+        "Audit aggregate TLH tool-friction counts across exported session JSONL roots.",
+        "",
+        "Options:",
+        "  --session-root <path>  Session root to scan (repeatable, required)",
+        "  --start <iso>          Inclusive ISO-8601 lower bound (required)",
+        "  --end <iso>            Inclusive ISO-8601 upper bound (required)",
+        "  -h, --help             Show this help",
+    ].join("\n");
+}
+export function parseArgs(argv) {
+    const args = {
+        sessionRoots: [],
+        startIso: "",
+        endIso: "",
+        help: false,
+    };
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === "-h" || arg === "--help") {
+            args.help = true;
+            continue;
+        }
+        if (arg === "--session-root") {
+            args.sessionRoots.push(readRequiredValue(argv, ++index, arg));
+            continue;
+        }
+        if (arg.startsWith("--session-root=")) {
+            const value = arg.slice("--session-root=".length);
+            if (!value) {
+                throw new Error("--session-root requires a value");
+            }
+            args.sessionRoots.push(value);
+            continue;
+        }
+        if (arg === "--start") {
+            args.startIso = readRequiredValue(argv, ++index, arg);
+            continue;
+        }
+        if (arg.startsWith("--start=")) {
+            args.startIso = arg.slice("--start=".length);
+            if (!args.startIso) {
+                throw new Error("--start requires a value");
+            }
+            continue;
+        }
+        if (arg === "--end") {
+            args.endIso = readRequiredValue(argv, ++index, arg);
+            continue;
+        }
+        if (arg.startsWith("--end=")) {
+            args.endIso = arg.slice("--end=".length);
+            if (!args.endIso) {
+                throw new Error("--end requires a value");
+            }
+            continue;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+    if (!args.help) {
+        if (args.sessionRoots.length === 0) {
+            throw new Error("At least one --session-root is required.");
+        }
+        if (!args.startIso) {
+            throw new Error("--start is required.");
+        }
+        if (!args.endIso) {
+            throw new Error("--end is required.");
+        }
+    }
+    return args;
+}
+function readRequiredValue(argv, index, flag) {
+    const value = argv[index];
+    if (!value) {
+        throw new Error(`${flag} requires a value`);
+    }
+    return value;
+}
+export async function runCli(argv) {
+    try {
+        const args = parseArgs(argv);
+        if (args.help) {
+            process.stdout.write(`${usage()}\n`);
+            return 0;
+        }
+        const result = await auditToolFriction(args);
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        return 0;
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`${message}\n\n${usage()}\n`);
+        return 1;
+    }
+}
+const invokedPath = process.argv[1];
+if (invokedPath && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+    const exitCode = await runCli(process.argv.slice(2));
+    if (exitCode !== 0) {
+        process.exitCode = exitCode;
+    }
+}

--- a/scripts/tlh-tool-friction-audit.mts
+++ b/scripts/tlh-tool-friction-audit.mts
@@ -1,0 +1,530 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { discoverSessionFiles, parseSessionJsonl, type RawSessionEntry } from "../extensions/the-last-harness/session-limit-report-scan.js";
+
+export const LARGE_OUTPUT_THRESHOLD_CHARACTERS = 50_000;
+const RATE_DENOMINATOR_LABEL = "per-1000-tool-results";
+const RATE_DENOMINATOR_MULTIPLIER = 1_000;
+
+export const PATH_MISS_ERROR_RE = /ENOENT|Path not found|Search path .* is not a directory|No such file or directory/i;
+export const EDIT_NON_UNIQUE_RE = /Found \d+ occurrences/i;
+export const EDIT_VALIDATION_RE = /Validation failed for tool "edit"/i;
+export const EDIT_NOT_FOUND_RE = /Could not find the exact text/i;
+export const MISSING_PYTHON_ERROR_RE = /python(?:3)?: (?:command )?not found|command not found: python\b/i;
+export const INVALID_REGEX_ERROR_RE = /regex parse error|invalid regex|invalid regular expression/i;
+export const UNSUPPORTED_COMPOUND_FIND_ERROR_RE = /rtk: rtk find does not support compound predicates or actions/i;
+
+export type ToolFrictionEditSubtype = "non-unique" | "validation" | "not-found";
+export type ToolFrictionClassKey =
+	| "pathMisses"
+	| "editFailures"
+	| "missingPython"
+	| "invalidRegex"
+	| "unsupportedCompoundFind"
+	| "largeOutput";
+
+export type ToolFrictionAuditOptions = {
+	sessionRoots: string[];
+	startIso: string;
+	endIso: string;
+};
+
+export type ToolFrictionRate = {
+	count: number;
+	ratePer1000ToolResults: number;
+};
+
+export type ToolFrictionBreakdown = ToolFrictionRate & {
+	toolResultsDenominator: number;
+};
+
+export type ToolFrictionToolBreakdown = {
+	toolName: string;
+	uniqueToolResults: number;
+	errorToolResults: number;
+	pathMisses: number;
+	editFailures: number;
+	missingPython: number;
+	invalidRegex: number;
+	unsupportedCompoundFind: number;
+	largeOutput: number;
+};
+
+export type ToolFrictionAuditResult = {
+	schemaVersion: 1;
+	window: {
+		startIso: string;
+		endIso: string;
+		inclusive: true;
+	};
+	inputs: {
+		sessionRootCount: number;
+	};
+	scan: {
+		filesDiscovered: number;
+		filesParsed: number;
+		parseFailures: number;
+		discoveryCaveatCount: number;
+		malformedLines: number;
+	};
+	toolResults: {
+		rawInWindow: number;
+		uniqueInWindow: number;
+		duplicateLogicalResultsSkipped: number;
+		errorResults: number;
+		rateDenominator: {
+			label: typeof RATE_DENOMINATOR_LABEL;
+			multiplier: typeof RATE_DENOMINATOR_MULTIPLIER;
+		};
+	};
+	friction: {
+		pathMisses: ToolFrictionBreakdown;
+		editFailures: ToolFrictionBreakdown & {
+			subtypes: Record<ToolFrictionEditSubtype, ToolFrictionBreakdown>;
+		};
+		missingPython: ToolFrictionBreakdown;
+		invalidRegex: ToolFrictionBreakdown;
+		unsupportedCompoundFind: ToolFrictionBreakdown;
+		largeOutput: ToolFrictionBreakdown & {
+			thresholdCharacters: typeof LARGE_OUTPUT_THRESHOLD_CHARACTERS;
+			thresholdLabel: "50,000 characters";
+			totalCharacters: number;
+			totalUtf8Bytes: number;
+			maxCharacters: number;
+			maxUtf8Bytes: number;
+		};
+	};
+	toolBreakdown: ToolFrictionToolBreakdown[];
+};
+
+type ToolResultView = {
+	timestamp: string;
+	toolName: string;
+	isError: boolean;
+	joinedText: string;
+};
+
+type MutableToolFrictionToolBreakdown = ToolFrictionToolBreakdown;
+
+type ParsedCliArgs = ToolFrictionAuditOptions & {
+	help: boolean;
+};
+
+export async function auditToolFriction(options: ToolFrictionAuditOptions): Promise<ToolFrictionAuditResult> {
+	const window = resolveAuditWindow(options.startIso, options.endIso);
+	const sessionRoots = options.sessionRoots.map((root) => resolve(root));
+	if (sessionRoots.length === 0) {
+		throw new Error("At least one --session-root is required.");
+	}
+
+	const seenFingerprints = new Set<string>();
+	const uniqueFiles = new Set<string>();
+	const toolBreakdown = new Map<string, MutableToolFrictionToolBreakdown>();
+	const counts: Record<ToolFrictionClassKey, number> = {
+		pathMisses: 0,
+		editFailures: 0,
+		missingPython: 0,
+		invalidRegex: 0,
+		unsupportedCompoundFind: 0,
+		largeOutput: 0,
+	};
+	const editSubtypeCounts: Record<ToolFrictionEditSubtype, number> = {
+		"non-unique": 0,
+		validation: 0,
+		"not-found": 0,
+	};
+	let filesParsed = 0;
+	let parseFailures = 0;
+	let discoveryCaveatCount = 0;
+	let malformedLines = 0;
+	let rawInWindow = 0;
+	let uniqueInWindow = 0;
+	let errorResults = 0;
+	let duplicateLogicalResultsSkipped = 0;
+	let largeOutputTotalCharacters = 0;
+	let largeOutputTotalUtf8Bytes = 0;
+	let largeOutputMaxCharacters = 0;
+	let largeOutputMaxUtf8Bytes = 0;
+
+	for (const sessionRoot of sessionRoots) {
+		// Explicit ISO bounds are the source of truth for inclusion. Avoid mtime pruning so
+		// copied/exported session trees with stale mtimes are still audited deterministically.
+		const discovered = discoverSessionFiles(sessionRoot, 0);
+		discoveryCaveatCount += discovered.caveats.length;
+		for (const filePath of discovered.files) {
+			uniqueFiles.add(filePath);
+		}
+	}
+
+	const discoveredFiles = [...uniqueFiles].sort((a, b) => a.localeCompare(b));
+	for (const filePath of discoveredFiles) {
+		let parsed;
+		try {
+			parsed = await parseSessionJsonl(filePath);
+		} catch {
+			parseFailures += 1;
+			continue;
+		}
+		filesParsed += 1;
+		malformedLines += parsed.malformedLineCount;
+
+		for (const entry of parsed.entries) {
+			const toolResult = getToolResultView(entry);
+			if (!toolResult) {
+				continue;
+			}
+			const entryMs = Date.parse(toolResult.timestamp);
+			if (!Number.isFinite(entryMs) || entryMs < window.startMs || entryMs > window.endMs) {
+				continue;
+			}
+			rawInWindow += 1;
+
+			const fingerprint = createResultFingerprint(toolResult);
+			if (seenFingerprints.has(fingerprint)) {
+				duplicateLogicalResultsSkipped += 1;
+				continue;
+			}
+			seenFingerprints.add(fingerprint);
+			uniqueInWindow += 1;
+
+			const toolCounts = getOrCreateToolBreakdown(toolBreakdown, toolResult.toolName);
+			toolCounts.uniqueToolResults += 1;
+			if (toolResult.isError) {
+				errorResults += 1;
+				toolCounts.errorToolResults += 1;
+			}
+
+			if (toolResult.isError && PATH_MISS_ERROR_RE.test(toolResult.joinedText)) {
+				counts.pathMisses += 1;
+				toolCounts.pathMisses += 1;
+			}
+
+			if (toolResult.isError && toolResult.toolName === "edit") {
+				const editSubtype = classifyEditFailureSubtype(toolResult.joinedText);
+				if (editSubtype) {
+					counts.editFailures += 1;
+					editSubtypeCounts[editSubtype] += 1;
+					toolCounts.editFailures += 1;
+				}
+			}
+
+			if (toolResult.isError && MISSING_PYTHON_ERROR_RE.test(toolResult.joinedText)) {
+				counts.missingPython += 1;
+				toolCounts.missingPython += 1;
+			}
+
+			if (toolResult.isError && INVALID_REGEX_ERROR_RE.test(toolResult.joinedText)) {
+				counts.invalidRegex += 1;
+				toolCounts.invalidRegex += 1;
+			}
+
+			if (toolResult.isError && UNSUPPORTED_COMPOUND_FIND_ERROR_RE.test(toolResult.joinedText)) {
+				counts.unsupportedCompoundFind += 1;
+				toolCounts.unsupportedCompoundFind += 1;
+			}
+
+			const characterCount = toolResult.joinedText.length;
+			if (characterCount >= LARGE_OUTPUT_THRESHOLD_CHARACTERS) {
+				const utf8Bytes = Buffer.byteLength(toolResult.joinedText, "utf8");
+				counts.largeOutput += 1;
+				toolCounts.largeOutput += 1;
+				largeOutputTotalCharacters += characterCount;
+				largeOutputTotalUtf8Bytes += utf8Bytes;
+				largeOutputMaxCharacters = Math.max(largeOutputMaxCharacters, characterCount);
+				largeOutputMaxUtf8Bytes = Math.max(largeOutputMaxUtf8Bytes, utf8Bytes);
+			}
+		}
+	}
+
+	const result: ToolFrictionAuditResult = {
+		schemaVersion: 1,
+		window: {
+			startIso: new Date(window.startMs).toISOString(),
+			endIso: new Date(window.endMs).toISOString(),
+			inclusive: true,
+		},
+		inputs: {
+			sessionRootCount: sessionRoots.length,
+		},
+		scan: {
+			filesDiscovered: discoveredFiles.length,
+			filesParsed,
+			parseFailures,
+			discoveryCaveatCount,
+			malformedLines,
+		},
+		toolResults: {
+			rawInWindow,
+			uniqueInWindow,
+			duplicateLogicalResultsSkipped,
+			errorResults,
+			rateDenominator: {
+				label: RATE_DENOMINATOR_LABEL,
+				multiplier: RATE_DENOMINATOR_MULTIPLIER,
+			},
+		},
+		friction: {
+			pathMisses: buildBreakdown(counts.pathMisses, uniqueInWindow),
+			editFailures: {
+				...buildBreakdown(counts.editFailures, uniqueInWindow),
+				subtypes: {
+					"non-unique": buildBreakdown(editSubtypeCounts["non-unique"], uniqueInWindow),
+					validation: buildBreakdown(editSubtypeCounts.validation, uniqueInWindow),
+					"not-found": buildBreakdown(editSubtypeCounts["not-found"], uniqueInWindow),
+				},
+			},
+			missingPython: buildBreakdown(counts.missingPython, uniqueInWindow),
+			invalidRegex: buildBreakdown(counts.invalidRegex, uniqueInWindow),
+			unsupportedCompoundFind: buildBreakdown(counts.unsupportedCompoundFind, uniqueInWindow),
+			largeOutput: {
+				...buildBreakdown(counts.largeOutput, uniqueInWindow),
+				thresholdCharacters: LARGE_OUTPUT_THRESHOLD_CHARACTERS,
+				thresholdLabel: "50,000 characters",
+				totalCharacters: largeOutputTotalCharacters,
+				totalUtf8Bytes: largeOutputTotalUtf8Bytes,
+				maxCharacters: largeOutputMaxCharacters,
+				maxUtf8Bytes: largeOutputMaxUtf8Bytes,
+			},
+		},
+		toolBreakdown: [...toolBreakdown.values()].sort((left, right) => {
+			if (right.uniqueToolResults !== left.uniqueToolResults) {
+				return right.uniqueToolResults - left.uniqueToolResults;
+			}
+			return left.toolName.localeCompare(right.toolName);
+		}),
+	};
+
+	return result;
+}
+
+function resolveAuditWindow(startIso: string, endIso: string): { startMs: number; endMs: number } {
+	const startMs = Date.parse(startIso);
+	if (!Number.isFinite(startMs)) {
+		throw new Error(`Invalid --start ISO timestamp: ${startIso}`);
+	}
+	const endMs = Date.parse(endIso);
+	if (!Number.isFinite(endMs)) {
+		throw new Error(`Invalid --end ISO timestamp: ${endIso}`);
+	}
+	if (startMs > endMs) {
+		throw new Error("--start must be less than or equal to --end.");
+	}
+	return { startMs, endMs };
+}
+
+function buildBreakdown(count: number, toolResultsDenominator: number): ToolFrictionBreakdown {
+	return {
+		count,
+		ratePer1000ToolResults: toolResultsDenominator > 0 ? Number(((count / toolResultsDenominator) * 1_000).toFixed(2)) : 0,
+		toolResultsDenominator,
+	};
+}
+
+function classifyEditFailureSubtype(joinedText: string): ToolFrictionEditSubtype | null {
+	if (EDIT_NON_UNIQUE_RE.test(joinedText)) {
+		return "non-unique";
+	}
+	if (EDIT_VALIDATION_RE.test(joinedText)) {
+		return "validation";
+	}
+	if (EDIT_NOT_FOUND_RE.test(joinedText)) {
+		return "not-found";
+	}
+	return null;
+}
+
+function createResultFingerprint(toolResult: ToolResultView): string {
+	return createHash("sha256")
+		.update(toolResult.timestamp)
+		.update("\u0000")
+		.update(toolResult.toolName)
+		.update("\u0000")
+		.update(String(toolResult.isError))
+		.update("\u0000")
+		.update(toolResult.joinedText)
+		.digest("hex");
+}
+
+function getOrCreateToolBreakdown(
+	toolBreakdown: Map<string, MutableToolFrictionToolBreakdown>,
+	toolName: string,
+): MutableToolFrictionToolBreakdown {
+	let counts = toolBreakdown.get(toolName);
+	if (counts) {
+		return counts;
+	}
+	counts = {
+		toolName,
+		uniqueToolResults: 0,
+		errorToolResults: 0,
+		pathMisses: 0,
+		editFailures: 0,
+		missingPython: 0,
+		invalidRegex: 0,
+		unsupportedCompoundFind: 0,
+		largeOutput: 0,
+	};
+	toolBreakdown.set(toolName, counts);
+	return counts;
+}
+
+function getToolResultView(entry: RawSessionEntry): ToolResultView | null {
+	if (entry.type !== "message") {
+		return null;
+	}
+	const message = entry.message;
+	if (!isRecord(message) || message.role !== "toolResult") {
+		return null;
+	}
+	if (typeof entry.timestamp !== "string") {
+		return null;
+	}
+	return {
+		timestamp: entry.timestamp,
+		toolName: typeof message.toolName === "string" && message.toolName.length > 0 ? message.toolName : "unknown",
+		isError: message.isError === true,
+		joinedText: joinToolResultText(message.content),
+	};
+}
+
+function joinToolResultText(content: unknown): string {
+	if (typeof content === "string") {
+		return content;
+	}
+	if (!Array.isArray(content)) {
+		return "";
+	}
+	return content
+		.map((part) => {
+			if (typeof part === "string") {
+				return part;
+			}
+			if (isRecord(part) && typeof part.text === "string") {
+				return part.text;
+			}
+			return "";
+		})
+		.filter((part) => part.length > 0)
+		.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function usage(): string {
+	return [
+		"Usage: node scripts/tlh-tool-friction-audit.mjs --session-root <path> [--session-root <path> ...] --start <iso> --end <iso>",
+		"",
+		"Audit aggregate TLH tool-friction counts across exported session JSONL roots.",
+		"",
+		"Options:",
+		"  --session-root <path>  Session root to scan (repeatable, required)",
+		"  --start <iso>          Inclusive ISO-8601 lower bound (required)",
+		"  --end <iso>            Inclusive ISO-8601 upper bound (required)",
+		"  -h, --help             Show this help",
+	].join("\n");
+}
+
+export function parseArgs(argv: readonly string[]): ParsedCliArgs {
+	const args: ParsedCliArgs = {
+		sessionRoots: [],
+		startIso: "",
+		endIso: "",
+		help: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+			continue;
+		}
+		if (arg === "--session-root") {
+			args.sessionRoots.push(readRequiredValue(argv, ++index, arg));
+			continue;
+		}
+		if (arg.startsWith("--session-root=")) {
+			const value = arg.slice("--session-root=".length);
+			if (!value) {
+				throw new Error("--session-root requires a value");
+			}
+			args.sessionRoots.push(value);
+			continue;
+		}
+		if (arg === "--start") {
+			args.startIso = readRequiredValue(argv, ++index, arg);
+			continue;
+		}
+		if (arg.startsWith("--start=")) {
+			args.startIso = arg.slice("--start=".length);
+			if (!args.startIso) {
+				throw new Error("--start requires a value");
+			}
+			continue;
+		}
+		if (arg === "--end") {
+			args.endIso = readRequiredValue(argv, ++index, arg);
+			continue;
+		}
+		if (arg.startsWith("--end=")) {
+			args.endIso = arg.slice("--end=".length);
+			if (!args.endIso) {
+				throw new Error("--end requires a value");
+			}
+			continue;
+		}
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	if (!args.help) {
+		if (args.sessionRoots.length === 0) {
+			throw new Error("At least one --session-root is required.");
+		}
+		if (!args.startIso) {
+			throw new Error("--start is required.");
+		}
+		if (!args.endIso) {
+			throw new Error("--end is required.");
+		}
+	}
+
+	return args;
+}
+
+function readRequiredValue(argv: readonly string[], index: number, flag: string): string {
+	const value = argv[index];
+	if (!value) {
+		throw new Error(`${flag} requires a value`);
+	}
+	return value;
+}
+
+export async function runCli(argv: readonly string[]): Promise<number> {
+	try {
+		const args = parseArgs(argv);
+		if (args.help) {
+			process.stdout.write(`${usage()}\n`);
+			return 0;
+		}
+		const result = await auditToolFriction(args);
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+		return 0;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		process.stderr.write(`${message}\n\n${usage()}\n`);
+		return 1;
+	}
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+	const exitCode = await runCli(process.argv.slice(2));
+	if (exitCode !== 0) {
+		process.exitCode = exitCode;
+	}
+}

--- a/tests/rtk-extension.test.mjs
+++ b/tests/rtk-extension.test.mjs
@@ -200,6 +200,69 @@ test("RTK extension leaves commands unchanged when rtk rewrite reports no native
 	});
 });
 
+test("RTK extension leaves unsupported native find commands unchanged before calling rewrite", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-rtk-extension-", { cwd: true, test: t });
+	writeSettings(fixture.agent, {});
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, RTK_DISABLED: undefined }, async () => {
+		const cases = [
+			"find . -name '*.ts' -o -name '*.js'",
+			"find . -type f -a -name '*.ts'",
+			"find . -not -name '*.test.ts'",
+			"find . ! -name '*.test.ts'",
+			"find . -name '*.ts' , -name '*.js'",
+			"find . \\( -name '*.ts' -o -name '*.js' \\)",
+			"find . -name '*.ts' -print",
+			"sudo find . -not -name '*.test.ts'",
+			"env find . ! -name '*.test.ts'",
+			"ls && find . -name '*.ts' -o -name '*.js'",
+		];
+
+		for (const command of cases) {
+			const pi = createPiHarness({ rewriteOutput: "rtk find . -name '*.ts'" });
+			await registerRtk(pi);
+
+			const event = { toolName: "bash", input: { command } };
+			await pi.handlers.get("tool_call")?.[0]?.(event, createToolCallContext(fixture.cwd));
+
+			assert.equal(event.input.command, command);
+			assert.deepEqual(pi.execCalls.map((call) => call.args[0]), ["--version"]);
+		}
+	});
+});
+
+test("RTK extension still rewrites simple native find commands", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-rtk-extension-", { cwd: true, test: t });
+	writeSettings(fixture.agent, {});
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, RTK_DISABLED: undefined }, async () => {
+		const pi = createPiHarness({ rewriteOutput: "rtk find . -name '*.ts'" });
+		await registerRtk(pi);
+
+		const event = { toolName: "bash", input: { command: "find . -name '*.ts'" } };
+		await pi.handlers.get("tool_call")?.[0]?.(event, createToolCallContext(fixture.cwd));
+
+		assert.equal(event.input.command, "rtk find . -name '*.ts'");
+		assert.deepEqual(pi.execCalls.map((call) => call.args[0]), ["--version", "rewrite"]);
+	});
+});
+
+test("RTK extension still accepts rewrite exit code 3 for non-find commands", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-rtk-extension-", { cwd: true, test: t });
+	writeSettings(fixture.agent, {});
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent, RTK_DISABLED: undefined }, async () => {
+		const pi = createPiHarness({ rewriteStatus: 3, rewriteOutput: "rtk git status" });
+		await registerRtk(pi);
+
+		const event = { toolName: "bash", input: { command: "git status" } };
+		await pi.handlers.get("tool_call")?.[0]?.(event, createToolCallContext(fixture.cwd));
+
+		assert.equal(event.input.command, "rtk git status");
+		assert.deepEqual(pi.execCalls.map((call) => call.args[0]), ["--version", "rewrite"]);
+	});
+});
+
 test("RTK extension duplicate-load guard keeps a single tool_call handler per session", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-rtk-extension-", { cwd: true, test: t });
 	writeSettings(fixture.agent, {});

--- a/tests/tlh-tool-friction-audit.test.mjs
+++ b/tests/tlh-tool-friction-audit.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import { createJiti } from "jiti";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const jiti = createJiti(import.meta.url);
+const {
+	auditToolFriction,
+	parseArgs,
+	LARGE_OUTPUT_THRESHOLD_CHARACTERS,
+} = await jiti.import("../scripts/tlh-tool-friction-audit.mts");
+const cliScript = join(repoRoot, "scripts", "tlh-tool-friction-audit.mjs");
+
+const WINDOW_START = "2026-07-25T10:00:00.000Z";
+const WINDOW_END = "2026-07-25T12:00:00.000Z";
+const WINDOW_OUTSIDE = "2026-07-25T12:00:00.001Z";
+const DUPLICATE_TIMESTAMP = "2026-07-25T10:15:00.000Z";
+const SECRET_PATH = "/Users/private/repo/secret.txt";
+const SECRET_TEXT = "TOP SECRET TOOL RESULT";
+
+function createSessionsRoot() {
+	return mkdtempSync(join(tmpdir(), "tlh-tool-friction-audit-"));
+}
+
+function sessionFile(root, projectName, fileName, lines) {
+	const projectDir = join(root, projectName);
+	mkdirSync(projectDir, { recursive: true });
+	const filePath = join(projectDir, fileName);
+	writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+	return filePath;
+}
+
+function messageLine({
+	timestamp,
+	toolName,
+	text,
+	isError = false,
+	role = "toolResult",
+}) {
+	return JSON.stringify({
+		type: "message",
+		timestamp,
+		message: {
+			role,
+			toolName,
+			isError,
+			content: [{ type: "text", text }],
+		},
+	});
+}
+
+function fixtureData() {
+	const rootA = createSessionsRoot();
+	const rootB = createSessionsRoot();
+	const largeOutput = "é".repeat(LARGE_OUTPUT_THRESHOLD_CHARACTERS);
+	const duplicatePathMissText = `ENOENT: no such file or directory, open ${SECRET_PATH}`;
+
+	sessionFile(rootA, "--Users-private-project-a--", "2026-07-25T10-00-00Z_a.jsonl", [
+		JSON.stringify({ type: "session", id: "session-a" }),
+		messageLine({ timestamp: DUPLICATE_TIMESTAMP, toolName: "read", isError: true, text: duplicatePathMissText }),
+		messageLine({ timestamp: "2026-07-25T10:20:00.000Z", toolName: "edit", isError: true, text: "Found 2 occurrences of the target block" }),
+		messageLine({ timestamp: "2026-07-25T10:25:00.000Z", toolName: "edit", isError: true, text: "Validation failed for tool \"edit\" while applying the patch" }),
+		messageLine({ timestamp: "2026-07-25T10:30:00.000Z", toolName: "edit", isError: true, text: "Could not find the exact text to replace" }),
+		messageLine({ timestamp: "2026-07-25T10:35:00.000Z", toolName: "bash", isError: true, text: "python: command not found" }),
+		"not valid json",
+	]);
+
+	sessionFile(rootB, "--Users-private-project-b--", "2026-07-25T10-00-00Z_b.jsonl", [
+		JSON.stringify({ type: "session", id: "session-b" }),
+		messageLine({ timestamp: DUPLICATE_TIMESTAMP, toolName: "read", isError: true, text: duplicatePathMissText }),
+		messageLine({ timestamp: "2026-07-25T10:40:00.000Z", toolName: "grep", isError: true, text: "regex parse error: repetition operator missing expression" }),
+		messageLine({ timestamp: "2026-07-25T10:45:00.000Z", toolName: "find", isError: true, text: "rtk: rtk find does not support compound predicates or actions" }),
+		messageLine({ timestamp: "2026-07-25T10:50:00.000Z", toolName: "bash", isError: false, text: largeOutput }),
+		messageLine({ timestamp: "2026-07-25T10:55:00.000Z", toolName: "ls", isError: false, text: "safe output 1" }),
+		messageLine({ timestamp: "2026-07-25T11:00:00.000Z", toolName: "grep", isError: false, text: `normal output mentioning ${SECRET_TEXT}` }),
+		messageLine({ timestamp: WINDOW_OUTSIDE, toolName: "read", isError: true, text: "ENOENT outside the window" }),
+	]);
+
+	return { rootA, rootB, largeOutput };
+}
+
+test("auditToolFriction aggregates all six friction classes, edit subtypes, malformed lines, and deduped logical results", async () => {
+	const { rootA, rootB, largeOutput } = fixtureData();
+
+	const result = await auditToolFriction({
+		sessionRoots: [rootA, rootB],
+		startIso: WINDOW_START,
+		endIso: WINDOW_END,
+	});
+
+	assert.equal(result.window.startIso, WINDOW_START);
+	assert.equal(result.window.endIso, WINDOW_END);
+	assert.equal(result.inputs.sessionRootCount, 2);
+	assert.equal(result.scan.filesDiscovered, 2);
+	assert.equal(result.scan.filesParsed, 2);
+	assert.equal(result.scan.parseFailures, 0);
+	assert.equal(result.scan.malformedLines, 1);
+	assert.equal(result.toolResults.rawInWindow, 11);
+	assert.equal(result.toolResults.uniqueInWindow, 10);
+	assert.equal(result.toolResults.duplicateLogicalResultsSkipped, 1);
+	assert.equal(result.toolResults.errorResults, 7);
+
+	assert.deepEqual(result.friction.pathMisses, {
+		count: 1,
+		ratePer1000ToolResults: 100,
+		toolResultsDenominator: 10,
+	});
+	assert.equal(result.friction.editFailures.count, 3);
+	assert.equal(result.friction.editFailures.subtypes["non-unique"].count, 1);
+	assert.equal(result.friction.editFailures.subtypes.validation.count, 1);
+	assert.equal(result.friction.editFailures.subtypes["not-found"].count, 1);
+	assert.equal(result.friction.missingPython.count, 1);
+	assert.equal(result.friction.invalidRegex.count, 1);
+	assert.equal(result.friction.unsupportedCompoundFind.count, 1);
+	assert.equal(result.friction.largeOutput.count, 1);
+	assert.equal(result.friction.largeOutput.thresholdCharacters, 50_000);
+	assert.equal(result.friction.largeOutput.thresholdLabel, "50,000 characters");
+	assert.equal(result.friction.largeOutput.totalCharacters, largeOutput.length);
+	assert.equal(result.friction.largeOutput.totalUtf8Bytes, Buffer.byteLength(largeOutput, "utf8"));
+	assert.equal(result.friction.largeOutput.maxCharacters, largeOutput.length);
+	assert.equal(result.friction.largeOutput.maxUtf8Bytes, Buffer.byteLength(largeOutput, "utf8"));
+	assert.ok(result.friction.largeOutput.totalUtf8Bytes > result.friction.largeOutput.totalCharacters);
+
+	assert.deepEqual(
+		result.toolBreakdown.map((entry) => [entry.toolName, entry.uniqueToolResults]),
+		[
+			["edit", 3],
+			["bash", 2],
+			["grep", 2],
+			["find", 1],
+			["ls", 1],
+			["read", 1],
+		],
+	);
+});
+
+test("auditToolFriction output stays aggregate-only and does not emit raw text, paths, or roots", async () => {
+	const { rootA, rootB } = fixtureData();
+	const result = await auditToolFriction({
+		sessionRoots: [rootA, rootB],
+		startIso: WINDOW_START,
+		endIso: WINDOW_END,
+	});
+	const json = JSON.stringify(result);
+
+	assert.doesNotMatch(json, /TOP SECRET TOOL RESULT/);
+	assert.doesNotMatch(json, /Users\/private\/repo/);
+	assert.doesNotMatch(json, /tlh-tool-friction-audit-/);
+	assert.doesNotMatch(json, /ENOENT outside the window/);
+});
+
+test("parseArgs requires explicit session roots and inclusive ISO bounds", () => {
+	assert.deepEqual(parseArgs([
+		"--session-root",
+		"/tmp/a",
+		"--session-root=/tmp/b",
+		"--start",
+		WINDOW_START,
+		"--end",
+		WINDOW_END,
+	]), {
+		sessionRoots: ["/tmp/a", "/tmp/b"],
+		startIso: WINDOW_START,
+		endIso: WINDOW_END,
+		help: false,
+	});
+	assert.throws(() => parseArgs(["--session-root", "/tmp/a", "--start", WINDOW_START]), /--end is required/);
+	assert.throws(() => parseArgs(["--start", WINDOW_START, "--end", WINDOW_END]), /At least one --session-root is required/);
+});
+
+test("CLI emits aggregate-only JSON for explicit inputs and window", () => {
+	const { rootA, rootB } = fixtureData();
+	const result = spawnSync(process.execPath, [
+		cliScript,
+		"--session-root",
+		rootA,
+		"--session-root",
+		rootB,
+		"--start",
+		WINDOW_START,
+		"--end",
+		WINDOW_END,
+	], {
+		cwd: repoRoot,
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.stderr, "");
+	const parsed = JSON.parse(result.stdout);
+	assert.equal(parsed.window.inclusive, true);
+	assert.equal(parsed.toolResults.uniqueInWindow, 10);
+	assert.equal(parsed.friction.largeOutput.thresholdLabel, "50,000 characters");
+	assert.doesNotMatch(result.stdout, /TOP SECRET TOOL RESULT/);
+	assert.doesNotMatch(result.stdout, /Users\/private\/repo/);
+});


### PR DESCRIPTION
## Summary

- add an aggregate-only, fixed-window analyzer for the six recurring tool-friction classes identified in #383
- report deterministic deduplication, per-1,000-result rates, edit subtypes, and separate JavaScript-character/UTF-8-byte large-output totals without exposing transcript content or private paths
- keep unsupported compound/action-bearing native `find` commands on the native path instead of allowing managed RTK to rewrite them to unsupported `rtk find`
- preserve simple `find` rewrites, non-`find` rewrites, and RTK rewrite exit-code-3 handling

Closes #383.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Passed. One initial full-suite run hit the existing timing-sensitive footer-refresh test under suite load; that test then passed three consecutive isolated runs, and the complete `npm run validate` rerun passed.

Focused checks also passed:

```sh
node --test tests/tlh-tool-friction-audit.test.mjs tests/rtk-extension.test.mjs
node scripts/runtime-typescript.mjs check
```

The private fixed-window audit emitted aggregate-only results across two explicitly supplied roots. Relative to the published baseline, edit failures and large-output totals matched exactly; path misses, missing Python, invalid regex, and unsupported compound-find counts showed disclosed corpus/deduplication drift rather than being hidden.

The RTK reproduction matrix confirmed all guarded unsupported forms remain native while a simple supported `find` still rewrites. Final review also identified and covered `find`'s comma list operator.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not required for this internal analyzer and narrow extension fix)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/383-tool-friction/install.sh | bash -s -- --ref fix/383-tool-friction --track ref
```
