### PR TITLE
Shard CI tests across runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validation:
-    name: Repository validation (${{ matrix.os }})
+    name: Non-test validation (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -32,10 +32,51 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run validation checks
+      - name: Run non-test validation checks
         env:
           HOME: ${{ runner.temp }}/tlh-home
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${HOME}"
-          npm run validate
+          npm run check:package-versions
+          npm run typecheck
+          npm run typecheck:runtime
+          npm run check:runtime
+          bash scripts/check-installer-smoke.sh
+          npm run lint
+          npm run lint:sh
+          node scripts/merge-settings.mjs --dry-run
+          npm pack --dry-run
+
+  tests:
+    name: Tests (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        shard:
+          - 1
+          - 2
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.19.0'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test shard
+        env:
+          HOME: ${{ runner.temp }}/tlh-home
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "${HOME}"
+          node --test --test-reporter=dot --test-shard=${{ matrix.shard }}/2 "tests/**/*.test.mjs"


### PR DESCRIPTION
## Summary

Split the CI test suite into two Node test-runner shards per operating system so tests run concurrently on separate runners. Keep local npm scripts unchanged and continue running every existing non-test validation command once on both Ubuntu and macOS.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Passed locally. Both explicit shards also passed and covered all 1,370 tests (729 + 641), matching the unsharded suite total.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not applicable; CI-only behavior)
- [x] Diff contains no secrets, local paths, or unintended generated files
