### PR TITLE
Update Anthropic defaults to Opus 5.0

### DIFF
--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Clarifies requirements, manages implementation tasks, and orchestrates minor subagents.
-model: anthropic/claude-opus-4-8
+model: anthropic/claude-opus-5-0
 tlhOpenaiModels: openai-codex/gpt-5.6-sol
 thinking: high
 applyModel: true

--- a/agents/primary/bug-hunter.md
+++ b/agents/primary/bug-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: bug-hunter
 description: Investigates reported bugs, identifies root causes, and recommends fixes without changing code.
-model: anthropic/claude-opus-4-8
+model: anthropic/claude-opus-5-0
 tlhOpenaiModels: openai-codex/gpt-5.5
 thinking: high
 applyModel: true

--- a/agents/primary/product.md
+++ b/agents/primary/product.md
@@ -1,7 +1,7 @@
 ---
 name: product
 description: Guides product strategy, decisions, product docs, and implementation ticket shaping without changing source.
-model: anthropic/claude-opus-4-6
+model: anthropic/claude-opus-5-0
 tlhOpenaiModels: openai-codex/gpt-5.5
 thinking: high
 applyModel: true

--- a/agents/subagents/code-reviewer.md
+++ b/agents/subagents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: Reviews diffs against assigned tasks for correctness, security, and maintainability.
 tools: read, grep, find, ls, bash, contact_supervisor
 tlhOpenaiModels: openai-codex/gpt-5.6-sol
-tlhAnthropicModels: anthropic/claude-opus-4-8
+tlhAnthropicModels: anthropic/claude-opus-5-0
 preferOppositeProvider: true
 thinking: high
 systemPromptMode: replace

--- a/agents/subagents/contrarian.md
+++ b/agents/subagents/contrarian.md
@@ -3,7 +3,7 @@ name: contrarian
 description: Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case.
 tools: read, grep, find, ls, bash, contact_supervisor
 tlhOpenaiModels: openai-codex/gpt-5.6-sol
-tlhAnthropicModels: anthropic/claude-opus-4-8
+tlhAnthropicModels: anthropic/claude-opus-5-0
 preferOppositeProvider: true
 thinking: high
 systemPromptMode: replace

--- a/agents/subagents/oracle.md
+++ b/agents/subagents/oracle.md
@@ -3,7 +3,7 @@ name: oracle
 description: Provides read-only high-reasoning second opinions and direct analysis.
 tools: read, grep, find, ls, contact_supervisor, bash
 tlhOpenaiModels: openai-codex/gpt-5.6-sol
-tlhAnthropicModels: anthropic/claude-opus-4-8
+tlhAnthropicModels: anthropic/claude-opus-5-0
 preferOppositeProvider: true
 thinking: high
 systemPromptMode: replace

--- a/tests/hermetic-core-workflow.test.mjs
+++ b/tests/hermetic-core-workflow.test.mjs
@@ -242,7 +242,7 @@ function writeFakeTk(path) {
 
 function registerScriptedProviders(modelRegistry, scriptState) {
 	const models = {
-		anthropic: ["claude-opus-4-8", "claude-sonnet-4-6"],
+		anthropic: ["claude-opus-5-0", "claude-sonnet-4-6"],
 		"openai-codex": ["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"],
 	};
 	for (const [provider, ids] of Object.entries(models)) {
@@ -272,7 +272,7 @@ function currentRole() {
 }
 
 function scriptedRoleForModel(model) {
-	if (model.provider === "anthropic" && model.id === "claude-opus-4-8") {
+	if (model.provider === "anthropic" && model.id === "claude-opus-5-0") {
 		return "architect";
 	}
 	if (model.provider === "openai-codex" && model.id === "gpt-5.4") {
@@ -610,7 +610,7 @@ test("hermetic core architect workflow runs end-to-end with deterministic subage
 		appendSystemPrompt: [],
 	});
 	await resourceLoader.reload();
-	const architectModel = modelRegistry.find("anthropic", "claude-opus-4-8");
+	const architectModel = modelRegistry.find("anthropic", "claude-opus-5-0");
 	assert.ok(architectModel);
 
 	const { session } = await withEnv(createHermeticRuntimeEnv(fixture), async () => createAgentSession({

--- a/tests/the-last-harness-effort.test.mjs
+++ b/tests/the-last-harness-effort.test.mjs
@@ -85,7 +85,7 @@ function productPrimary() {
 	return {
 		name: "product",
 		description: "Product primary",
-		model: "anthropic/claude-opus-4-6",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "high",
 		lockThinking: true,
 		tools: [],
@@ -98,7 +98,7 @@ function bugHunterPrimary() {
 	return {
 		name: "bug-hunter",
 		description: "Bug-hunter primary",
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "high",
 		lockThinking: true,
 		tools: [],
@@ -111,7 +111,7 @@ function architectPrimary() {
 	return {
 		name: "architect",
 		description: "Architect primary",
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "high",
 		minThinking: "medium",
 		tools: [],

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -403,7 +403,10 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 	const rush = primaryAgents.get("rush");
 	assert.ok(architect, "architect primary prompt should load");
 	assert.ok(rush, "Rush primary prompt should load");
+	assert.equal(architect.model, "anthropic/claude-opus-5-0");
+	assert.equal(architect.thinking, "high");
 	assert.deepEqual(architect.tlhOpenaiModels, ["openai-codex/gpt-5.6-sol"]);
+	assert.equal(rush.model, "anthropic/claude-opus-4-8");
 	assert.deepEqual(rush.tlhOpenaiModels, ["openai-codex/gpt-5.5"]);
 	assert.equal(rush.thinking, "low");
 	assert.equal(rush.tlhOpenaiThinking, "off");
@@ -419,33 +422,30 @@ test("primary and child prompts do not include disabled-ticket fallback guidance
 
 	const product = primaryAgents.get("product");
 	assert.ok(product, "product primary prompt should load");
+	assert.equal(product.model, "anthropic/claude-opus-5-0");
+	assert.equal(product.thinking, "high");
 	assert.equal(product.applyModel, true);
 	assert.equal(product.applyThinking, true);
 	assert.equal(product.lockThinking, true);
 
 	const bugHunter = primaryAgents.get("bug-hunter");
 	assert.ok(bugHunter, "bug-hunter primary prompt should load");
+	assert.equal(bugHunter.model, "anthropic/claude-opus-5-0");
+	assert.equal(bugHunter.thinking, "high");
 	assert.equal(bugHunter.applyModel, true);
 	assert.equal(bugHunter.applyThinking, true);
 	assert.equal(bugHunter.lockThinking, true);
 
 	assert.match(rush.systemPrompt, /Do not delegate implementation to `developer`/);
-	assert.deepEqual(
-		loadSubagentMetadata().find((agent) => agent.name === "developer")?.tlhOpenaiModels,
-		["openai-codex/gpt-5.4"],
-	);
-	assert.deepEqual(
-		loadSubagentMetadata().find((agent) => agent.name === "code-reviewer")?.tlhOpenaiModels,
-		["openai-codex/gpt-5.6-sol"],
-	);
-	assert.deepEqual(
-		loadSubagentMetadata().find((agent) => agent.name === "oracle")?.tlhOpenaiModels,
-		["openai-codex/gpt-5.6-sol"],
-	);
-	assert.deepEqual(
-		loadSubagentMetadata().find((agent) => agent.name === "contrarian")?.tlhOpenaiModels,
-		["openai-codex/gpt-5.6-sol"],
-	);
+	const subagentMetadata = loadSubagentMetadata();
+	const developer = subagentMetadata.find((agent) => agent.name === "developer");
+	assert.deepEqual(developer?.tlhAnthropicModels, ["anthropic/claude-sonnet-4-6"]);
+	assert.deepEqual(developer?.tlhOpenaiModels, ["openai-codex/gpt-5.4"]);
+	for (const name of ["code-reviewer", "oracle", "contrarian"]) {
+		const agent = subagentMetadata.find((candidate) => candidate.name === name);
+		assert.deepEqual(agent?.tlhAnthropicModels, ["anthropic/claude-opus-5-0"], `${name} Anthropic default`);
+		assert.deepEqual(agent?.tlhOpenaiModels, ["openai-codex/gpt-5.6-sol"], `${name} OpenAI default`);
+	}
 
 	const primaryPrompt = buildTlhSystemPrompt(rush, loadSubagentMetadata(), true);
 	const legacyFlagPrimaryPrompt = buildTlhSystemPrompt(rush, loadSubagentMetadata(), true, {

--- a/tests/the-last-harness-model-defaults.test.mjs
+++ b/tests/the-last-harness-model-defaults.test.mjs
@@ -18,22 +18,22 @@ const developer = {
 const codeReviewer = {
 	name: "code-reviewer",
 	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
-	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+	tlhAnthropicModels: ["anthropic/claude-opus-5-0"],
 	preferOppositeProvider: true,
 };
 
 const oracle = {
 	name: "oracle",
 	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
-	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+	tlhAnthropicModels: ["anthropic/claude-opus-5-0"],
 	preferOppositeProvider: true,
 };
 
 const anthropicParentPrefersCodexReviewer = {
 	name: "anthropic-parent-prefers-codex-reviewer",
-	model: "anthropic/claude-opus-4-8",
+	model: "anthropic/claude-opus-5-0",
 	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
-	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+	tlhAnthropicModels: ["anthropic/claude-opus-5-0"],
 	preferOppositeProvider: true,
 };
 
@@ -41,7 +41,7 @@ const openaiParentPrefersAnthropicReviewer = {
 	name: "openai-parent-prefers-anthropic-reviewer",
 	model: "openai-codex/gpt-5.6-sol",
 	tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
-	tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+	tlhAnthropicModels: ["anthropic/claude-opus-5-0"],
 	preferOppositeProvider: true,
 };
 
@@ -69,6 +69,7 @@ const agents = new Map([
 const anthropicAvailable = [
 	{ provider: "anthropic", id: "claude-sonnet-5" },
 	{ provider: "anthropic", id: "claude-sonnet-4-6" },
+	{ provider: "anthropic", id: "claude-opus-5-0" },
 	{ provider: "anthropic", id: "claude-opus-4-8" },
 ];
 
@@ -142,7 +143,7 @@ test("provider-aware opposite-provider preference picks Codex for opted-in Anthr
 	const input = { agent: anthropicParentPrefersCodexReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "anthropic"), 1);
 	assert.equal(input.model, "openai-codex/gpt-5.6-sol");
-	assert.deepEqual(input.fallbackModels, ["anthropic/claude-opus-4-8"]);
+	assert.deepEqual(input.fallbackModels, ["anthropic/claude-opus-5-0"]);
 	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
 
@@ -152,16 +153,16 @@ test("provider-aware opposite-provider preference picks Anthropic for opted-in O
 
 	assert.equal(
 		selectProviderAwareAgentModelId(openaiParentPrefersAnthropicReviewer, available, "openai"),
-		"anthropic/claude-opus-4-8",
+		"anthropic/claude-opus-5-0",
 	);
 	assert.equal(
 		selectProviderAwareAgentModelId(openaiParentPrefersAnthropicReviewer, available, "openai-codex"),
-		"anthropic/claude-opus-4-8",
+		"anthropic/claude-opus-5-0",
 	);
 
 	const input = { agent: openaiParentPrefersAnthropicReviewer.name, task: "Review the diff" };
 	assert.equal(applyProviderAwareSubagentModels(input, agents, available, "openai-codex"), 1);
-	assert.equal(input.model, "anthropic/claude-opus-4-8");
+	assert.equal(input.model, "anthropic/claude-opus-5-0");
 	assert.deepEqual(input.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(input.modelFallbackNotice, reducedIndependenceNotice);
 });
@@ -181,12 +182,12 @@ test("provider-aware subagent mutation gives code-reviewer the opposite availabl
 	const anthropicInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(anthropicInput, agents, available, "anthropic"), 1);
 	assert.equal(anthropicInput.model, "openai-codex/gpt-5.6-sol");
-	assert.deepEqual(anthropicInput.fallbackModels, ["anthropic/claude-opus-4-8"]);
+	assert.deepEqual(anthropicInput.fallbackModels, ["anthropic/claude-opus-5-0"]);
 	assert.equal(anthropicInput.modelFallbackNotice, reducedIndependenceNotice);
 
 	const codexInput = { agent: "code-reviewer" };
 	assert.equal(applyProviderAwareSubagentModels(codexInput, agents, available, "openai-codex"), 1);
-	assert.equal(codexInput.model, "anthropic/claude-opus-4-8");
+	assert.equal(codexInput.model, "anthropic/claude-opus-5-0");
 	assert.deepEqual(codexInput.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(codexInput.modelFallbackNotice, reducedIndependenceNotice);
 
@@ -226,7 +227,7 @@ test("provider-aware subagent mutation gives code-reviewer and oracle current-se
 		),
 		1,
 	);
-	assert.equal(oracleInput.model, "anthropic/claude-opus-4-8");
+	assert.equal(oracleInput.model, "anthropic/claude-opus-5-0");
 	assert.deepEqual(oracleInput.fallbackModels, ["openai-codex/gpt-5.4"]);
 	assert.equal(oracleInput.modelFallbackNotice, reducedIndependenceNotice);
 });
@@ -363,7 +364,7 @@ test("provider-aware subagent mutation injects model but preserves caller-suppli
 	// TLH auto-adds fallbackModels, caller-provided modelFallbackNotice kept.
 	const withFallbackNotice = { agent: "oracle", modelFallbackNotice: "custom fallback notice" };
 	assert.equal(applyProviderAwareSubagentModels(withFallbackNotice, agents, available, "openai-codex"), 1);
-	assert.equal(withFallbackNotice.model, "anthropic/claude-opus-4-8");
+	assert.equal(withFallbackNotice.model, "anthropic/claude-opus-5-0");
 	assert.deepEqual(withFallbackNotice.fallbackModels, ["openai-codex/gpt-5.6-sol"]);
 	assert.equal(withFallbackNotice.modelFallbackNotice, "custom fallback notice");
 

--- a/tests/the-last-harness-primary-agent-runtime-delegation.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime-delegation.test.mjs
@@ -138,7 +138,7 @@ test("enabled primary mode allows contrarian by default and stale contrarian set
 		modelRegistry: {
 			getAvailable: () => [
 				{ provider: "openai-codex", id: "gpt-5.4" },
-				{ provider: "anthropic", id: "claude-opus-4-8" },
+				{ provider: "anthropic", id: "claude-opus-5-0" },
 			],
 		},
 		model: { provider: "openai-codex", id: "gpt-5.4" },
@@ -148,7 +148,7 @@ test("enabled primary mode allows contrarian by default and stale contrarian set
 		const { toolCall } = registerRuntimeHarness({ primaryAgents: selectablePrimaryAgents(), subagentMetadata });
 		const defaultEvent = { toolName: "subagent", input: { agent: "contrarian", task: "stress-test this plan" } };
 		assert.equal(await toolCall(defaultEvent, blockedCtx), undefined);
-		assert.equal(defaultEvent.input.model, "anthropic/claude-opus-4-8");
+		assert.equal(defaultEvent.input.model, "anthropic/claude-opus-5-0");
 		assert.equal(defaultEvent.input.agentScope, "user");
 		assert.equal(defaultEvent.input.context, "fresh");
 
@@ -158,7 +158,7 @@ test("enabled primary mode allows contrarian by default and stale contrarian set
 		);
 		const legacyFlagEvent = { toolName: "subagent", input: { agent: "contrarian", task: "stress-test this plan" } };
 		assert.equal(await toolCall(legacyFlagEvent, blockedCtx), undefined);
-		assert.equal(legacyFlagEvent.input.model, "anthropic/claude-opus-4-8");
+		assert.equal(legacyFlagEvent.input.model, "anthropic/claude-opus-5-0");
 		assert.equal(legacyFlagEvent.input.agentScope, "user");
 		assert.equal(legacyFlagEvent.input.context, "fresh");
 	});
@@ -340,7 +340,7 @@ test("/switch-primary-agent model reset clears the active primary model override
 			modelRegistry: {
 				getAvailable: () => [
 					{ provider: "openai-codex", id: "gpt-5.5" },
-					{ provider: "anthropic", id: "claude-opus-4-8" },
+					{ provider: "anthropic", id: "claude-opus-5-0" },
 				],
 			},
 			model: { provider: "openai-codex", id: "gpt-5.4" },
@@ -349,7 +349,7 @@ test("/switch-primary-agent model reset clears the active primary model override
 
 		const written = JSON.parse(readFileSync(join(fixture.agent, "settings.json"), "utf8"));
 		assert.equal(written.tlh.primaryAgent.modelOverrides, undefined);
-		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-8" });
+		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-5-0" });
 		assert.equal(reset.notifications.at(-1)?.type, "info");
 		assert.match(reset.notifications.at(-1)?.message ?? "", /Cleared model override for architect/);
 	});

--- a/tests/the-last-harness-primary-agent-runtime-prompt-guidance.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime-prompt-guidance.test.mjs
@@ -55,7 +55,7 @@ test("disabled primary mode allows contrarian by default and ignores stale contr
 		modelRegistry: {
 			getAvailable: () => [
 				{ provider: "openai-codex", id: "gpt-5.4" },
-				{ provider: "anthropic", id: "claude-opus-4-8" },
+				{ provider: "anthropic", id: "claude-opus-5-0" },
 			],
 		},
 		model: { provider: "openai-codex", id: "gpt-5.4" },
@@ -68,7 +68,7 @@ test("disabled primary mode allows contrarian by default and ignores stale contr
 			input: { agent: "contrarian", prompt: "stress-test this plan", agentScope: "project", context: "resume" },
 		};
 		assert.equal(await toolCall(defaultEvent, ctx), undefined);
-		assert.equal(defaultEvent.input.model, "anthropic/claude-opus-4-8");
+		assert.equal(defaultEvent.input.model, "anthropic/claude-opus-5-0");
 		assert.equal(defaultEvent.input.agentScope, "project");
 		assert.equal(defaultEvent.input.context, "resume");
 
@@ -82,7 +82,7 @@ test("disabled primary mode allows contrarian by default and ignores stale contr
 				input: { agent: "contrarian", prompt: "stress-test this plan", agentScope: "project", context: "resume" },
 			};
 			assert.equal(await toolCall(staleEvent, ctx), undefined);
-			assert.equal(staleEvent.input.model, "anthropic/claude-opus-4-8");
+			assert.equal(staleEvent.input.model, "anthropic/claude-opus-5-0");
 			assert.equal(staleEvent.input.agentScope, "project");
 			assert.equal(staleEvent.input.context, "resume");
 		}

--- a/tests/the-last-harness-primary-agent-runtime-test-helpers.mjs
+++ b/tests/the-last-harness-primary-agent-runtime-test-helpers.mjs
@@ -111,14 +111,14 @@ export function contrarianMetadata() {
 		name: "contrarian",
 		description: "Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case.",
 		tlhOpenaiModels: ["openai-codex/gpt-5.6-sol"],
-		tlhAnthropicModels: ["anthropic/claude-opus-4-8"],
+		tlhAnthropicModels: ["anthropic/claude-opus-5-0"],
 		preferOppositeProvider: true,
 	};
 }
 
 export function rushLikePrimary(name = "architect") {
 	return createPrimaryPrompt(name, {
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		tlhOpenaiModels: ["openai-codex/gpt-5.5"],
 		thinking: "low",
 		tlhOpenaiThinking: "off",

--- a/tests/the-last-harness-primary-agent-runtime.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime.test.mjs
@@ -101,11 +101,11 @@ test("primary runtime falls back to Anthropic Rush-like metadata defaults when o
 				cwd: fixture.cwd,
 				sessionManager: { getBranch: () => [] },
 				ui: { notify() {} },
-				modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
+				modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-5-0" }] },
 				model: { provider: "openai-codex", id: "gpt-5.4" },
 			});
 
-			assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-8" });
+			assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-5-0" });
 			assert.equal(pi.thinkingLevel, "low");
 		});
 	} finally {
@@ -142,7 +142,7 @@ test("primary runtime respects explicit false settings over Rush-like metadata d
 test("architect before_agent_start preserves medium floor selection but restores declared default after rush", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "high",
 		minThinking: "medium",
 		applyModel: true,
@@ -168,8 +168,11 @@ test("architect before_agent_start preserves medium floor selection but restores
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => branch },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
-			model: { provider: "anthropic", id: "claude-opus-4-8" },
+			modelRegistry: { getAvailable: () => [
+				{ provider: "anthropic", id: "claude-opus-5-0" },
+				{ provider: "anthropic", id: "claude-opus-4-8" },
+			] },
+			model: { provider: "anthropic", id: "claude-opus-5-0" },
 		});
 
 		await runtime.applySessionStart(makeCtx([]));
@@ -193,7 +196,7 @@ test("architect before_agent_start preserves medium floor selection but restores
 test("primary runtime applies a max thinking default", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "max",
 		applyModel: true,
 		applyThinking: true,
@@ -208,8 +211,8 @@ test("primary runtime applies a max thinking default", async (t) => {
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => branch },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
-			model: { provider: "anthropic", id: "claude-opus-4-8" },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-5-0" }] },
+			model: { provider: "anthropic", id: "claude-opus-5-0" },
 		});
 
 		await runtime.applySessionStart(makeCtx([]));
@@ -259,7 +262,7 @@ test("locked primary (rush) overrides global applyThinking=false and applyModel=
 test("non-locked primary (architect) honors global applyThinking=false override", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const architectPrimary = createPrimaryPrompt("architect", {
-		model: "anthropic/claude-opus-4-8",
+		model: "anthropic/claude-opus-5-0",
 		thinking: "high",
 		applyModel: true,
 		applyThinking: true,
@@ -278,8 +281,8 @@ test("non-locked primary (architect) honors global applyThinking=false override"
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => [] },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
-			model: { provider: "anthropic", id: "claude-opus-4-8" },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-5-0" }] },
+			model: { provider: "anthropic", id: "claude-opus-5-0" },
 		});
 
 		// Global applyThinking: false is respected for non-locked primary
@@ -378,7 +381,7 @@ function createPiHarnessWithFiringModelSelect(getCtx) {
 test("model override resolution: stored override is applied when the model is in the registry", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const primaryAgents = new Map([["architect", rushLikePrimary()]]);
-	// Bundled default for rushLikePrimary on Anthropic is anthropic/claude-opus-4-8.
+	// Bundled default for rushLikePrimary on Anthropic is anthropic/claude-opus-5-0.
 	// Store a different available Anthropic model so override precedence is observable.
 	const initialSettings = JSON.stringify({
 		tlh: { primaryAgent: { modelOverrides: { architect: "anthropic/claude-sonnet-4-6" } } },
@@ -395,14 +398,14 @@ test("model override resolution: stored override is applied when the model is in
 			ui: { notify() {} },
 			modelRegistry: {
 				getAvailable: () => [
-					{ provider: "anthropic", id: "claude-opus-4-8" },
+					{ provider: "anthropic", id: "claude-opus-5-0" },
 					{ provider: "anthropic", id: "claude-sonnet-4-6" },
 				],
 			},
 			model: { provider: "anthropic", id: "claude-haiku-4-5" },
 		});
 
-		// Override should win over the bundled anthropic/claude-opus-4-8 default.
+		// Override should win over the bundled anthropic/claude-opus-5-0 default.
 		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-sonnet-4-6" });
 	});
 });
@@ -424,21 +427,21 @@ test("model override resolution: falls back to bundled default when override mod
 			sessionManager: { getBranch: () => [] },
 			ui: { notify() {} },
 			// Override model (openai-codex/gpt-5.5) is NOT in the registry
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-5-0" }] },
 			model: { provider: "anthropic", id: "claude-sonnet-4-6" },
 		});
 
 		// Falls back to bundled Anthropic default
-		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-4-8" });
+		assert.deepEqual(pi.model, { provider: "anthropic", id: "claude-opus-5-0" });
 	});
 });
 
 test("model_select listener writes override to settings when user picks a non-default model", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 	const primaryAgents = new Map([["architect", rushLikePrimary()]]);
-	// rushLikePrimary has model: "anthropic/claude-opus-4-8".
+	// rushLikePrimary has model: "anthropic/claude-opus-5-0".
 	// The user picks a different Anthropic model that is NOT the bundled default for the architect primary.
-	// Available: both claude-opus-4-8 (bundled default) and claude-sonnet-4-6 (non-default).
+	// Available: both claude-opus-5-0 (bundled default) and claude-sonnet-4-6 (non-default).
 
 	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
 		const { pi } = registerRuntimeHarness({ primaryAgents, subagentMetadata: [] });
@@ -451,16 +454,16 @@ test("model_select listener writes override to settings when user picks a non-de
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => [] },
 			ui: { notify() {} },
-			// Registry includes the bundled default (claude-opus-4-8) and the override target (claude-sonnet-4-6)
+			// Registry includes the bundled default (claude-opus-5-0) and the override target (claude-sonnet-4-6)
 			modelRegistry: {
 				getAvailable: () => [
-					{ provider: "anthropic", id: "claude-opus-4-8" },
+					{ provider: "anthropic", id: "claude-opus-5-0" },
 					{ provider: "anthropic", id: "claude-sonnet-4-6" },
 				],
 			},
 			model: overrideModel,
 		};
-		// bundledKey for provider "anthropic" with rushLikePrimary: "anthropic/claude-opus-4-8" (the primary's .model field)
+		// bundledKey for provider "anthropic" with rushLikePrimary: "anthropic/claude-opus-5-0" (the primary's .model field)
 		// chosenKey: "anthropic/claude-sonnet-4-6" → different → should write override
 		await modelSelectHandler(
 			{ type: "model_select", model: overrideModel, previousModel: undefined, source: "set" },
@@ -485,13 +488,13 @@ test("model_select listener clears override when user reselects the primary's bu
 		const modelSelectHandler = pi.events.find((e) => e.name === "model_select")?.handler;
 		assert.ok(modelSelectHandler, "model_select handler must be registered");
 
-		// rushLikePrimary with only anthropic available: bundled default is anthropic/claude-opus-4-8
-		const bundledDefaultModel = { provider: "anthropic", id: "claude-opus-4-8" };
+		// rushLikePrimary with only anthropic available: bundled default is anthropic/claude-opus-5-0
+		const bundledDefaultModel = { provider: "anthropic", id: "claude-opus-5-0" };
 		const ctx = {
 			cwd: fixture.cwd,
 			sessionManager: { getBranch: () => [] },
 			ui: { notify() {} },
-			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-4-8" }] },
+			modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-opus-5-0" }] },
 			model: bundledDefaultModel,
 		};
 		await modelSelectHandler(


### PR DESCRIPTION
## Summary

Update the bundled Anthropic defaults for Architect, Product, Bug Hunter, Code Reviewer, Oracle, and Contrarian to Claude Opus 5.0 with high thinking. Preserve Rush, Developer, lightweight-agent, and all OpenAI defaults.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed end-to-end. Focused model-default and runtime suite also passed with 143 tests and 0 failures.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/update-anthropic-opus-5-defaults/install.sh | bash -s -- --ref update-anthropic-opus-5-defaults --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the default Anthropic model used by primary and supporting agents to the latest Claude Opus version.
  * Improved model selection consistency across agent delegation, fallback handling, and reset workflows.

* **Tests**
  * Updated coverage and expectations to validate the new default model across agent configuration, runtime behavior, and provider-aware model resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->