### PR TITLE
Show MCP context estimate in footer

### DIFF
--- a/extensions/the-last-harness/footer.js
+++ b/extensions/the-last-harness/footer.js
@@ -11,6 +11,11 @@ export { formatTlhSubscriptionUsageFooterSegment } from "./footer-subscription-u
 const CHARS_PER_TOKEN = 4;
 const ESTIMATED_IMAGE_CHARS = 4800;
 const MCP_STATUS_PREFIX = /^MCP:\s/i;
+const KNOWN_PI_MCP_ADAPTER_SOURCES = [
+    "npm:pi-mcp-adapter",
+    "npm:@diegopetrucci/pi-mcp-adapter",
+    "git:github.com/diegopetrucci/pi-mcp-adapter",
+];
 function formatCost(cost) {
     return cost < 0.001 ? "<$0.001" : `$${cost.toFixed(3)}`;
 }
@@ -68,14 +73,30 @@ function resultContentChars(content) {
 function estimateTokensFromChars(charCount) {
     return charCount > 0 ? Math.ceil(charCount / CHARS_PER_TOKEN) : 0;
 }
+function hasKnownPiMcpAdapterSource(source) {
+    return (typeof source === "string" &&
+        KNOWN_PI_MCP_ADAPTER_SOURCES.some((knownSource) => source === knownSource || source.startsWith(`${knownSource}@`)));
+}
+function hasPersistedDirectMcpResultDetails(toolName, details) {
+    if (!details || typeof details !== "object") {
+        return false;
+    }
+    const candidate = details;
+    if (typeof candidate.server !== "string" ||
+        candidate.server.length === 0 ||
+        typeof candidate.tool !== "string" ||
+        candidate.tool.length === 0) {
+        return false;
+    }
+    const serverPrefix = candidate.server.replaceAll("-", "_");
+    const shortPrefix = candidate.server.replace(/-?mcp$/i, "").replaceAll("-", "_") || "mcp";
+    return new Set([candidate.tool, `${serverPrefix}_${candidate.tool}`, `${shortPrefix}_${candidate.tool}`]).has(toolName);
+}
 function getMcpToolKind(toolName, toolInfo) {
     if (toolName === "mcp") {
         return "proxy";
     }
-    const sourceHint = [toolInfo?.sourceInfo?.source, toolInfo?.sourceInfo?.path]
-        .filter((value) => typeof value === "string")
-        .join(" ");
-    return sourceHint && /mcp/i.test(sourceHint) ? "direct" : undefined;
+    return hasKnownPiMcpAdapterSource(toolInfo?.sourceInfo?.source) ? "direct" : undefined;
 }
 function estimateMcpDefinitionTokens(toolInfo) {
     return estimateTokensFromChars(safeJsonLength({
@@ -100,11 +121,19 @@ function getMcpContextEstimateSuffix(pi, ctx, contextUsage, cache) {
         return cache;
     }
     const allTools = pi.getAllTools();
-    const activeMcpTools = activeToolNames
-        .map((toolName) => allTools.find((candidate) => candidate.name === toolName))
-        .filter((toolInfo) => Boolean(toolInfo?.name))
-        .filter((toolInfo) => getMcpToolKind(toolInfo.name, toolInfo) !== undefined);
     const toolCatalogByName = new Map(allTools.map((toolInfo) => [toolInfo.name, toolInfo]));
+    const knownDirectMcpToolNames = new Set();
+    const activeMcpTools = activeToolNames
+        .map((toolName) => toolCatalogByName.get(toolName))
+        .filter((toolInfo) => Boolean(toolInfo?.name))
+        .filter((toolInfo) => {
+        const kind = getMcpToolKind(toolInfo.name, toolInfo);
+        if (kind === "direct") {
+            knownDirectMcpToolNames.add(toolInfo.name);
+        }
+        return kind !== undefined;
+    });
+    const pendingToolCallsById = new Map();
     let mcpTokens = activeMcpTools.reduce((sum, toolInfo) => sum + estimateMcpDefinitionTokens(toolInfo), 0);
     for (const entry of ctx.sessionManager.buildContextEntries()) {
         if (entry.type !== "message") {
@@ -116,16 +145,38 @@ function getMcpContextEstimateSuffix(pi, ctx, contextUsage, cache) {
                 if (block?.type !== "toolCall" || typeof block.name !== "string") {
                     continue;
                 }
-                if (!getMcpToolKind(block.name, toolCatalogByName.get(block.name))) {
+                const catalogKind = getMcpToolKind(block.name, toolCatalogByName.get(block.name));
+                if (catalogKind === "direct") {
+                    knownDirectMcpToolNames.add(block.name);
+                }
+                const kind = catalogKind ?? (knownDirectMcpToolNames.has(block.name) ? "direct" : undefined);
+                const argumentTokens = estimateTokensFromChars(safeJsonLength(block.arguments));
+                if (kind) {
+                    mcpTokens += argumentTokens;
                     continue;
                 }
-                mcpTokens += estimateTokensFromChars(safeJsonLength(block.arguments));
+                if (typeof block.id === "string") {
+                    pendingToolCallsById.set(block.id, { toolName: block.name, tokens: argumentTokens });
+                }
             }
             continue;
         }
         if (message.role === "toolResult" && typeof message.toolName === "string") {
-            if (!getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName))) {
+            const pendingCall = typeof message.toolCallId === "string" ? pendingToolCallsById.get(message.toolCallId) : undefined;
+            const hasPairedDirectResultProvenance = message.toolName !== "mcp" &&
+                pendingCall?.toolName === message.toolName &&
+                hasPersistedDirectMcpResultDetails(message.toolName, message.details);
+            const kind = getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName)) ??
+                (knownDirectMcpToolNames.has(message.toolName) || hasPairedDirectResultProvenance ? "direct" : undefined);
+            if (!kind) {
                 continue;
+            }
+            if (kind === "direct") {
+                knownDirectMcpToolNames.add(message.toolName);
+                if (pendingCall?.toolName === message.toolName && typeof message.toolCallId === "string") {
+                    mcpTokens += pendingCall.tokens;
+                    pendingToolCallsById.delete(message.toolCallId);
+                }
             }
             mcpTokens += estimateTokensFromChars(resultContentChars(message.content));
         }

--- a/extensions/the-last-harness/footer.js
+++ b/extensions/the-last-harness/footer.js
@@ -8,6 +8,9 @@ import { TK_WORKFLOW_STATUS_KEY } from "./ticket-workflow-ui-constants.js";
 import { composeTlhFooterFirstLine } from "./footer-first-line.js";
 import { getTlhSubscriptionUsageFooterState, } from "./footer-subscription-usage.js";
 export { formatTlhSubscriptionUsageFooterSegment } from "./footer-subscription-usage.js";
+const CHARS_PER_TOKEN = 4;
+const ESTIMATED_IMAGE_CHARS = 4800;
+const MCP_STATUS_PREFIX = /^MCP:\s/i;
 function formatCost(cost) {
     return cost < 0.001 ? "<$0.001" : `$${cost.toFixed(3)}`;
 }
@@ -33,7 +36,115 @@ function collectUsageTotals(ctx) {
     }
     return totals;
 }
+function safeJsonLength(value) {
+    if (value == null) {
+        return 0;
+    }
+    try {
+        return JSON.stringify(value).length;
+    }
+    catch {
+        return 0;
+    }
+}
+function resultContentChars(content) {
+    if (!Array.isArray(content)) {
+        return 0;
+    }
+    let total = 0;
+    for (const item of content) {
+        if (!item || typeof item !== "object" || !("type" in item)) {
+            continue;
+        }
+        if (item.type === "text" && "text" in item && typeof item.text === "string") {
+            total += item.text.length;
+        }
+        else if (item.type === "image") {
+            total += ESTIMATED_IMAGE_CHARS;
+        }
+    }
+    return total;
+}
+function estimateTokensFromChars(charCount) {
+    return charCount > 0 ? Math.ceil(charCount / CHARS_PER_TOKEN) : 0;
+}
+function getMcpToolKind(toolName, toolInfo) {
+    if (toolName === "mcp") {
+        return "proxy";
+    }
+    const sourceHint = [toolInfo?.sourceInfo?.source, toolInfo?.sourceInfo?.path]
+        .filter((value) => typeof value === "string")
+        .join(" ");
+    return sourceHint && /mcp/i.test(sourceHint) ? "direct" : undefined;
+}
+function estimateMcpDefinitionTokens(toolInfo) {
+    return estimateTokensFromChars(safeJsonLength({
+        name: toolInfo.name,
+        description: toolInfo.description,
+        parameters: toolInfo.parameters,
+        promptGuidelines: toolInfo.promptGuidelines,
+    }));
+}
+function buildMcpContextEstimateCacheKey(activeToolNames, ctx, contextTokens) {
+    const leafId = ctx.sessionManager.getLeafId?.() ?? "";
+    return `${leafId}::${contextTokens}::${activeToolNames.join("|")}`;
+}
+function getMcpContextEstimateSuffix(pi, ctx, contextUsage, cache) {
+    const contextTokens = contextUsage?.tokens;
+    if (typeof contextTokens !== "number" || !Number.isFinite(contextTokens) || contextTokens <= 0) {
+        return { key: "no-context", suffix: undefined };
+    }
+    const activeToolNames = pi.getActiveTools();
+    const cacheKey = buildMcpContextEstimateCacheKey(activeToolNames, ctx, contextTokens);
+    if (cache?.key === cacheKey) {
+        return cache;
+    }
+    const allTools = pi.getAllTools();
+    const activeMcpTools = activeToolNames
+        .map((toolName) => allTools.find((candidate) => candidate.name === toolName))
+        .filter((toolInfo) => Boolean(toolInfo?.name))
+        .filter((toolInfo) => getMcpToolKind(toolInfo.name, toolInfo) !== undefined);
+    const toolCatalogByName = new Map(allTools.map((toolInfo) => [toolInfo.name, toolInfo]));
+    let mcpTokens = activeMcpTools.reduce((sum, toolInfo) => sum + estimateMcpDefinitionTokens(toolInfo), 0);
+    for (const entry of ctx.sessionManager.buildContextEntries()) {
+        if (entry.type !== "message") {
+            continue;
+        }
+        const message = entry.message;
+        if (message.role === "assistant" && Array.isArray(message.content)) {
+            for (const block of message.content) {
+                if (block?.type !== "toolCall" || typeof block.name !== "string") {
+                    continue;
+                }
+                if (!getMcpToolKind(block.name, toolCatalogByName.get(block.name))) {
+                    continue;
+                }
+                mcpTokens += estimateTokensFromChars(safeJsonLength(block.arguments));
+            }
+            continue;
+        }
+        if (message.role === "toolResult" && typeof message.toolName === "string") {
+            if (!getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName))) {
+                continue;
+            }
+            mcpTokens += estimateTokensFromChars(resultContentChars(message.content));
+        }
+    }
+    const rawPercent = (mcpTokens / contextTokens) * 100;
+    const percent = Number.isFinite(rawPercent) ? Math.min(100, Math.max(0, rawPercent)) : 0;
+    return {
+        key: cacheKey,
+        suffix: ` • (${percent.toFixed(1)}% of context)`,
+    };
+}
+function appendMcpContextEstimate(statusText, suffix) {
+    if (!suffix || !MCP_STATUS_PREFIX.test(statusText) || statusText.includes("% of context)")) {
+        return statusText;
+    }
+    return `${statusText}${suffix}`;
+}
 export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usageOptions = {}, gitCache, installNotice) {
+    let mcpContextEstimateCache;
     return {
         render(width) {
             const model = ctx.model;
@@ -88,6 +199,12 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
             const line3 = line3Parts.length > 0 ? line3Parts.join(" · ") : undefined;
             const lines = [pwdLine, agentLine2];
             const extensionStatuses = footerData?.getExtensionStatuses?.();
+            const hasMcpStatus = extensionStatuses
+                ? Array.from(extensionStatuses.values()).some((status) => MCP_STATUS_PREFIX.test(sanitizeStatusText(status)))
+                : false;
+            if (hasMcpStatus) {
+                mcpContextEstimateCache = getMcpContextEstimateSuffix(pi, ctx, contextUsage, mcpContextEstimateCache);
+            }
             const tkWorkflowStatus = extensionStatuses?.get(TK_WORKFLOW_STATUS_KEY);
             if (tkWorkflowStatus) {
                 const tkWorkflowLines = tkWorkflowStatus
@@ -114,7 +231,7 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
                     .filter(([key]) => key !== TK_WORKFLOW_STATUS_KEY)
                     .sort(([a], [b]) => a.localeCompare(b));
                 const statusLine = visibleStatuses
-                    .map(([, text]) => sanitizeStatusText(text))
+                    .map(([, text]) => appendMcpContextEstimate(sanitizeStatusText(text), mcpContextEstimateCache?.suffix))
                     .filter(Boolean)
                     .join(" ");
                 if (statusLine) {

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -24,6 +24,11 @@ export { formatTlhSubscriptionUsageFooterSegment } from "./footer-subscription-u
 const CHARS_PER_TOKEN = 4;
 const ESTIMATED_IMAGE_CHARS = 4800;
 const MCP_STATUS_PREFIX = /^MCP:\s/i;
+const KNOWN_PI_MCP_ADAPTER_SOURCES = [
+	"npm:pi-mcp-adapter",
+	"npm:@diegopetrucci/pi-mcp-adapter",
+	"git:github.com/diegopetrucci/pi-mcp-adapter",
+] as const;
 
 type McpFooterContextEstimateCache = {
 	key: string;
@@ -90,14 +95,36 @@ function estimateTokensFromChars(charCount: number): number {
 	return charCount > 0 ? Math.ceil(charCount / CHARS_PER_TOKEN) : 0;
 }
 
-function getMcpToolKind(toolName: string, toolInfo?: ToolInfo): "proxy" | "direct" | undefined {
+function hasKnownPiMcpAdapterSource(source: unknown): source is string {
+	return (
+		typeof source === "string" &&
+		KNOWN_PI_MCP_ADAPTER_SOURCES.some((knownSource) => source === knownSource || source.startsWith(`${knownSource}@`))
+	);
+}
+
+function hasPersistedDirectMcpResultDetails(toolName: string, details: unknown): boolean {
+	if (!details || typeof details !== "object") {
+		return false;
+	}
+	const candidate = details as { server?: unknown; tool?: unknown };
+	if (
+		typeof candidate.server !== "string" ||
+		candidate.server.length === 0 ||
+		typeof candidate.tool !== "string" ||
+		candidate.tool.length === 0
+	) {
+		return false;
+	}
+	const serverPrefix = candidate.server.replaceAll("-", "_");
+	const shortPrefix = candidate.server.replace(/-?mcp$/i, "").replaceAll("-", "_") || "mcp";
+	return new Set([candidate.tool, `${serverPrefix}_${candidate.tool}`, `${shortPrefix}_${candidate.tool}`]).has(toolName);
+}
+
+function getMcpToolKind(toolName: string, toolInfo?: Pick<ToolInfo, "sourceInfo">): "proxy" | "direct" | undefined {
 	if (toolName === "mcp") {
 		return "proxy";
 	}
-	const sourceHint = [toolInfo?.sourceInfo?.source, toolInfo?.sourceInfo?.path]
-		.filter((value): value is string => typeof value === "string")
-		.join(" ");
-	return sourceHint && /mcp/i.test(sourceHint) ? "direct" : undefined;
+	return hasKnownPiMcpAdapterSource(toolInfo?.sourceInfo?.source) ? "direct" : undefined;
 }
 
 function estimateMcpDefinitionTokens(toolInfo: ToolInfo): number {
@@ -134,11 +161,19 @@ function getMcpContextEstimateSuffix(
 	}
 
 	const allTools = pi.getAllTools();
-	const activeMcpTools = activeToolNames
-		.map((toolName) => allTools.find((candidate) => candidate.name === toolName))
-		.filter((toolInfo): toolInfo is ToolInfo => Boolean(toolInfo?.name))
-		.filter((toolInfo) => getMcpToolKind(toolInfo.name, toolInfo) !== undefined);
 	const toolCatalogByName = new Map(allTools.map((toolInfo) => [toolInfo.name, toolInfo]));
+	const knownDirectMcpToolNames = new Set<string>();
+	const activeMcpTools = activeToolNames
+		.map((toolName) => toolCatalogByName.get(toolName))
+		.filter((toolInfo): toolInfo is ToolInfo => Boolean(toolInfo?.name))
+		.filter((toolInfo) => {
+			const kind = getMcpToolKind(toolInfo.name, toolInfo);
+			if (kind === "direct") {
+				knownDirectMcpToolNames.add(toolInfo.name);
+			}
+			return kind !== undefined;
+		});
+	const pendingToolCallsById = new Map<string, { toolName: string; tokens: number }>();
 
 	let mcpTokens = activeMcpTools.reduce((sum, toolInfo) => sum + estimateMcpDefinitionTokens(toolInfo), 0);
 	for (const entry of ctx.sessionManager.buildContextEntries()) {
@@ -151,16 +186,40 @@ function getMcpContextEstimateSuffix(
 				if (block?.type !== "toolCall" || typeof block.name !== "string") {
 					continue;
 				}
-				if (!getMcpToolKind(block.name, toolCatalogByName.get(block.name))) {
+				const catalogKind = getMcpToolKind(block.name, toolCatalogByName.get(block.name));
+				if (catalogKind === "direct") {
+					knownDirectMcpToolNames.add(block.name);
+				}
+				const kind = catalogKind ?? (knownDirectMcpToolNames.has(block.name) ? "direct" : undefined);
+				const argumentTokens = estimateTokensFromChars(safeJsonLength(block.arguments));
+				if (kind) {
+					mcpTokens += argumentTokens;
 					continue;
 				}
-				mcpTokens += estimateTokensFromChars(safeJsonLength(block.arguments));
+				if (typeof block.id === "string") {
+					pendingToolCallsById.set(block.id, { toolName: block.name, tokens: argumentTokens });
+				}
 			}
 			continue;
 		}
 		if (message.role === "toolResult" && typeof message.toolName === "string") {
-			if (!getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName))) {
+			const pendingCall = typeof message.toolCallId === "string" ? pendingToolCallsById.get(message.toolCallId) : undefined;
+			const hasPairedDirectResultProvenance =
+				message.toolName !== "mcp" &&
+				pendingCall?.toolName === message.toolName &&
+				hasPersistedDirectMcpResultDetails(message.toolName, message.details);
+			const kind =
+				getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName)) ??
+				(knownDirectMcpToolNames.has(message.toolName) || hasPairedDirectResultProvenance ? "direct" : undefined);
+			if (!kind) {
 				continue;
+			}
+			if (kind === "direct") {
+				knownDirectMcpToolNames.add(message.toolName);
+				if (pendingCall?.toolName === message.toolName && typeof message.toolCallId === "string") {
+					mcpTokens += pendingCall.tokens;
+					pendingToolCallsById.delete(message.toolCallId);
+				}
 			}
 			mcpTokens += estimateTokensFromChars(resultContentChars(message.content));
 		}

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -5,6 +5,7 @@ import {
 	type ExtensionContext,
 	type ReadonlyFooterDataProvider,
 	type Theme,
+	type ToolInfo,
 } from "@earendil-works/pi-coding-agent";
 import { DUMB_ZONE_LABEL, DUMB_ZONE_THRESHOLD_TOKENS } from "./constants.js";
 import { DEFAULT_PRIMARY_AGENT } from "../the-last-harness-primary-agent.mjs";
@@ -19,6 +20,15 @@ import {
 } from "./footer-subscription-usage.js";
 import type { TlhInstallNotice } from "./types.js";
 export { formatTlhSubscriptionUsageFooterSegment } from "./footer-subscription-usage.js";
+
+const CHARS_PER_TOKEN = 4;
+const ESTIMATED_IMAGE_CHARS = 4800;
+const MCP_STATUS_PREFIX = /^MCP:\s/i;
+
+type McpFooterContextEstimateCache = {
+	key: string;
+	suffix: string | undefined;
+};
 
 function formatCost(cost: number): string {
 	return cost < 0.001 ? "<$0.001" : `$${cost.toFixed(3)}`;
@@ -47,6 +57,130 @@ function collectUsageTotals(ctx: ExtensionContext) {
 	return totals;
 }
 
+function safeJsonLength(value: unknown): number {
+	if (value == null) {
+		return 0;
+	}
+	try {
+		return JSON.stringify(value).length;
+	} catch {
+		return 0;
+	}
+}
+
+function resultContentChars(content: unknown): number {
+	if (!Array.isArray(content)) {
+		return 0;
+	}
+	let total = 0;
+	for (const item of content) {
+		if (!item || typeof item !== "object" || !("type" in item)) {
+			continue;
+		}
+		if (item.type === "text" && "text" in item && typeof item.text === "string") {
+			total += item.text.length;
+		} else if (item.type === "image") {
+			total += ESTIMATED_IMAGE_CHARS;
+		}
+	}
+	return total;
+}
+
+function estimateTokensFromChars(charCount: number): number {
+	return charCount > 0 ? Math.ceil(charCount / CHARS_PER_TOKEN) : 0;
+}
+
+function getMcpToolKind(toolName: string, toolInfo?: ToolInfo): "proxy" | "direct" | undefined {
+	if (toolName === "mcp") {
+		return "proxy";
+	}
+	const sourceHint = [toolInfo?.sourceInfo?.source, toolInfo?.sourceInfo?.path]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ");
+	return sourceHint && /mcp/i.test(sourceHint) ? "direct" : undefined;
+}
+
+function estimateMcpDefinitionTokens(toolInfo: ToolInfo): number {
+	return estimateTokensFromChars(
+		safeJsonLength({
+			name: toolInfo.name,
+			description: toolInfo.description,
+			parameters: toolInfo.parameters,
+			promptGuidelines: toolInfo.promptGuidelines,
+		}),
+	);
+}
+
+function buildMcpContextEstimateCacheKey(activeToolNames: string[], ctx: ExtensionContext, contextTokens: number): string {
+	const leafId = ctx.sessionManager.getLeafId?.() ?? "";
+	return `${leafId}::${contextTokens}::${activeToolNames.join("|")}`;
+}
+
+function getMcpContextEstimateSuffix(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	contextUsage: ReturnType<ExtensionContext["getContextUsage"]>,
+	cache: McpFooterContextEstimateCache | undefined,
+): McpFooterContextEstimateCache {
+	const contextTokens = contextUsage?.tokens;
+	if (typeof contextTokens !== "number" || !Number.isFinite(contextTokens) || contextTokens <= 0) {
+		return { key: "no-context", suffix: undefined };
+	}
+
+	const activeToolNames = pi.getActiveTools();
+	const cacheKey = buildMcpContextEstimateCacheKey(activeToolNames, ctx, contextTokens);
+	if (cache?.key === cacheKey) {
+		return cache;
+	}
+
+	const allTools = pi.getAllTools();
+	const activeMcpTools = activeToolNames
+		.map((toolName) => allTools.find((candidate) => candidate.name === toolName))
+		.filter((toolInfo): toolInfo is ToolInfo => Boolean(toolInfo?.name))
+		.filter((toolInfo) => getMcpToolKind(toolInfo.name, toolInfo) !== undefined);
+	const toolCatalogByName = new Map(allTools.map((toolInfo) => [toolInfo.name, toolInfo]));
+
+	let mcpTokens = activeMcpTools.reduce((sum, toolInfo) => sum + estimateMcpDefinitionTokens(toolInfo), 0);
+	for (const entry of ctx.sessionManager.buildContextEntries()) {
+		if (entry.type !== "message") {
+			continue;
+		}
+		const message = entry.message;
+		if (message.role === "assistant" && Array.isArray(message.content)) {
+			for (const block of message.content) {
+				if (block?.type !== "toolCall" || typeof block.name !== "string") {
+					continue;
+				}
+				if (!getMcpToolKind(block.name, toolCatalogByName.get(block.name))) {
+					continue;
+				}
+				mcpTokens += estimateTokensFromChars(safeJsonLength(block.arguments));
+			}
+			continue;
+		}
+		if (message.role === "toolResult" && typeof message.toolName === "string") {
+			if (!getMcpToolKind(message.toolName, toolCatalogByName.get(message.toolName))) {
+				continue;
+			}
+			mcpTokens += estimateTokensFromChars(resultContentChars(message.content));
+		}
+	}
+
+	const rawPercent = (mcpTokens / contextTokens) * 100;
+	const percent = Number.isFinite(rawPercent) ? Math.min(100, Math.max(0, rawPercent)) : 0;
+	return {
+		key: cacheKey,
+		suffix: ` • (${percent.toFixed(1)}% of context)`,
+	};
+}
+
+function appendMcpContextEstimate(statusText: string, suffix: string | undefined): string {
+	if (!suffix || !MCP_STATUS_PREFIX.test(statusText) || statusText.includes("% of context)")) {
+		return statusText;
+	}
+	return `${statusText}${suffix}`;
+}
+
 export type TlhFooterUsageOptions = TlhFooterSubscriptionUsageOptions;
 
 export function createTlhFooter(
@@ -59,6 +193,7 @@ export function createTlhFooter(
 	gitCache?: FooterGitCache | null,
 	installNotice?: TlhInstallNotice,
 ) {
+	let mcpContextEstimateCache: McpFooterContextEstimateCache | undefined;
 	return {
 		render(width: number): string[] {
 			const model = ctx.model;
@@ -128,6 +263,12 @@ export function createTlhFooter(
 			const lines: string[] = [pwdLine, agentLine2];
 
 			const extensionStatuses = footerData?.getExtensionStatuses?.();
+			const hasMcpStatus = extensionStatuses
+				? Array.from(extensionStatuses.values()).some((status) => MCP_STATUS_PREFIX.test(sanitizeStatusText(status)))
+				: false;
+			if (hasMcpStatus) {
+				mcpContextEstimateCache = getMcpContextEstimateSuffix(pi, ctx, contextUsage, mcpContextEstimateCache);
+			}
 			const tkWorkflowStatus = extensionStatuses?.get(TK_WORKFLOW_STATUS_KEY);
 			if (tkWorkflowStatus) {
 				const tkWorkflowLines = tkWorkflowStatus
@@ -159,7 +300,7 @@ export function createTlhFooter(
 					.filter(([key]) => key !== TK_WORKFLOW_STATUS_KEY)
 					.sort(([a], [b]) => a.localeCompare(b));
 				const statusLine = visibleStatuses
-					.map(([, text]) => sanitizeStatusText(text))
+					.map(([, text]) => appendMcpContextEstimate(sanitizeStatusText(text), mcpContextEstimateCache?.suffix))
 					.filter(Boolean)
 					.join(" ");
 				if (statusLine) {

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -21,6 +21,8 @@ const theme = {
 
 const pi = {
 	getThinkingLevel: () => "medium",
+	getActiveTools: () => [],
+	getAllTools: () => [],
 };
 
 function createFooterData(options = {}) {
@@ -116,6 +118,8 @@ function createCtx(options = {}) {
 		},
 		sessionManager: {
 			getEntries: () => options.entries ?? [assistantCostEntry(1.25)],
+			buildContextEntries: () => options.contextEntries ?? options.entries ?? [assistantCostEntry(1.25)],
+			getLeafId: () => options.leafId ?? "leaf-1",
 			getCwd: () => "/tmp/the-last-harness",
 			getSessionName: () => options.sessionName,
 		},
@@ -124,6 +128,21 @@ function createCtx(options = {}) {
 			getEditorText: () => options.editorText ?? "",
 		},
 		isIdle: () => options.idle ?? true,
+	};
+}
+
+function createToolInfo(name, source = "built-in") {
+	return {
+		name,
+		description: `${name} description`,
+		parameters: { type: "object", properties: { value: { type: "string" } } },
+		promptGuidelines: [`Use ${name}`],
+		sourceInfo: {
+			source,
+			path: `/tmp/${name}.ts`,
+			scope: "project",
+			origin: "top-level",
+		},
 	};
 }
 
@@ -841,4 +860,212 @@ test("footer warning line stays within narrow widths", () => {
 	const width = 20;
 	const lines = footer.render(width);
 	assert.ok(lines.every((line) => visibleWidth(line) <= width), `all lines must fit in ${width} chars`);
+});
+
+function renderMcpStatus({ activeTools = [], allTools = [], contextEntries = [], contextTokens = 100000, status = "MCP: 0/1 servers" } = {}) {
+	const mcpPi = {
+		...pi,
+		getActiveTools: () => activeTools,
+		getAllTools: () => allTools,
+	};
+	const ctx = createCtx({
+		entries: [],
+		contextUsage: { tokens: contextTokens, contextWindow: 200000, percent: 50 },
+		contextEntries,
+	});
+	const footerData = {
+		...createFooterData(),
+		getExtensionStatuses: () => new Map([["mcp-status", status]]),
+	};
+	return createTlhFooter(mcpPi, ctx, theme, () => "architect", footerData, {}).render(WIDTH).at(-1) ?? "";
+}
+
+function mcpStatusPercent(options) {
+	return Number(renderMcpStatus(options).match(/\((\d+\.\d)% of context\)$/)?.[1]);
+}
+
+test("footer appends a one-decimal MCP context estimate to the existing status", () => {
+	const status = renderMcpStatus({
+		activeTools: ["mcp"],
+		allTools: [createToolInfo("mcp", "mcp-proxy")],
+		contextTokens: 1000,
+	});
+	assert.equal(status, "MCP: 0/1 servers • (3.8% of context)");
+});
+
+test("footer independently attributes proxy and direct MCP definitions, arguments, and results", () => {
+	const proxyTool = { ...createToolInfo("mcp", "mcp-proxy"), description: "p".repeat(4000) };
+	const directTool = { ...createToolInfo("jiraSearch", "acme-mcp"), description: "d".repeat(4000) };
+	const allTools = [proxyTool, directTool];
+	const baseline = mcpStatusPercent({ allTools });
+	const proxyDefinition = mcpStatusPercent({ activeTools: ["mcp"], allTools });
+	const directDefinition = mcpStatusPercent({ activeTools: ["jiraSearch"], allTools });
+
+	assert.equal(proxyDefinition - baseline, 1, "proxy definition contributes independently");
+	assert.equal(directDefinition - baseline, 1, "direct definition contributes independently");
+
+	const proxyCall = mcpStatusPercent({
+		activeTools: ["mcp"],
+		allTools,
+		contextEntries: [
+			{ type: "message", message: { role: "assistant", content: [{ type: "toolCall", name: "mcp", arguments: { payload: "x".repeat(4000) } }] } },
+		],
+	});
+	const directCall = mcpStatusPercent({
+		activeTools: ["jiraSearch"],
+		allTools,
+		contextEntries: [
+			{ type: "message", message: { role: "assistant", content: [{ type: "toolCall", name: "jiraSearch", arguments: { payload: "x".repeat(4000) } }] } },
+		],
+	});
+	assert.equal(proxyCall - proxyDefinition, 1, "proxy call arguments contribute independently");
+	assert.equal(directCall - directDefinition, 1, "direct call arguments contribute independently");
+
+	const proxyResult = mcpStatusPercent({
+		activeTools: ["mcp"],
+		allTools,
+		contextEntries: [
+			{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: "x".repeat(4000) }] } },
+		],
+	});
+	const directResult = mcpStatusPercent({
+		activeTools: ["jiraSearch"],
+		allTools,
+		contextEntries: [
+			{ type: "message", message: { role: "toolResult", toolName: "jiraSearch", content: [{ type: "text", text: "x".repeat(4000) }] } },
+		],
+	});
+	assert.equal(proxyResult - proxyDefinition, 1, "proxy result content contributes independently");
+	assert.equal(directResult - directDefinition, 1, "direct result content contributes independently");
+});
+
+test("footer clamps MCP context share to a finite 0–100% range", () => {
+	const tool = createToolInfo("mcp", "mcp-proxy");
+	assert.equal(
+		renderMcpStatus({ activeTools: ["mcp"], allTools: [tool], contextTokens: 1 }),
+		"MCP: 0/1 servers • (100.0% of context)",
+	);
+	assert.equal(renderMcpStatus({ activeTools: ["mcp"], allTools: [tool], contextTokens: Number.NaN }), "MCP: 0/1 servers");
+});
+
+test("footer MCP context estimate counts each tool-result image as 1200 tokens", () => {
+	const mcpPi = {
+		...pi,
+		getActiveTools: () => ["mcp"],
+		getAllTools: () => [createToolInfo("mcp", "mcp-proxy")],
+	};
+	const footerData = {
+		...createFooterData(),
+		getExtensionStatuses: () => new Map([["mcp-status", "MCP: 1/1 servers"]]),
+	};
+	const renderPercent = (content) => {
+		const ctx = createCtx({
+			entries: [],
+			contextUsage: { tokens: 120000, contextWindow: 200000, percent: 60 },
+			contextEntries: [{ type: "message", message: { role: "toolResult", toolName: "mcp", content } }],
+		});
+		const status = createTlhFooter(mcpPi, ctx, theme, () => "architect", footerData, {}).render(WIDTH).at(-1) ?? "";
+		return Number(status.match(/\((\d+\.\d)% of context\)$/)?.[1]);
+	};
+
+	const withoutImage = renderPercent([{ type: "text", text: "ok" }]);
+	const withImage = renderPercent([
+		{ type: "text", text: "ok" },
+		{ type: "image", data: "ignored-base64-data", mimeType: "image/png" },
+	]);
+	assert.equal(withImage - withoutImage, 1);
+});
+
+test("footer MCP context estimate uses active compaction-aware entries and omits unknown context totals", () => {
+	const mcpPi = {
+		...pi,
+		getActiveTools: () => ["mcp"],
+		getAllTools: () => [createToolInfo("mcp", "mcp-proxy")],
+	};
+	const archivedPayload = "x".repeat(800);
+	const activePayload = "ok";
+	const footerData = {
+		...createFooterData(),
+		getExtensionStatuses: () => new Map([["mcp-status", "MCP: 1/1 servers"]]),
+	};
+	const ctx = createCtx({
+		entries: [
+			{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: archivedPayload }] } },
+		],
+		contextEntries: [
+			{ type: "compaction", summary: "older history compacted" },
+			{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: activePayload }] } },
+		],
+		contextUsage: { tokens: 1000, contextWindow: 200000, percent: 12.3 },
+	});
+	const lines = createTlhFooter(mcpPi, ctx, theme, () => "architect", footerData, {}).render(WIDTH);
+	assert.match(lines.at(-1) ?? "", /MCP: 1\/1 servers • \(3\.9% of context\)$/);
+
+	const unknownContextCtx = createCtx({
+		entries: [],
+		contextEntries: ctx.sessionManager.buildContextEntries(),
+		contextUsage: { tokens: null, contextWindow: 200000, percent: null },
+	});
+	const unknownLines = createTlhFooter(mcpPi, unknownContextCtx, theme, () => "architect", footerData, {}).render(WIDTH);
+	assert.equal(unknownLines.at(-1), "MCP: 1/1 servers");
+});
+
+test("footer caches repeated MCP context estimates until the active context changes", () => {
+	let getAllToolsCalls = 0;
+	let buildContextEntriesCalls = 0;
+	const leafState = { current: "leaf-1" };
+	const mcpPi = {
+		...pi,
+		getActiveTools: () => ["mcp"],
+		getAllTools: () => {
+			getAllToolsCalls += 1;
+			return [createToolInfo("mcp", "mcp-proxy")];
+		},
+	};
+	const ctx = createCtx({
+		entries: [],
+		leafId: leafState.current,
+		contextUsage: { tokens: 1000, contextWindow: 200000, percent: 12.3 },
+		contextEntries: [{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: "ok" }] } }],
+	});
+	ctx.sessionManager.getLeafId = () => leafState.current;
+	ctx.sessionManager.buildContextEntries = () => {
+		buildContextEntriesCalls += 1;
+		return [{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: "ok" }] } }];
+	};
+	const footerData = {
+		...createFooterData(),
+		getExtensionStatuses: () => new Map([["mcp-status", "MCP: 1/1 servers"]]),
+	};
+	const footer = createTlhFooter(mcpPi, ctx, theme, () => "architect", footerData, {});
+
+	footer.render(WIDTH);
+	footer.render(WIDTH);
+	assert.equal(getAllToolsCalls, 1);
+	assert.equal(buildContextEntriesCalls, 1);
+
+	leafState.current = "leaf-2";
+	footer.render(WIDTH);
+	assert.equal(getAllToolsCalls, 2);
+	assert.equal(buildContextEntriesCalls, 2);
+});
+
+test("footer keeps the MCP status estimate within narrow widths", () => {
+	const mcpPi = {
+		...pi,
+		getActiveTools: () => ["mcp"],
+		getAllTools: () => [createToolInfo("mcp", "mcp-proxy")],
+	};
+	const footerData = {
+		...createFooterData(),
+		getExtensionStatuses: () => new Map([["mcp-status", "MCP: 0/1 servers"]]),
+	};
+	const ctx = createCtx({
+		entries: [],
+		contextUsage: { tokens: 1000, contextWindow: 200000, percent: 12.3 },
+		contextEntries: [{ type: "message", message: { role: "toolResult", toolName: "mcp", content: [{ type: "text", text: "ok" }] } }],
+	});
+	const lines = createTlhFooter(mcpPi, ctx, theme, () => "architect", footerData, {}).render(24);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 24));
+	assert.match(lines.at(-1) ?? "", /\.\.\./);
 });

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -131,7 +131,7 @@ function createCtx(options = {}) {
 	};
 }
 
-function createToolInfo(name, source = "built-in") {
+function createToolInfo(name, source = "built-in", path = `/tmp/${name}.ts`) {
 	return {
 		name,
 		description: `${name} description`,
@@ -139,7 +139,7 @@ function createToolInfo(name, source = "built-in") {
 		promptGuidelines: [`Use ${name}`],
 		sourceInfo: {
 			source,
-			path: `/tmp/${name}.ts`,
+			path,
 			scope: "project",
 			origin: "top-level",
 		},
@@ -894,8 +894,11 @@ test("footer appends a one-decimal MCP context estimate to the existing status",
 });
 
 test("footer independently attributes proxy and direct MCP definitions, arguments, and results", () => {
-	const proxyTool = { ...createToolInfo("mcp", "mcp-proxy"), description: "p".repeat(4000) };
-	const directTool = { ...createToolInfo("jiraSearch", "acme-mcp"), description: "d".repeat(4000) };
+	const proxyTool = { ...createToolInfo("mcp", "npm:pi-mcp-adapter", "extensions/mcp.mjs"), description: "p".repeat(4000) };
+	const directTool = {
+		...createToolInfo("jiraSearch", "npm:@diegopetrucci/pi-mcp-adapter@2.10.1", "extensions/direct-tools/jira.mjs"),
+		description: "d".repeat(4000),
+	};
 	const allTools = [proxyTool, directTool];
 	const baseline = mcpStatusPercent({ allTools });
 	const proxyDefinition = mcpStatusPercent({ activeTools: ["mcp"], allTools });
@@ -937,6 +940,97 @@ test("footer independently attributes proxy and direct MCP definitions, argument
 	});
 	assert.equal(proxyResult - proxyDefinition, 1, "proxy result content contributes independently");
 	assert.equal(directResult - directDefinition, 1, "direct result content contributes independently");
+});
+
+test("footer ignores unrelated non-adapter provenance even when source paths include mcp", () => {
+	const misleadingTool = createToolInfo("jiraSearch", "npm:acme-helper", "extensions/mcp-utils/jira.mjs");
+	const baseline = mcpStatusPercent({ allTools: [misleadingTool] });
+	const definition = mcpStatusPercent({ activeTools: ["jiraSearch"], allTools: [misleadingTool] });
+	const call = mcpStatusPercent({
+		activeTools: ["jiraSearch"],
+		allTools: [misleadingTool],
+		contextEntries: [
+			{ type: "message", message: { role: "assistant", content: [{ type: "toolCall", name: "jiraSearch", arguments: { payload: "x".repeat(4000) } }] } },
+		],
+	});
+	const result = mcpStatusPercent({
+		activeTools: ["jiraSearch"],
+		allTools: [misleadingTool],
+		contextEntries: [
+			{ type: "message", message: { role: "toolResult", toolName: "jiraSearch", content: [{ type: "text", text: "x".repeat(4000) }] } },
+		],
+	});
+
+	assert.equal(baseline, 0);
+	assert.equal(definition, 0);
+	assert.equal(call, 0);
+	assert.equal(result, 0);
+});
+
+test("footer releases all pending cold-catalog direct calls after real adapter provenance is established", () => {
+	const recovered = mcpStatusPercent({
+		activeTools: ["jira_search_issues"],
+		allTools: [],
+		contextEntries: [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "call-1", name: "jira_search_issues", arguments: { payload: "x".repeat(4000) } },
+						{ type: "toolCall", id: "call-2", name: "jira_search_issues", arguments: { payload: "x".repeat(4000) } },
+					],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "jira_search_issues",
+					toolCallId: "call-1",
+					details: { server: "jira", tool: "search_issues" },
+					content: [{ type: "text", text: "x".repeat(4000) }],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "jira_search_issues",
+					toolCallId: "call-2",
+					details: { error: "tool_error", server: "jira" },
+					content: [{ type: "text", text: "x".repeat(4000) }],
+				},
+			},
+		],
+	});
+
+	assert.equal(recovered, 4);
+});
+
+test("footer rejects generic paired server/tool details that do not match adapter direct-tool naming", () => {
+	const lookalike = mcpStatusPercent({
+		activeTools: ["jiraSearch"],
+		allTools: [],
+		contextEntries: [
+			{
+				type: "message",
+				message: { role: "assistant", content: [{ type: "toolCall", id: "other-call", name: "jiraSearch", arguments: { payload: "x".repeat(4000) } }] },
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "jiraSearch",
+					toolCallId: "other-call",
+					details: { server: "jira", tool: "search_issues" },
+					content: [{ type: "text", text: "x".repeat(4000) }],
+				},
+			},
+		],
+	});
+
+	assert.equal(lookalike, 0);
 });
 
 test("footer clamps MCP context share to a finite 0–100% range", () => {


### PR DESCRIPTION
## Summary

- append an estimated MCP share to the existing MCP footer status, for example `MCP: 0/1 servers • (0.2% of context)`
- include active proxy/direct MCP definitions and compaction-aware MCP calls/results
- cache attribution across unchanged footer renders and safely bound the display to `0–100%`

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
node --test tests/the-last-harness-footer-usage.test.mjs
npm run check:runtime
npx eslint extensions/the-last-harness/footer.ts extensions/the-last-harness/footer.js tests/the-last-harness-footer-usage.test.mjs
```

- Focused footer tests pass: 59/59.
- Typechecks, runtime freshness, package-version checks, installer smoke, and scoped lint pass.
- Full validation reaches `npm test` but local `node_modules` contain Pi/TUI `0.82.0` while the repository pins `0.82.1`; package-runtime smoke therefore stops before later chained checks. No package manifests or lockfiles changed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this focused footer enhancement)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/feature/mcp-context-footer/install.sh | bash -s -- --ref feature/mcp-context-footer --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP status lines in the footer now display the estimated percentage of context used by MCP tools and results.
  * Estimates account for tool definitions, calls, returned content, and images.
  * Percentages adapt to current context and update when the active session changes.

* **Bug Fixes**
  * MCP usage percentages are bounded between 0% and 100%.
  * Footer status remains readable in narrow terminal windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->