### PR TITLE
Retry Herdr activity socket reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to The Last Harness will be documented in this file.
 - Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.10` to `npm:@diegopetrucci/pi-subagents@0.31.11`.
 - **pi-intercom retired:** the `pi-intercom` default remains force-removed from isolated settings on update. With bundled `pi-subagents` 0.31.11, child-session escalations should use `contact_supervisor`. Blocking requests durably pause and are resolved with `subagent` resume or interrupt. `subagent_supervisor` provides pending/status inspection and legacy live-session reply compatibility when available. Use `steer` for non-blocking guidance. The `/intercom` overlay, `Alt+M` keybind, and peer-session ask/reply are no longer available.
 
+### Fixed
+
+- TLH's Herdr activity reporter now retries one failed socket delivery attempt with the same bounded timeout sequence Herdr 0.7.5 expects, while preserving TLH-owned reporter source/session sequencing and external Herdr configuration.
+
 ## [0.31.0] - 2026-07-27
 
 ### Changed

--- a/extensions/the-last-harness/activity-reporters.js
+++ b/extensions/the-last-harness/activity-reporters.js
@@ -6,6 +6,7 @@ const HERDR_SOURCE = "herdr:tlh";
 const HERDR_AGENT = "pi";
 const CMUX_STATUS_KEY = "tlh";
 const DEFAULT_IDLE_DEBOUNCE_MS = 250;
+const HERDR_SOCKET_ATTEMPT_TIMEOUTS_MS = [500, 1500];
 function parseDurationEnv(env, name, fallback) {
     const raw = env[name];
     if (!raw)
@@ -123,39 +124,73 @@ function withSessionRef(params, sessionRef) {
     }
     return params;
 }
-function defaultHerdrRequestSender(env) {
+function createHerdrSocketAttempt(socketPath, request, timeoutMs, options) {
+    const timers = {
+        setTimeout: options.timers?.setTimeout ?? setTimeout,
+        clearTimeout: options.timers?.clearTimeout ?? clearTimeout,
+    };
+    const payload = `${JSON.stringify(request)}\n`;
+    const createSocket = options.createSocket ?? ((path) => createConnection(path));
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let timeout;
+        const finish = (delivered) => {
+            if (settled)
+                return;
+            settled = true;
+            if (timeout) {
+                timers.clearTimeout(timeout);
+                timeout = undefined;
+            }
+            socket?.removeListener?.("error", handleError);
+            socket?.removeListener?.("connect", handleConnect);
+            socket?.removeListener?.("data", handleData);
+            socket?.removeListener?.("end", handleEnd);
+            try {
+                socket?.destroy();
+            }
+            catch {
+            }
+            resolve(delivered);
+        };
+        const handleError = () => finish(false);
+        const handleConnect = () => {
+            try {
+                socket?.write(payload);
+            }
+            catch {
+                finish(false);
+            }
+        };
+        const handleData = () => finish(true);
+        const handleEnd = () => finish(false);
+        try {
+            socket = createSocket(socketPath);
+        }
+        catch {
+            finish(false);
+            return;
+        }
+        socket.on("error", handleError);
+        socket.on("connect", handleConnect);
+        socket.on("data", handleData);
+        socket.on("end", handleEnd);
+        timeout = timers.setTimeout(() => finish(false), timeoutMs);
+        timeout.unref?.();
+    });
+}
+function defaultHerdrRequestSender(env, options = {}) {
     return async (request) => {
         const socketPath = env.HERDR_SOCKET_PATH;
         if (!socketPath)
             return;
-        await new Promise((resolve) => {
-            let settled = false;
-            let socket;
-            const finish = () => {
-                if (settled)
-                    return;
-                settled = true;
-                try {
-                    socket?.destroy();
-                }
-                catch {
-                }
-                resolve();
-            };
-            try {
-                socket = createConnection(socketPath);
-            }
-            catch {
-                finish();
+        for (const timeoutMs of HERDR_SOCKET_ATTEMPT_TIMEOUTS_MS) {
+            const delivered = await createHerdrSocketAttempt(socketPath, request, timeoutMs, options);
+            if (delivered) {
                 return;
             }
-            socket.on("error", finish);
-            socket.on("connect", () => socket?.write(`${JSON.stringify(request)}\n`));
-            socket.on("data", finish);
-            socket.on("end", finish);
-            const timeout = setTimeout(finish, 500);
-            timeout.unref?.();
-        });
+        }
     };
 }
 export function createHerdrActivityReporter(options = {}) {
@@ -171,7 +206,7 @@ export function createHerdrActivityReporter(options = {}) {
     if (agentDir && existsSync(join(agentDir, "extensions", "herdr-agent-state.ts"))) {
         return createNoopReporter();
     }
-    const sendRequest = options.sendRequest ?? defaultHerdrRequestSender(env);
+    const sendRequest = options.sendRequest ?? defaultHerdrRequestSender(env, options);
     const now = options.now ?? Date.now;
     let reportSeq = now() * 1000;
     let sessionRef = {};

--- a/extensions/the-last-harness/activity-reporters.ts
+++ b/extensions/the-last-harness/activity-reporters.ts
@@ -9,6 +9,7 @@ const HERDR_SOURCE = "herdr:tlh";
 const HERDR_AGENT = "pi";
 const CMUX_STATUS_KEY = "tlh";
 const DEFAULT_IDLE_DEBOUNCE_MS = 250;
+const HERDR_SOCKET_ATTEMPT_TIMEOUTS_MS = [500, 1500] as const;
 
 type TimeoutHandle = ReturnType<typeof setTimeout>;
 
@@ -32,12 +33,15 @@ type TlhActivityReporterOptions = {
 };
 
 type HerdrRequestSender = (request: unknown) => Promise<void>;
+type HerdrSocket = Pick<ReturnType<typeof createConnection>, "on" | "removeListener" | "write" | "destroy">;
+type HerdrSocketFactory = (path: string) => HerdrSocket;
 
 type HerdrActivityReporterOptions = TlhActivityReporterOptions & {
 	env?: NodeJS.ProcessEnv;
 	sendRequest?: HerdrRequestSender;
 	now?: () => number;
 	agentDir?: string;
+	createSocket?: HerdrSocketFactory;
 };
 
 type CommandRunner = (command: string, args: readonly string[]) => Promise<void>;
@@ -174,36 +178,81 @@ function withSessionRef(params: Record<string, unknown>, sessionRef: ActivitySes
 	return params;
 }
 
-function defaultHerdrRequestSender(env: NodeJS.ProcessEnv): HerdrRequestSender {
+function createHerdrSocketAttempt(
+	socketPath: string,
+	request: unknown,
+	timeoutMs: number,
+	options: {
+		createSocket?: HerdrSocketFactory;
+		timers?: Partial<TimerApi>;
+	},
+): Promise<boolean> {
+	const timers: TimerApi = {
+		setTimeout: options.timers?.setTimeout ?? setTimeout,
+		clearTimeout: options.timers?.clearTimeout ?? clearTimeout,
+	};
+	const payload = `${JSON.stringify(request)}\n`;
+	const createSocket = options.createSocket ?? ((path: string) => createConnection(path));
+	return new Promise<boolean>((resolve) => {
+		let settled = false;
+		let socket: HerdrSocket | undefined;
+		let timeout: TimeoutHandle | undefined;
+		const finish = (delivered: boolean) => {
+			if (settled) return;
+			settled = true;
+			if (timeout) {
+				timers.clearTimeout(timeout);
+				timeout = undefined;
+			}
+			socket?.removeListener?.("error", handleError);
+			socket?.removeListener?.("connect", handleConnect);
+			socket?.removeListener?.("data", handleData);
+			socket?.removeListener?.("end", handleEnd);
+			try {
+				socket?.destroy();
+			} catch {
+				// Ignore teardown failures.
+			}
+			resolve(delivered);
+		};
+		const handleError = () => finish(false);
+		const handleConnect = () => {
+			try {
+				socket?.write(payload);
+			} catch {
+				finish(false);
+			}
+		};
+		const handleData = () => finish(true);
+		const handleEnd = () => finish(false);
+		try {
+			socket = createSocket(socketPath);
+		} catch {
+			finish(false);
+			return;
+		}
+		socket.on("error", handleError);
+		socket.on("connect", handleConnect);
+		socket.on("data", handleData);
+		socket.on("end", handleEnd);
+		timeout = timers.setTimeout(() => finish(false), timeoutMs);
+		(timeout as { unref?: () => void }).unref?.();
+	});
+}
+
+function defaultHerdrRequestSender(
+	env: NodeJS.ProcessEnv,
+	options: Pick<HerdrActivityReporterOptions, "createSocket" | "timers"> = {},
+): HerdrRequestSender {
 	return async (request) => {
 		const socketPath = env.HERDR_SOCKET_PATH;
 		if (!socketPath) return;
-		await new Promise<void>((resolve) => {
-			let settled = false;
-			let socket: ReturnType<typeof createConnection> | undefined;
-			const finish = () => {
-				if (settled) return;
-				settled = true;
-				try {
-					socket?.destroy();
-				} catch {
-					// Ignore teardown failures.
-				}
-				resolve();
-			};
-			try {
-				socket = createConnection(socketPath);
-			} catch {
-				finish();
+		for (const timeoutMs of HERDR_SOCKET_ATTEMPT_TIMEOUTS_MS) {
+			const delivered = await createHerdrSocketAttempt(socketPath, request, timeoutMs, options);
+			if (delivered) {
 				return;
 			}
-			socket.on("error", finish);
-			socket.on("connect", () => socket?.write(`${JSON.stringify(request)}\n`));
-			socket.on("data", finish);
-			socket.on("end", finish);
-			const timeout = setTimeout(finish, 500);
-			timeout.unref?.();
-		});
+		}
 	};
 }
 
@@ -220,7 +269,7 @@ export function createHerdrActivityReporter(options: HerdrActivityReporterOption
 	if (agentDir && existsSync(join(agentDir, "extensions", "herdr-agent-state.ts"))) {
 		return createNoopReporter();
 	}
-	const sendRequest = options.sendRequest ?? defaultHerdrRequestSender(env);
+	const sendRequest = options.sendRequest ?? defaultHerdrRequestSender(env, options);
 	const now = options.now ?? Date.now;
 	let reportSeq = now() * 1000;
 	let sessionRef: ActivitySessionRef = {};

--- a/tests/the-last-harness-activity-reporters.test.mjs
+++ b/tests/the-last-harness-activity-reporters.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,7 +20,7 @@ function createFakeTimers() {
 		now: () => now,
 		setTimeout(fn, delay = 0) {
 			const id = nextId++;
-			timers.set(id, { fn, at: now + delay });
+			timers.set(id, { fn, at: now + delay, delay });
 			return { id, unref() {} };
 		},
 		clearTimeout(handle) {
@@ -38,7 +39,25 @@ function createFakeTimers() {
 				}
 			}
 		},
+		getPendingDelays() {
+			return [...timers.values()].map((timer) => timer.delay).sort((a, b) => a - b);
+		},
 	};
+}
+
+function createFakeSocket(path) {
+	const socket = new EventEmitter();
+	socket.path = path;
+	socket.writes = [];
+	socket.destroyCalls = 0;
+	socket.write = (chunk) => {
+		socket.writes.push(chunk);
+		return true;
+	};
+	socket.destroy = () => {
+		socket.destroyCalls += 1;
+	};
+	return socket;
 }
 
 async function flushAsyncWork() {
@@ -74,6 +93,89 @@ test("Herdr reporter no-ops without required env and when official reporter is i
 	singleWriterReporter.handleSnapshot({ inProgress: true, primaryReasons: ["primary:agent-loop"], activeAsyncJobIds: [] });
 	await flushAsyncWork();
 	assert.deepEqual(singleWriterCalls, []);
+});
+
+test("Herdr reporter retries timed out activity socket delivery once", async () => {
+	const timers = createFakeTimers();
+	const sockets = [];
+	const reporter = createHerdrActivityReporter({
+		env: { HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "pane-1" },
+		createSocket: (path) => {
+			const socket = createFakeSocket(path);
+			sockets.push(socket);
+			return socket;
+		},
+		timers,
+		now: timers.now,
+	});
+
+	reporter.handleSessionStart({
+		hasUI: true,
+		sessionManager: { getSessionFile: () => undefined, getSessionId: () => undefined },
+	});
+	reporter.handleSnapshot({ inProgress: true, primaryReasons: ["primary:agent-loop"], activeAsyncJobIds: [] });
+	await flushAsyncWork();
+	assert.equal(sockets.length, 1);
+	assert.deepEqual(timers.getPendingDelays(), [500]);
+
+	sockets[0].emit("connect");
+	assert.equal(sockets[0].writes.length, 1);
+
+	timers.advance(499);
+	await flushAsyncWork();
+	assert.equal(sockets.length, 1);
+	assert.equal(sockets[0].destroyCalls, 0);
+
+	timers.advance(1);
+	await flushAsyncWork();
+	assert.equal(sockets[0].destroyCalls, 1);
+	assert.equal(sockets.length, 2);
+	assert.deepEqual(timers.getPendingDelays(), [1500]);
+
+	sockets[1].emit("connect");
+	assert.equal(sockets[1].writes.length, 1);
+	assert.equal(JSON.parse(sockets[1].writes[0]).method, "pane.report_agent");
+	sockets[1].emit("data", Buffer.from("ok"));
+	await flushAsyncWork();
+	assert.equal(sockets[1].destroyCalls, 1);
+	assert.deepEqual(timers.getPendingDelays(), []);
+	assert.deepEqual(JSON.parse(sockets[0].writes[0]), JSON.parse(sockets[1].writes[0]));
+});
+
+test("Herdr reporter does not retry after first activity socket response", async () => {
+	const timers = createFakeTimers();
+	const sockets = [];
+	const reporter = createHerdrActivityReporter({
+		env: { HERDR_SOCKET_PATH: "/tmp/herdr.sock", HERDR_PANE_ID: "pane-1" },
+		createSocket: (path) => {
+			const socket = createFakeSocket(path);
+			sockets.push(socket);
+			return socket;
+		},
+		timers,
+		now: timers.now,
+	});
+
+	reporter.handleSessionStart({
+		hasUI: true,
+		sessionManager: { getSessionFile: () => undefined, getSessionId: () => undefined },
+	});
+	reporter.handleSnapshot({ inProgress: true, primaryReasons: ["primary:agent-loop"], activeAsyncJobIds: [] });
+	await flushAsyncWork();
+	assert.equal(sockets.length, 1);
+	assert.deepEqual(timers.getPendingDelays(), [500]);
+
+	sockets[0].emit("connect");
+	assert.equal(sockets[0].writes.length, 1);
+	sockets[0].emit("data", Buffer.from("ok"));
+	await flushAsyncWork();
+	assert.equal(sockets[0].destroyCalls, 1);
+	assert.deepEqual(timers.getPendingDelays(), []);
+
+	timers.advance(5000);
+	await flushAsyncWork();
+	assert.equal(sockets.length, 1);
+	assert.equal(JSON.parse(sockets[0].writes[0]).method, "pane.report_agent");
 });
 
 test("Herdr reporter sends monotonic working/idle state with session refs", async () => {


### PR DESCRIPTION
## Summary

Retry dropped TLH Herdr activity socket reports using Herdr 0.7.5's bounded 500 ms / 1500 ms delivery attempts. This prevents foreground work from remaining incorrectly idle when the first socket report races Herdr startup or load.

Preserves the `herdr:tlh` source, external configuration, session sequencing, and official-reporter single-writer guard. Related upstream behavior: https://github.com/ogulcancelik/herdr/issues/1049

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed after refreshing the stale local dependency install with `npm ci`.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants; installer behavior is unchanged
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/herdr-activity-retry/install.sh | bash -s -- --ref fix/herdr-activity-retry --track ref
```
