### PR TITLE
Release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-08-03
+
 ### Added
 
 - In the footer, TLH now shows how much context MCPs are consuming.

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ The installer is split into a stage-0 Bash bootstrapper (`install.sh`) and a sta
 - Pinned to a release tag for future updates:
 
 ```sh
-curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.31.0/install.sh | bash -s -- --track pinned-tag
+curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.32.0/install.sh | bash -s -- --track pinned-tag
 ```
 - Any remote branch, eg `main`:
 
@@ -44,7 +44,7 @@ curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/main
     TLH_WRAPPER_NAME=tlh TLH_AGENT_DIR=~/.the-last-harness/agent bash -s -- --ref main --track ref
   ```
 
-These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a header warning only for those installs. It appears above `Context:` and reads `Warning: running TLH from {name} track` (for example `Warning: running TLH from v0.31.0 track`, `Warning: running TLH from main track`, `Warning: running TLH from local track`, or `Warning: running TLH from unknown track`). Official latest-release installs skip that warning, though interactive starts may still show a quiet startup tip.
+These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH shows a header warning only for those installs. It appears above `Context:` and reads `Warning: running TLH from {name} track` (for example `Warning: running TLH from v0.32.0 track`, `Warning: running TLH from main track`, `Warning: running TLH from local track`, or `Warning: running TLH from unknown track`). Official latest-release installs skip that warning, though interactive starts may still show a quiet startup tip.
 
 ## Installer options
 
@@ -69,7 +69,7 @@ These alternatives keep TLH isolated, but they are not the official latest stabl
 Example pinned-tag install:
 
 ```sh
-curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.31.0/install.sh | bash -s -- --track pinned-tag
+curl -fsSL https://github.com/diegopetrucci/the-last-harness/releases/download/v0.32.0/install.sh | bash -s -- --track pinned-tag
 ```
 
 ## Update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-last-harness",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-last-harness",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/browser": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-last-harness",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "The Last Harness Pi package",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Release prep for TLH v0.32.0:

- Bump `package.json` version 0.31.0 → 0.32.0 (and matching `package-lock.json` version fields)
- Move accumulated Unreleased changelog entries into a new `## [0.32.0] - 2026-08-03` section; leave `[Unreleased]` empty
- Update versioned install-doc examples and track-warning example from `v0.31.0` to `v0.32.0`
- Retarget the RTK changelog assertion in `tests/tlh-ticket-docs-static.test.mjs` from the `[Unreleased]` section to `[0.32.0]`, keeping main's relaxed assertions

The dependency refresh and TypeScript 7 toolchain changes that were originally part of this PR have been split out into a separate draft PR: #430. That work is still in progress.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [x] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Final validation run locally on `release/v0.32.0` @ `492654e` (macOS, Node 24):

```sh
npm install --no-package-lock --legacy-peer-deps   # main's documented flow; resolves TypeScript 6.0.3
npm run validate
# → exit 0 — every phase passed: check:package-versions, typecheck, typecheck:runtime,
#   check:runtime, installer smoke checks, npm test, lint, lint:sh,
#   merge-settings --dry-run, npm pack --dry-run

node scripts/release-notes.mjs --tag v0.32.0 --output /tmp/tlh-release-notes-v0.32.0.md
# → exit 0; generated notes match the CHANGELOG `## [0.32.0]` section
#   byte-for-byte (1624 chars each, compared programmatically)
```

`npm run check:startup-performance` was intentionally not run locally — it is a release-tier,
machine-dependent manual check per `VALIDATING.md`. The informational Startup performance CI job passes.

### Fixed a stale RTK changelog assertion during validation

The first `npm run validate` on the pre-amend commit `3d10fa7` failed exactly one test, reproducing a
pre-existing CI failure on `Tests (macos-latest, shard 2/2)` and `Tests (ubuntu-latest, shard 2/2)`:

```
✖ v0.32.0 changelog section keeps only a concise RTK removal note
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

    [
  +   '- Removed RTK from TLH (see [this analysis as to why](https://www.stet.sh/blog/gpt-56-token-saving-modes)).'
  -   '- Removed RTK from TLH.'
    ]
      at tests/tlh-ticket-docs-static.test.mjs:88:9
```

Cause: the retarget hunk was ported from a revision that predated main's deliberate relaxation of this
assertion, so it reintroduced a rigid `assert.deepEqual` against the plain sentence. The CHANGELOG text is
correct and was not touched.

Fix (folded into the release commit): the test now starts from main's current relaxed assertions and changes
only the section it reads.

- keeps main's `assert.strictEqual(rtkLines.length, 1, ...)` and `assert.match(rtkLines[0], /^- Removed RTK from TLH/, ...)`
- keeps main's implementation-detail `assert.doesNotMatch(...)` guard unchanged
- only substantive difference vs `origin/main`: reads the released `[0.32.0]` section instead of `[Unreleased]`
  (now empty), plus the test title and related identifiers/messages

All CI checks pass on the amended commit `492654e`.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/release/v0.32.0/install.sh | bash -s -- --ref release/v0.32.0 --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.32.0.
  * Updated installation examples to reference version 0.32.0.

* **Chores**
  * Updated the package version to 0.32.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

