### PR TITLE
Bound ticket footer title lookups

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -71,7 +71,7 @@ Both `/thinking` and `/effort` are subject to the active primary-agent thinking 
 
 ### `/tickets`
 
-`/tickets` shows the current repo/worktree's read-only ticket workflow details from `tk`: ready, blocked, in-progress, active, and total counts, plus the same sole-in-progress detail used by the footer when that selection is unambiguous. The footer status is always on by default when TLH can resolve a single titled in-progress ticket, rendered as `ticket: <title> (/tickets)`.
+`/tickets` shows the current repo/worktree's read-only ticket workflow details from `tk`: ready, blocked, in-progress, active, and total counts, followed by one in-progress detail line or an `In progress:` list when multiple tickets are in progress. Each detail includes the ticket ID and its title when available. The footer status is on by default and renders one `ticket: <title> (/tickets)` line per in-progress ticket. In both views, TLH strips terminal control sequences from titles and falls back to the ticket ID when a title cannot be resolved or is empty after sanitization.
 
 ### `/tokens`
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -30,7 +30,7 @@ Legacy `settings.tlh.tickets.enabled=false` values are re-enabled during install
 
 At TLH session start, TLH also scopes `tk` to one ticket store for that session by exporting `TICKETS_DIR` before the ticket UI or agent prompts run. If `TICKETS_DIR` is already set, TLH preserves it. Otherwise TLH points `tk` at `<git-worktree-root>/.tickets`; outside Git it falls back to `<session-cwd>/.tickets`. This keeps architect sessions, child sessions, `/tickets`, and Bash-launched `tk` commands on the same repo-local ticket store without touching ancestor stores such as `~/Developer/.tickets`.
 
-When TLH can resolve one titled in-progress ticket, the footer now shows a single read-only status line by default as `ticket: <title> (/tickets)`. Use `/tickets` for the fuller read-only detail view.
+The ticket footer status is on by default and shows one read-only `ticket: <title> (/tickets)` line per in-progress ticket. TLH strips terminal control sequences from titles and falls back to the ticket ID when a title cannot be resolved or is empty after sanitization. `/tickets` shows the workflow counts plus one ID/title detail line for a single in-progress ticket or an `In progress:` list for multiple tickets, using the same title sanitization and ID fallback.
 
 If TLH cannot validate a configured/existing `tk` and cannot install the managed copy, install or update fails with an actionable error instead of starting with an incomplete workflow. To recover, provide a valid `tk` command and run `tlh tickets enable --install-path /path/to/tk`, or rerun the installer/update once the managed download can succeed.
 

--- a/extensions/the-last-harness/ticket-workflow-ui.js
+++ b/extensions/the-last-harness/ticket-workflow-ui.js
@@ -1,10 +1,12 @@
 import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
 import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { isRecord } from "./common.js";
 import { activateTlhTicketSessionScope, findValidTlhTicketCommand } from "./tickets.js";
 import { TK_WORKFLOW_STATUS_KEY, TK_WORKFLOW_WIDGET_KEY } from "./ticket-workflow-ui-constants.js";
 const TK_STATUS_COMMAND = "tickets";
 const TK_COMMAND_TIMEOUT_MS = 4000;
+const TK_TITLE_RESOLUTION_BUDGET_MS = TK_COMMAND_TIMEOUT_MS;
 const TK_USER_BASH_REFRESH_DELAY_MS = 250;
 const TK_STATUS_HINT = " (/tickets)";
 const TK_WORKING_ON_PREFIX = "ticket: ";
@@ -27,11 +29,11 @@ function isNoRepoMessage(message) {
     return (typeof message === "string" &&
         (/no \.tickets directory found/i.test(message) || /tickets directory ['"].+['"] does not exist/i.test(message)));
 }
-function runTkCommand(command, cwd, args) {
+function runTkCommand(command, cwd, args, timeoutMs) {
     return spawnSync(command, args, {
         cwd,
         encoding: "utf8",
-        timeout: TK_COMMAND_TIMEOUT_MS,
+        timeout: timeoutMs,
     });
 }
 function parseJsonLines(output) {
@@ -74,21 +76,31 @@ function extractTicketTitleFromShowOutput(output) {
     }
     return undefined;
 }
-function getInProgressTicketTitle(command, cwd, ticketId) {
-    const showResult = runTkCommand(command, cwd, ["show", ticketId]);
+function getInProgressTicketTitle(command, cwd, ticketId, timeoutMs, runner) {
+    const showResult = runner(command, cwd, ["show", ticketId], timeoutMs);
     if (showResult.error || showResult.status !== 0) {
         return undefined;
     }
     return extractTicketTitleFromShowOutput(showResult.stdout || "");
 }
-function getTkWorkflowSnapshot(cwd) {
+function resolveInProgressTickets(command, cwd, ticketIds, runner, now) {
+    const deadlineMs = now() + TK_TITLE_RESOLUTION_BUDGET_MS;
+    return ticketIds.map((ticketId) => {
+        const timeoutMs = Math.floor(deadlineMs - now());
+        const title = timeoutMs > 0 ? getInProgressTicketTitle(command, cwd, ticketId, timeoutMs, runner) : undefined;
+        return { id: ticketId, title };
+    });
+}
+function getTkWorkflowSnapshot(cwd, options) {
     activateTlhTicketSessionScope(cwd);
     const settings = getTlhGlobalSettings(cwd);
     const command = findValidTlhTicketCommand(settings, getAgentDir());
     if (!command) {
         return { kind: "unavailable", message: "tk is unavailable for this TLH profile." };
     }
-    const queryResult = runTkCommand(command, cwd, ["query"]);
+    const runner = options.runner ?? runTkCommand;
+    const now = options.now ?? (() => performance.now());
+    const queryResult = runner(command, cwd, ["query"], TK_COMMAND_TIMEOUT_MS);
     const queryFailure = firstOutputLine(queryResult);
     if (queryResult.error) {
         return { kind: "unavailable", message: queryResult.error.message };
@@ -108,7 +120,7 @@ function getTkWorkflowSnapshot(cwd) {
     if (tickets.length === 0) {
         return { kind: "no-tickets" };
     }
-    const readyResult = runTkCommand(command, cwd, ["ready"]);
+    const readyResult = runner(command, cwd, ["ready"], TK_COMMAND_TIMEOUT_MS);
     if (readyResult.error) {
         return { kind: "unavailable", message: readyResult.error.message };
     }
@@ -118,7 +130,7 @@ function getTkWorkflowSnapshot(cwd) {
             ? { kind: "no-repo", message: "No .tickets directory found for this repo." }
             : { kind: "unavailable", message: failure ?? "tk ready failed." };
     }
-    const blockedResult = runTkCommand(command, cwd, ["blocked"]);
+    const blockedResult = runner(command, cwd, ["blocked"], TK_COMMAND_TIMEOUT_MS);
     if (blockedResult.error) {
         return { kind: "unavailable", message: blockedResult.error.message };
     }
@@ -129,11 +141,11 @@ function getTkWorkflowSnapshot(cwd) {
             : { kind: "unavailable", message: failure ?? "tk blocked failed." };
     }
     const active = tickets.filter((ticket) => ticket.status === "open" || ticket.status === "in_progress").length;
-    const inProgress = tickets
+    const inProgressTicketIds = tickets
         .filter((ticket) => ticket.status === "in_progress")
         .map((ticket) => ticket.id?.trim())
-        .filter((ticketId) => Boolean(ticketId))
-        .map((ticketId) => ({ id: ticketId, title: getInProgressTicketTitle(command, cwd, ticketId) }));
+        .filter((ticketId) => Boolean(ticketId));
+    const inProgress = resolveInProgressTickets(command, cwd, inProgressTicketIds, runner, now);
     return {
         kind: "ok",
         total: tickets.length,
@@ -189,6 +201,9 @@ function stripTerminalControlSequences(text) {
     }
     return sanitized;
 }
+function getSafeInProgressTicketId(ticket) {
+    return stripTerminalControlSequences(ticket.id).trim();
+}
 function getSafeInProgressTicketTitle(ticket) {
     const safeTitle = ticket.title ? stripTerminalControlSequences(ticket.title).trim() : undefined;
     return safeTitle || undefined;
@@ -199,7 +214,7 @@ function formatTkWorkflowFooterStatus(snapshot) {
     }
     return snapshot.inProgress
         .map((ticket) => {
-        const label = getSafeInProgressTicketTitle(ticket) ?? ticket.id;
+        const label = getSafeInProgressTicketTitle(ticket) ?? getSafeInProgressTicketId(ticket);
         return `${TK_WORKING_ON_PREFIX}${label}${TK_STATUS_HINT}`;
     })
         .join("\n");
@@ -222,13 +237,15 @@ function formatTkWorkflowDetails(snapshot) {
     }
     else if (snapshot.inProgress.length === 1) {
         const [ticket] = snapshot.inProgress;
+        const id = getSafeInProgressTicketId(ticket);
         const title = getSafeInProgressTicketTitle(ticket);
-        lines.push(`In progress: ${title ? `${ticket.id} - ${title}` : ticket.id}`);
+        lines.push(`In progress: ${title ? `${id} - ${title}` : id}`);
     }
     else {
         lines.push("In progress:", ...snapshot.inProgress.map((ticket) => {
+            const id = getSafeInProgressTicketId(ticket);
             const title = getSafeInProgressTicketTitle(ticket);
-            return `- ${title ? `${ticket.id} - ${title}` : ticket.id}`;
+            return `- ${title ? `${id} - ${title}` : id}`;
         }));
     }
     if (snapshot.ready.length > 0) {
@@ -264,14 +281,14 @@ function shouldRefreshFromBashCommand(command) {
     }
     return false;
 }
-export function createTlhTicketWorkflowUiRuntime(pi) {
+export function createTlhTicketWorkflowUiRuntime(pi, options = {}) {
     let commandRegistered = false;
     const pendingUserBashRefreshes = new Set();
     const refresh = (ctx) => {
         if (!ctx.hasUI) {
             return;
         }
-        setTkWorkflowUi(ctx, getTkWorkflowSnapshot(ctx.cwd));
+        setTkWorkflowUi(ctx, getTkWorkflowSnapshot(ctx.cwd, options));
     };
     const ensureCommandRegistered = () => {
         if (commandRegistered) {
@@ -280,7 +297,7 @@ export function createTlhTicketWorkflowUiRuntime(pi) {
         pi.registerCommand(TK_STATUS_COMMAND, {
             description: "Show TLH ticket workflow status",
             handler: async (_args, commandCtx) => {
-                commandCtx.ui.notify(formatTkWorkflowDetails(getTkWorkflowSnapshot(commandCtx.cwd)), "info");
+                commandCtx.ui.notify(formatTkWorkflowDetails(getTkWorkflowSnapshot(commandCtx.cwd, options)), "info");
             },
         });
         commandRegistered = true;

--- a/extensions/the-last-harness/ticket-workflow-ui.ts
+++ b/extensions/the-last-harness/ticket-workflow-ui.ts
@@ -1,4 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { performance } from "node:perf_hooks";
 
 import { SettingsManager, getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 
@@ -9,6 +10,7 @@ import type { TlhSettings } from "./types.js";
 
 const TK_STATUS_COMMAND = "tickets";
 const TK_COMMAND_TIMEOUT_MS = 4000;
+const TK_TITLE_RESOLUTION_BUDGET_MS = TK_COMMAND_TIMEOUT_MS;
 const TK_USER_BASH_REFRESH_DELAY_MS = 250;
 const TK_STATUS_HINT = " (/tickets)";
 const TK_WORKING_ON_PREFIX = "ticket: ";
@@ -30,6 +32,12 @@ type TkWorkflowSnapshot =
 		};
 
 type TkCommandResult = SpawnSyncReturns<string>;
+type TkCommandRunner = (command: string, cwd: string, args: string[], timeoutMs: number) => TkCommandResult;
+
+export type TlhTicketWorkflowUiRuntimeOptions = {
+	runner?: TkCommandRunner;
+	now?: () => number;
+};
 
 function getTlhGlobalSettings(cwd: string): TlhSettings {
 	try {
@@ -54,11 +62,11 @@ function isNoRepoMessage(message: string | undefined): boolean {
 	);
 }
 
-function runTkCommand(command: string, cwd: string, args: string[]): TkCommandResult {
+function runTkCommand(command: string, cwd: string, args: string[], timeoutMs: number): TkCommandResult {
 	return spawnSync(command, args, {
 		cwd,
 		encoding: "utf8",
-		timeout: TK_COMMAND_TIMEOUT_MS,
+		timeout: timeoutMs,
 	});
 }
 
@@ -107,23 +115,46 @@ function extractTicketTitleFromShowOutput(output: string): string | undefined {
 	return undefined;
 }
 
-function getInProgressTicketTitle(command: string, cwd: string, ticketId: string): string | undefined {
-	const showResult = runTkCommand(command, cwd, ["show", ticketId]);
+function getInProgressTicketTitle(
+	command: string,
+	cwd: string,
+	ticketId: string,
+	timeoutMs: number,
+	runner: TkCommandRunner,
+): string | undefined {
+	const showResult = runner(command, cwd, ["show", ticketId], timeoutMs);
 	if (showResult.error || showResult.status !== 0) {
 		return undefined;
 	}
 	return extractTicketTitleFromShowOutput(showResult.stdout || "");
 }
 
-function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
+function resolveInProgressTickets(
+	command: string,
+	cwd: string,
+	ticketIds: string[],
+	runner: TkCommandRunner,
+	now: () => number,
+): TkWorkflowInProgressTicket[] {
+	const deadlineMs = now() + TK_TITLE_RESOLUTION_BUDGET_MS;
+	return ticketIds.map((ticketId) => {
+		const timeoutMs = Math.floor(deadlineMs - now());
+		const title = timeoutMs > 0 ? getInProgressTicketTitle(command, cwd, ticketId, timeoutMs, runner) : undefined;
+		return { id: ticketId, title };
+	});
+}
+
+function getTkWorkflowSnapshot(cwd: string, options: TlhTicketWorkflowUiRuntimeOptions): TkWorkflowSnapshot {
 	activateTlhTicketSessionScope(cwd);
 	const settings = getTlhGlobalSettings(cwd);
 	const command = findValidTlhTicketCommand(settings, getAgentDir());
 	if (!command) {
 		return { kind: "unavailable", message: "tk is unavailable for this TLH profile." };
 	}
+	const runner = options.runner ?? runTkCommand;
+	const now = options.now ?? (() => performance.now());
 
-	const queryResult = runTkCommand(command, cwd, ["query"]);
+	const queryResult = runner(command, cwd, ["query"], TK_COMMAND_TIMEOUT_MS);
 	const queryFailure = firstOutputLine(queryResult);
 	if (queryResult.error) {
 		return { kind: "unavailable", message: queryResult.error.message };
@@ -144,7 +175,7 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 		return { kind: "no-tickets" };
 	}
 
-	const readyResult = runTkCommand(command, cwd, ["ready"]);
+	const readyResult = runner(command, cwd, ["ready"], TK_COMMAND_TIMEOUT_MS);
 	if (readyResult.error) {
 		return { kind: "unavailable", message: readyResult.error.message };
 	}
@@ -155,7 +186,7 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 			: { kind: "unavailable", message: failure ?? "tk ready failed." };
 	}
 
-	const blockedResult = runTkCommand(command, cwd, ["blocked"]);
+	const blockedResult = runner(command, cwd, ["blocked"], TK_COMMAND_TIMEOUT_MS);
 	if (blockedResult.error) {
 		return { kind: "unavailable", message: blockedResult.error.message };
 	}
@@ -167,11 +198,11 @@ function getTkWorkflowSnapshot(cwd: string): TkWorkflowSnapshot {
 	}
 
 	const active = tickets.filter((ticket) => ticket.status === "open" || ticket.status === "in_progress").length;
-	const inProgress = tickets
+	const inProgressTicketIds = tickets
 		.filter((ticket) => ticket.status === "in_progress")
 		.map((ticket) => ticket.id?.trim())
-		.filter((ticketId): ticketId is string => Boolean(ticketId))
-		.map((ticketId) => ({ id: ticketId, title: getInProgressTicketTitle(command, cwd, ticketId) }));
+		.filter((ticketId): ticketId is string => Boolean(ticketId));
+	const inProgress = resolveInProgressTickets(command, cwd, inProgressTicketIds, runner, now);
 	return {
 		kind: "ok",
 		total: tickets.length,
@@ -232,6 +263,10 @@ function stripTerminalControlSequences(text: string): string {
 	return sanitized;
 }
 
+function getSafeInProgressTicketId(ticket: TkWorkflowInProgressTicket): string {
+	return stripTerminalControlSequences(ticket.id).trim();
+}
+
 function getSafeInProgressTicketTitle(ticket: TkWorkflowInProgressTicket): string | undefined {
 	const safeTitle = ticket.title ? stripTerminalControlSequences(ticket.title).trim() : undefined;
 	return safeTitle || undefined;
@@ -243,7 +278,7 @@ function formatTkWorkflowFooterStatus(snapshot: TkWorkflowSnapshot): string | un
 	}
 	return snapshot.inProgress
 		.map((ticket) => {
-			const label = getSafeInProgressTicketTitle(ticket) ?? ticket.id;
+			const label = getSafeInProgressTicketTitle(ticket) ?? getSafeInProgressTicketId(ticket);
 			return `${TK_WORKING_ON_PREFIX}${label}${TK_STATUS_HINT}`;
 		})
 		.join("\n");
@@ -267,14 +302,16 @@ function formatTkWorkflowDetails(snapshot: TkWorkflowSnapshot): string {
 		lines.push("In progress: none. Footer stays quiet.");
 	} else if (snapshot.inProgress.length === 1) {
 		const [ticket] = snapshot.inProgress;
+		const id = getSafeInProgressTicketId(ticket);
 		const title = getSafeInProgressTicketTitle(ticket);
-		lines.push(`In progress: ${title ? `${ticket.id} - ${title}` : ticket.id}`);
+		lines.push(`In progress: ${title ? `${id} - ${title}` : id}`);
 	} else {
 		lines.push(
 			"In progress:",
 			...snapshot.inProgress.map((ticket) => {
+				const id = getSafeInProgressTicketId(ticket);
 				const title = getSafeInProgressTicketTitle(ticket);
-				return `- ${title ? `${ticket.id} - ${title}` : ticket.id}`;
+				return `- ${title ? `${id} - ${title}` : id}`;
 			}),
 		);
 	}
@@ -320,7 +357,10 @@ export type TlhTicketWorkflowUiRuntime = {
 	handleToolResult(event: { toolName: string; input: { command?: unknown } }, ctx: ExtensionContext): void;
 };
 
-export function createTlhTicketWorkflowUiRuntime(pi: ExtensionAPI): TlhTicketWorkflowUiRuntime {
+export function createTlhTicketWorkflowUiRuntime(
+	pi: ExtensionAPI,
+	options: TlhTicketWorkflowUiRuntimeOptions = {},
+): TlhTicketWorkflowUiRuntime {
 	let commandRegistered = false;
 	const pendingUserBashRefreshes = new Set<ReturnType<typeof setTimeout>>();
 
@@ -328,7 +368,7 @@ export function createTlhTicketWorkflowUiRuntime(pi: ExtensionAPI): TlhTicketWor
 		if (!ctx.hasUI) {
 			return;
 		}
-		setTkWorkflowUi(ctx, getTkWorkflowSnapshot(ctx.cwd));
+		setTkWorkflowUi(ctx, getTkWorkflowSnapshot(ctx.cwd, options));
 	};
 
 	const ensureCommandRegistered = () => {
@@ -338,7 +378,7 @@ export function createTlhTicketWorkflowUiRuntime(pi: ExtensionAPI): TlhTicketWor
 		pi.registerCommand(TK_STATUS_COMMAND, {
 			description: "Show TLH ticket workflow status",
 			handler: async (_args, commandCtx) => {
-				commandCtx.ui.notify(formatTkWorkflowDetails(getTkWorkflowSnapshot(commandCtx.cwd)), "info");
+				commandCtx.ui.notify(formatTkWorkflowDetails(getTkWorkflowSnapshot(commandCtx.cwd, options)), "info");
 			},
 		});
 		commandRegistered = true;

--- a/tests/tlh-ticket-workflow-ui.test.mjs
+++ b/tests/tlh-ticket-workflow-ui.test.mjs
@@ -8,7 +8,9 @@ import { createJiti } from "jiti";
 import { createIsolatedProfileFixture, withEnv } from "./test-fixture-helpers.mjs";
 
 const jiti = createJiti(import.meta.url);
-const { registerTlhTicketWorkflowUi } = await jiti.import("../extensions/the-last-harness/ticket-workflow-ui.ts");
+const { createTlhTicketWorkflowUiRuntime, registerTlhTicketWorkflowUi } = await jiti.import(
+	"../extensions/the-last-harness/ticket-workflow-ui.ts",
+);
 
 function resetTicketWorkflowTestState() {
 	delete process.env.TICKETS_DIR;
@@ -422,6 +424,53 @@ test("ticket workflow UI falls back to the ticket id when the sole in-progress t
 	});
 });
 
+test("ticket workflow UI sanitizes decoded terminal controls from fallback ticket ids in the footer and /tickets", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
+	const statePath = join(fixture.dir, "tk-state");
+	writeFileSync(statePath, "default\n");
+	installFakeTk(fixture.agent, statePath);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		const decodedUnsafeTicketId = "tlhf-safe\u001b[31m-red\u001b[0m\u0007";
+		let showCalls = 0;
+		const runner = (_command, _cwd, args) => {
+			switch (args[0]) {
+				case "query":
+					return {
+						status: 0,
+						stdout: `${JSON.stringify({ id: decodedUnsafeTicketId, status: "in_progress" })}\n`,
+						stderr: "",
+					};
+				case "ready":
+				case "blocked":
+					return { status: 0, stdout: "", stderr: "" };
+				case "show":
+					showCalls += 1;
+					assert.equal(args[1], decodedUnsafeTicketId);
+					return { status: 1, stdout: "", stderr: "ticket metadata unavailable" };
+				default:
+					return assert.fail(`unexpected tk command: ${args.join(" ")}`);
+			}
+		};
+
+		const pi = createPiHarness();
+		const runtime = createTlhTicketWorkflowUiRuntime(pi, { runner });
+		const uiHarness = createUiHarness();
+		const ctx = createCtx(fixture.cwd, uiHarness.ui);
+
+		runtime.applyCurrentSettings(ctx);
+		assert.equal(uiHarness.statusUpdates.at(-1)?.text, "ticket: tlhf-safe-red (/tickets)");
+
+		await pi.commands.get("tickets").handler("", ctx);
+		assert.equal(showCalls, 2);
+		assert.equal(
+			uiHarness.notifications.at(-1)?.message,
+			"tk: 0 ready • 0 blocked • 1 in progress • 1 active • 1 total\nIn progress: tlhf-safe-red",
+		);
+	});
+});
+
 test("ticket workflow UI strips ANSI and control sequences from the sole in-progress footer title", async (t) => {
 	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
 	mkdirSync(join(fixture.cwd, ".tickets"));
@@ -496,6 +545,77 @@ test("ticket workflow UI renders every in-progress ticket on its own footer line
 			/In progress:\n- tlhf-16ll - First in-progress ticket\n- tlhf-7rd2 - Second in-progress ticket/,
 		);
 		assert.doesNotMatch(details, /ambiguous|Footer stays quiet/i);
+	});
+});
+
+test("ticket workflow UI bounds multi-ticket title lookups to one overall timeout budget", async (t) => {
+	const fixture = createIsolatedProfileFixture("tlh-ticket-workflow-ui-", { cwd: true, test: t });
+	mkdirSync(join(fixture.cwd, ".tickets"));
+	const statePath = join(fixture.dir, "tk-state");
+	writeFileSync(statePath, "default\n");
+	installFakeTk(fixture.agent, statePath);
+
+	await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+		let nowMs = 0;
+		const showCalls = [];
+		const runner = (_command, _cwd, args, timeoutMs) => {
+			switch (args[0]) {
+				case "query":
+					return {
+						status: 0,
+						stdout: [
+							'{"id":"tlhf-first","status":"in_progress"}',
+							'{"id":"tlhf-slow","status":"in_progress"}',
+							'{"id":"tlhf-unattempted","status":"in_progress"}',
+						].join("\n"),
+						stderr: "",
+					};
+				case "ready":
+				case "blocked":
+					return { status: 0, stdout: "", stderr: "" };
+				case "show": {
+					const ticketId = args[1];
+					showCalls.push({ ticketId, timeoutMs });
+					if (ticketId === "tlhf-first") {
+						nowMs += 1000;
+						return {
+							status: 0,
+							stdout: "---\nid: tlhf-first\nstatus: in_progress\n---\n# Resolved first title\n",
+							stderr: "",
+						};
+					}
+					if (ticketId === "tlhf-slow") {
+						nowMs += timeoutMs;
+						return {
+							status: null,
+							stdout: "",
+							stderr: "",
+							error: Object.assign(new Error("title lookup timed out"), { code: "ETIMEDOUT" }),
+						};
+					}
+					return assert.fail(`title lookup exceeded the overall budget: ${ticketId}`);
+				}
+				default:
+					assert.fail(`unexpected tk command: ${args.join(" ")}`);
+			}
+		};
+
+		const pi = createPiHarness();
+		const runtime = createTlhTicketWorkflowUiRuntime(pi, { runner, now: () => nowMs });
+		const uiHarness = createUiHarness();
+		const ctx = createCtx(fixture.cwd, uiHarness.ui);
+
+		runtime.applyCurrentSettings(ctx);
+
+		assert.deepEqual(showCalls, [
+			{ ticketId: "tlhf-first", timeoutMs: 4000 },
+			{ ticketId: "tlhf-slow", timeoutMs: 3000 },
+		]);
+		assert.equal(nowMs, 4000);
+		assert.equal(
+			uiHarness.statusUpdates.at(-1)?.text,
+			"ticket: Resolved first title (/tickets)\nticket: tlhf-slow (/tickets)\nticket: tlhf-unattempted (/tickets)",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

Follow up on #417 by bounding all serial `tk show` title lookups to one shared four-second budget, falling back to sanitized ticket IDs when titles cannot be resolved, and documenting the multi-ticket footer contract.

Addresses review feedback from:
- https://github.com/diegopetrucci/the-last-harness/pull/417#discussion_r3698421448
- https://github.com/diegopetrucci/the-last-harness/pull/417#discussion_r3698421452

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed on top of the current `main`, including typechecks, generated-runtime freshness, installer smoke tests, full tests, lint, shell lint, settings merge dry-run, and package dry-run.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/bound-ticket-footer-lookups/install.sh | bash -s -- --ref fix/bound-ticket-footer-lookups --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket details now display sanitized ticket titles and IDs, preventing terminal control characters from appearing.
  * Multiple in-progress tickets now receive clearer detail output, including per-ticket status information.
  * Ticket title lookups use a shared time limit, with reliable fallback behavior when lookups time out.

* **Documentation**
  * Updated `/tickets` and ticket footer documentation to reflect multi-ticket output, title handling, ID fallbacks, and default read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->