### PR TITLE
Pin pi-subagents to 0.31.14 (max thinking level fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 - In the footer, TLH now shows how much context MCPs are consuming.
 
+### Changed
+
+- Bumped the bundled critical `pi-subagents` default extension pin from `npm:@diegopetrucci/pi-subagents@0.31.12` to `npm:@diegopetrucci/pi-subagents@0.31.14`, delivering the max thinking level fix so the `:max` thinking badge renders correctly.
+
 ### Model defaults
 
 - The `developer` subagent now defaults to `gpt-5.6-luna max` for OpenAI, `sonnet-4-6 medium` for Anthropic.

--- a/config/default-extensions.json
+++ b/config/default-extensions.json
@@ -62,7 +62,7 @@
     "replaces": ["npm:pi-subagents", "git:github.com/nicobailon/pi-subagents", "git:github.com/diegopetrucci/pi-subagents"],
     "migrateReplacements": true,
     "critical": true,
-    "source": "npm:@diegopetrucci/pi-subagents@0.31.12",
+    "source": "npm:@diegopetrucci/pi-subagents@0.31.14",
     "description": "Delegate work to isolated TLH-profile subagents."
   }
 ]

--- a/docs/pin-bump-verification.md
+++ b/docs/pin-bump-verification.md
@@ -8,9 +8,9 @@ Running checklist of behaviors that could **only be unit-tested / statically ver
 during the `@diegopetrucci/pi-subagents` v0.34.0 intake and its follow-ups, and therefore
 still need a **live-session runtime check** on the bumped pin.
 
-The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.12`)
+The pin lives at `config/default-extensions.json` (`npm:@diegopetrucci/pi-subagents@0.31.14`)
 with manifest-consistency/migration assertions in `tests/default-extensions.test.mjs` (the test derives its expected value from the manifest, so it would still pass if only the manifest changed). Previous pin bumps landed in
-PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8, #386 → 0.31.9, and #390 → 0.31.10, plus direct commit `7e4deba` → 0.31.11. The current checkout advances the pin to 0.31.12; the live-session pass is what remains.
+PRs #347 → 0.31.5, #367 → 0.31.7, #370 → 0.31.8, #386 → 0.31.9, and #390 → 0.31.10, plus direct commit `7e4deba` → 0.31.11, and PR #427 → 0.31.12. The current checkout advances the pin to 0.31.14; the live-session pass is what remains.
 
 Mark each item `[x]` once verified in a real TLH session on the bumped pin.
 
@@ -50,3 +50,4 @@ Mark each item `[x]` once verified in a real TLH session on the bumped pin.
   only if a new slash command delegates a user-supplied `agent`/`task`, or `pi-prompt-template-model`
   is installed.
 - Windows-only behaviors (e.g. the fork's win32 E2E skip) are out of scope — TLH targets macOS/Linux.
+- 0.31.13 (async widget presentation wording) and 0.31.14 (thinking-level allowlist fix) add no new verification surface beyond confirming that a `:max` thinking badge renders correctly in a live session. All five pending items above carry over unchanged.


### PR DESCRIPTION
## Summary

Bumps the bundled critical `pi-subagents` default-extension pin from `0.31.12` to `0.31.14`, so the `max` thinking level fix actually reaches TLH installs.

TLH ships a `developer` subagent configured with `max` thinking on OpenAI (#431). pi-subagents carried **two** separate stale `THINKING_LEVELS` allowlists that both omitted `max`, which produced a corrupted double model suffix (`…luna:max:high`) and a status badge that rendered the raw model name with no thinking indicator. Until this pin moves, installs keep that behavior.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [x] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Exit 0, zero test failures. `tests/default-extensions.test.mjs` derives its expected pin from the manifest, so no test needed editing. The `merge-settings --dry-run` step confirms the migration path is picked up:

```
Would update default extension package source:
  npm:@diegopetrucci/pi-subagents@0.31.12 -> npm:@diegopetrucci/pi-subagents@0.31.14
```

Also confirmed `@diegopetrucci/pi-subagents@0.31.14` resolves from npm (published with SLSA provenance).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants — pin/manifest only; `replaces` and `migrateReplacements` untouched, so migration from prior upstream and TLH git sources is unaffected
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Pin PR

**What the new fork tag / pin includes:**

- `0.31.14` — adds `max` to `THINKING_LEVELS` in `src/shared/model-info.ts` and **removes the duplicate local copy** in `src/runs/shared/pi-args.ts` in favour of importing the shared list, so the two cannot drift apart again. Extends the opt-in gate to `xhigh || max`, and filters `max` out of the unknown-model early returns so it is never advertised for models whose metadata does not declare it. Adopted from upstream `nicobailon/pi-subagents@747de756` (upstream PR #423, upstream v0.35.0) rather than hand-written, so it does not register as fork-only divergence. Recorded in the fork's `.upstream-ledger.jsonl` as an `adopted-with-exceptions` hotfix; three upstream paths covering chain and watchdog surfaces were excluded because they do not exist in the fork.
- `0.31.13` — async widget presentation wording only; removes chain/step terminology from user-facing summaries and stops completed/failed single jobs from appearing active.

**Link to merged fork PR:** diegopetrucci/pi-subagents#123 (fix), released via diegopetrucci/pi-subagents#124

**Before → after pin:** `npm:@diegopetrucci/pi-subagents@0.31.12` → `npm:@diegopetrucci/pi-subagents@0.31.14`

**`npm run validate` result:** exit 0, zero failures.

---

## Note on the verification tally

The five pending live-session items in `docs/pin-bump-verification.md` are **deliberately left unticked**. That debt predates this bump — it dates to the v0.34.0 intake and is tracked in #346 — and can only be cleared by a human in a real session on the bumped pin. Ticking them here would quietly reset visible debt.

A note records that `0.31.13` and `0.31.14` add no new verification surface beyond confirming a `:max` thinking badge renders correctly live.

`extensions/the-last-harness/primary-agent-runtime.ts` is deliberately untouched: its resume-exemption comment is already accurate for 0.31.12, and the re-evaluation is tracked in #420.

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/pin-pi-subagents-0.31.14/install.sh | bash -s -- --ref chore/pin-pi-subagents-0.31.14 --track ref
```
