### PR TITLE
Raise librarian tool budget and clarify tk ticket deletion guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to The Last Harness will be documented in this file.
 
 - Removed stale `/subagents-profiles`, `/subagents-check-profile`, and `/subagents-models` from `HIDDEN_SLASH_COMMANDS` and from `docs/commands.md`; these commands were removed in `pi-subagents` 0.31.14. Added `/subagents-fleet` to the visible bundled-extension command table. Hid `/subagent-cost` via `HIDDEN_SLASH_COMMANDS` because `/tokens` is the TLH-native token report; true removal requires a fork-side change in `pi-subagents`.
 - Architect steering of async child runs now actually works at runtime. The 0.32.0 changelog entry claimed steering support, but `steer` was missing from the allowed action set at that time; it is now included. Steer calls require an explicit `id` and `message`; execution fields (`agent`, `tasks`, `chain`, `context`, `agentScope`) and non-integer `index` values are rejected. `rush` is blocked from `steer` outright because an opaque steer carries no `agent` field, so TLH cannot verify the steered child is not a `developer` subagent. `product` and `bug-hunter` can steer already-started runs — see the accepted issue #330 note in `docs/embedded-subagents.md`.
+
+### Changed
+
+- The `librarian` subagent tool budget was raised from soft 20 / hard 30 to soft 30 / hard 60 so external GitHub research tasks are less likely to end early on budget exhaustion.
+- The architect cleanup guidance now spells out how to delete `tk` tickets: `tk` has no delete subcommand, so ticket files are removed directly with `rm .tickets/<id>.md` after checking for dangling dependency references.
+
 ### Removed
 
 - **fff (`npm:@ff-labs/pi-fff`) is no longer a bundled default extension.** TLH-installed copies are automatically removed from the isolated profile on the next `tlh install` or `tlh update` run. TLH determines ownership from the profile's `tlh.defaultExtensionProvenance` metadata: on profiles carrying that metadata (TLH 0.17.0 and later), only copies TLH originally installed are removed and any manually added copy is preserved. On older pre-provenance profiles (TLH 0.16.x and earlier, where fff was a bundled default anyway), TLH infers ownership from the installed package identity and removes it even if it was added manually. Settings are backed up before any write. If you have leftover files under `~/.the-last-harness/agent/npm/node_modules/@ff-labs/`, you may delete that directory manually.

--- a/agents/primary/architect.md
+++ b/agents/primary/architect.md
@@ -143,7 +143,7 @@ When the incoming user turn's first line is exactly `[/review]`, skip the normal
 ## Cleanup
 
 1. Only start ticket cleanup after final review is complete and any review-driven fixes are finished.
-2. During cleanup after final review and before the final handoff, delete any `tk` tickets created for the current workflow or session once they are closed.
+2. During cleanup after final review and before the final handoff, remove any `tk` tickets created for the current workflow or session once they are closed. `tk` has no delete subcommand — deletion is done by removing the ticket file directly: `rm .tickets/<id>.md`. Before removing, check for dangling dependency references with `tk dep tree <id>` or `grep -r '<id>' .tickets/` and resolve any that remain.
 3. Verify no session-created `.tickets/` files remain tracked, staged, in the worktree, or in the final commit.
 4. If this workflow closed or modified a ticket that already existed in the repository, ask the user whether they want to keep the change, revert it, or delete the ticket.
 5. When opening PRs, if a PR template is present for the repository, always follow it.

--- a/agents/subagents/librarian.md
+++ b/agents/subagents/librarian.md
@@ -6,7 +6,7 @@ tlhOpenaiModels: openai-codex/gpt-5.4-mini
 tlhAnthropicModels: anthropic/claude-haiku-4-5
 tlhAnthropicThinking: high
 tlhOpenaiThinking: high
-toolBudget: {"soft":20,"hard":30}
+toolBudget: {"soft":30,"hard":60}
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/tests/agent-prompt-contracts.test.mjs
+++ b/tests/agent-prompt-contracts.test.mjs
@@ -68,7 +68,7 @@ test("scout and research subagent prompts keep bounded scope and tool budgets", 
 	const diffSummarizer = readAgentPrompt("subagents", "diff-summarizer");
 	const webScout = readAgentPrompt("subagents", "web-scout");
 
-	assertBodyPattern(librarian, "librarian tool budget", /toolBudget:\s*\{"soft":20,"hard":30\}/i);
+	assertBodyPattern(librarian, "librarian tool budget", /toolBudget:\s*\{"soft":30,"hard":60\}/i);
 	assertBodyPattern(repoScout, "repo-scout tool budget", /toolBudget:\s*\{"soft":20,"hard":30\}/i);
 	assertBodyPattern(diffSummarizer, "diff-summarizer tool budget", /toolBudget:\s*\{"soft":12,"hard":20\}/i);
 	assertBodyPattern(webScout, "web-scout tool budget", /toolBudget:\s*\{"soft":5,"hard":7\}/i);


### PR DESCRIPTION
## Summary

Two small agent-prompt improvements:

- Raise the `librarian` subagent tool budget from soft 20 / hard 30 to **soft 30 / hard 60** — external GitHub research tasks were ending early on budget exhaustion (observed in practice on a `wedow/ticket` research task).
- Make the architect Cleanup guidance explicit about `tk` ticket deletion: `tk` has no delete subcommand, so tickets are removed with `rm .tickets/<id>.md` after checking for dangling dependency references (`tk dep tree <id>` / grep). The architect had been observed stumbling here.

Includes the matching `tests/agent-prompt-contracts.test.mjs` assertion update and CHANGELOG entries under Unreleased.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Passes (exit 0), including the updated `agent-prompt-contracts` test. Note: an initial run failed on two pre-existing environment issues (stale local `node_modules` with Pi 0.81.1 vs the pinned 0.83.0); reproduced on a clean HEAD worktree and resolved with `npm ci` — unrelated to this diff.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/librarian-budget-tk-deletion-guidance/install.sh | bash -s -- --ref librarian-budget-tk-deletion-guidance --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Improved workflow cleanup guidance to help resolve closed tickets and prevent lingering dependency references.
  * Increased the librarian agent’s available tool capacity, supporting more thorough research and task handling.
* **Documentation**
  * Updated the unreleased change log with the latest workflow and agent improvements.
* **Tests**
  * Updated automated checks to reflect the expanded librarian tool capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->