### PR TITLE
Fix local-source package duplication and CI timeout flake

### DIFF
--- a/extensions/subagents/test/integration/async-digest-surfacing.test.ts
+++ b/extensions/subagents/test/integration/async-digest-surfacing.test.ts
@@ -26,6 +26,7 @@ import {
 	events,
 	tryImport,
 } from "../support/helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 
 interface ArtifactPaths {
 	inputPath: string;
@@ -70,7 +71,7 @@ assert.equal(asyncMod.isAsyncAvailable(), true, "required async runner module is
 // prompt carries an acceptance contract.
 const MOCK_COMMAND_EVIDENCE = /\[passed\] mock validation/;
 
-async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<string> {
+async function waitForAsyncResultFile(id: string, timeoutMs = scaleTestTimeout(15_000)): Promise<string> {
 	const resultPath = path.join(RESULTS_DIR!, `${id}.json`);
 	const deadline = Date.now() + timeoutMs;
 	while (!fs.existsSync(resultPath)) {

--- a/extensions/subagents/test/integration/async-execution.test.ts
+++ b/extensions/subagents/test/integration/async-execution.test.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeAgentConfigs, makeMinimalCtx, removeTempDir, tryImport } from "../support/helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 import type { MockPi } from "../support/helpers.ts";
 import { deliverInterruptRequest } from "../../src/runs/background/control-channel.ts";
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
@@ -232,7 +233,7 @@ function writePackageSkill(packageRoot: string, skillName: string): void {
 	);
 }
 
-async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<string> {
+async function waitForAsyncResultFile(id: string, timeoutMs = scaleTestTimeout(15_000)): Promise<string> {
 	const resultPath = path.join(RESULTS_DIR, `${id}.json`);
 	const deadline = Date.now() + timeoutMs;
 	while (!fs.existsSync(resultPath)) {
@@ -242,7 +243,7 @@ async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<s
 	return resultPath;
 }
 
-async function waitForAsyncState(asyncDir: string, state: string, timeoutMs = 15_000): Promise<void> {
+async function waitForAsyncState(asyncDir: string, state: string, timeoutMs = scaleTestTimeout(15_000)): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (readStatus(asyncDir)?.state !== state) {
 		if (Date.now() > deadline) assert.fail(`Timed out waiting for async state '${state}' in ${asyncDir}`);
@@ -250,7 +251,7 @@ async function waitForAsyncState(asyncDir: string, state: string, timeoutMs = 15
 	}
 }
 
-async function waitForAsyncStatusPredicate(asyncDir: string, predicate: (status: AsyncStatusPayload) => boolean, label: string, timeoutMs = 15_000): Promise<AsyncStatusPayload> {
+async function waitForAsyncStatusPredicate(asyncDir: string, predicate: (status: AsyncStatusPayload) => boolean, label: string, timeoutMs = scaleTestTimeout(15_000)): Promise<AsyncStatusPayload> {
 	const statusPath = path.join(asyncDir, "status.json");
 	const deadline = Date.now() + timeoutMs;
 	while (true) {
@@ -266,7 +267,7 @@ async function waitForAsyncStatusPredicate(asyncDir: string, predicate: (status:
 async function waitForAsyncControlCondition(
 	asyncDir: string,
 	predicate: (status: AsyncStatusPayload, eventText: string) => boolean,
-	timeoutMs = 10_000,
+	timeoutMs = scaleTestTimeout(10_000),
 ): Promise<{ status: AsyncStatusPayload; eventText: string }> {
 	const eventsPath = path.join(asyncDir, "events.jsonl");
 	const statusPath = path.join(asyncDir, "status.json");
@@ -286,7 +287,7 @@ async function waitForAsyncControlCondition(
 	}
 }
 
-async function waitForMockPiCall(mockPi: MockPi, index: number, timeoutMs = 30_000): Promise<{ args: string[]; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> }> {
+async function waitForMockPiCall(mockPi: MockPi, index: number, timeoutMs = scaleTestTimeout(30_000)): Promise<{ args: string[]; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> }> {
 	const deadline = Date.now() + timeoutMs;
 	for (;;) {
 		const callFile = fs.readdirSync(mockPi.dir)
@@ -303,7 +304,7 @@ async function waitForMockPiCall(mockPi: MockPi, index: number, timeoutMs = 30_0
 	}
 }
 
-async function waitForMockPiArgs(mockPi: MockPi, index: number, timeoutMs = 30_000): Promise<string[]> {
+async function waitForMockPiArgs(mockPi: MockPi, index: number, timeoutMs = scaleTestTimeout(30_000)): Promise<string[]> {
 	return (await waitForMockPiCall(mockPi, index, timeoutMs)).args;
 }
 
@@ -348,7 +349,7 @@ function startedMockPiPids(mockPi: MockPi): number[] {
 		.filter((pid) => Number.isInteger(pid) && pid > 0);
 }
 
-async function waitForMockPiSignal(mockPi: MockPi, pid: number, signal: "SIGINT" | "SIGTERM", timeoutMs = 10_000): Promise<void> {
+async function waitForMockPiSignal(mockPi: MockPi, pid: number, signal: "SIGINT" | "SIGTERM", timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 	const signalLogPath = path.join(mockPi.dir, `signals-${pid}.jsonl`);
 	const deadline = Date.now() + timeoutMs;
 	while (true) {
@@ -374,7 +375,7 @@ function assertPidExited(pid: number | undefined, label: string): void {
 	}
 }
 
-async function waitForPidsToExit(pids: Array<number | undefined>, label: string, timeoutMs = 10_000): Promise<void> {
+async function waitForPidsToExit(pids: Array<number | undefined>, label: string, timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 	const live = pids.filter((pid): pid is number => typeof pid === "number" && pid > 0);
 	const deadline = Date.now() + timeoutMs;
 	while (live.some((pid) => {

--- a/extensions/subagents/test/integration/async-job-tracker.test.ts
+++ b/extensions/subagents/test/integration/async-job-tracker.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 
 interface AsyncJobTrackerModule {
 	createAsyncJobTracker(
@@ -69,7 +70,7 @@ function pidGone(): never {
 async function waitForCondition(
 	condition: () => boolean,
 	description: string,
-	timeoutMs = 1000,
+	timeoutMs = scaleTestTimeout(1000),
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (!condition()) {

--- a/extensions/subagents/test/integration/intercom-result-delivery.test.ts
+++ b/extensions/subagents/test/integration/intercom-result-delivery.test.ts
@@ -17,6 +17,7 @@ import {
 	removeTempDir,
 	tryImport,
 } from "../support/helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 
 interface ExecutorResult {
 	content: Array<{ text?: string }>;
@@ -147,7 +148,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		return JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 	}
 
-	async function waitForFile(filePath: string, timeoutMs = 10_000): Promise<void> {
+	async function waitForFile(filePath: string, timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (!fs.existsSync(filePath)) {
 			if (Date.now() > deadline) assert.fail(`Timed out waiting for file: ${filePath}`);
@@ -155,7 +156,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		}
 	}
 
-	async function waitForAsyncState(runId: string, expected: string, timeoutMs = 10_000): Promise<void> {
+	async function waitForAsyncState(runId: string, expected: string, timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 		const statusPath = path.join(ASYNC_DIR, runId, "status.json");
 		const deadline = Date.now() + timeoutMs;
 		while (true) {
@@ -172,7 +173,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		runId: string,
 		predicate: (status: { state?: string; currentStep?: number; sessionFile?: string; steps?: Array<{ status?: string; sessionFile?: string; acceptance?: { status?: string } }> }) => boolean,
 		label: string,
-		timeoutMs = 10_000,
+		timeoutMs = scaleTestTimeout(10_000),
 	): Promise<void> {
 		const statusPath = path.join(ASYNC_DIR, runId, "status.json");
 		const deadline = Date.now() + timeoutMs;
@@ -190,7 +191,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		return JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, runId, "status.json"), "utf-8")) as T;
 	}
 
-	async function waitForMockPiCall(index: number, timeoutMs = 10_000): Promise<void> {
+	async function waitForMockPiCall(index: number, timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (true) {
 			const callFile = fs.readdirSync(mockPi.dir)
@@ -203,7 +204,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		}
 	}
 
-	async function waitForRevivedAsyncResult(result: ExecutorResult, timeoutMs = 10_000): Promise<string> {
+	async function waitForRevivedAsyncResult(result: ExecutorResult, timeoutMs = scaleTestTimeout(10_000)): Promise<string> {
 		const revivedId = result.details?.asyncId;
 		assert.ok(revivedId, "expected revived async id");
 		const resultPath = path.join(RESULTS_DIR, `${revivedId}.json`);
@@ -246,7 +247,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		return repoDir;
 	}
 
-	async function waitFor(predicate: () => boolean, failure: string, timeoutMs = 10_000): Promise<void> {
+	async function waitFor(predicate: () => boolean, failure: string, timeoutMs = scaleTestTimeout(10_000)): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (!predicate()) {
 			if (Date.now() > deadline) assert.fail(failure);
@@ -1086,7 +1087,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		);
 		const asyncId = started.details?.asyncId;
 		assert.ok(asyncId, "expected async id");
-		const pausedResumeWaitMs = process.platform === "win32" ? 30_000 : 15_000;
+		const pausedResumeWaitMs = scaleTestTimeout(process.platform === "win32" ? 30_000 : 15_000);
 		await waitForAsyncStatusPredicate(
 			asyncId,
 			(status) => status.state === "running" && status.steps?.[0]?.status === "running" && !!(status.steps[0]?.sessionFile ?? status.sessionFile),
@@ -1215,7 +1216,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		);
 		const asyncId = started.details?.asyncId;
 		assert.ok(asyncId, "expected async id");
-		const pausedResumeWaitMs = process.platform === "win32" ? 30_000 : 15_000;
+		const pausedResumeWaitMs = scaleTestTimeout(process.platform === "win32" ? 30_000 : 15_000);
 		await waitForAsyncStatusPredicate(
 			asyncId,
 			(status) => status.state === "running"

--- a/extensions/subagents/test/integration/result-watcher-notify.test.ts
+++ b/extensions/subagents/test/integration/result-watcher-notify.test.ts
@@ -7,6 +7,7 @@ import registerSubagentNotify from "../../src/runs/background/notify.ts";
 import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
 import { reconcileAsyncRun } from "../../src/runs/background/stale-run-reconciler.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 
 function createState(sessionId: string): SubagentState {
 	return {
@@ -28,7 +29,7 @@ function createState(sessionId: string): SubagentState {
 	};
 }
 
-async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+async function waitUntil(predicate: () => boolean, timeoutMs = scaleTestTimeout(1000)): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (!predicate()) {
 		if (Date.now() >= deadline) throw new Error("Timed out waiting for watcher-to-notify delivery");

--- a/extensions/subagents/test/support/scale-timeout.ts
+++ b/extensions/subagents/test/support/scale-timeout.ts
@@ -1,0 +1,20 @@
+/**
+ * Timeout scaling helper for spawn-heavy integration tests.
+ *
+ * Returns `ms * factor` when `TLH_TEST_TIMEOUT_SCALE` is set in the
+ * environment, otherwise returns `ms` unchanged.  The runner
+ * (`scripts/run-subagents-tests.mjs`) sets `TLH_TEST_TIMEOUT_SCALE=3` when
+ * `CI` is truthy so that GitHub-hosted macOS runners have enough headroom for
+ * process-spawn and filesystem-polling operations without slowing local runs.
+ *
+ * Usage:
+ *   import { scaleTestTimeout } from "../support/scale-timeout.ts";
+ *   async function waitForFoo(timeoutMs = scaleTestTimeout(15_000)) { ... }
+ */
+export function scaleTestTimeout(ms: number): number {
+	const raw = process.env.TLH_TEST_TIMEOUT_SCALE;
+	if (!raw) return ms;
+	const factor = Number(raw);
+	if (!Number.isFinite(factor) || factor <= 0) return ms;
+	return Math.round(ms * factor);
+}

--- a/scripts/merge-settings.mjs
+++ b/scripts/merge-settings.mjs
@@ -148,6 +148,14 @@ function prepareDefaults(defaults, packageSource, defaultExtensions, disabledIds
             .map((extension) => extension.source),
     ];
     const ensuredIdentities = new Set(ensuredPackages.map(packageIdentity).filter((value) => Boolean(value)));
+    // When the ensured source is non-canonical (local path, file: URL, etc.), add the
+    // canonical TLH identity to the exclusion set so the defaults' canonical entry is
+    // not carried through into packages. Without this, two TLH entries reach the
+    // profile and Pi clones both, failing at launch with a tool-registration conflict.
+    // Revert: remove the block below to restore the prior inclusive behaviour.
+    if (HARNESS_PACKAGE_IDENTITY && packageIdentity(ensuredSource) !== HARNESS_PACKAGE_IDENTITY) {
+        ensuredIdentities.add(HARNESS_PACKAGE_IDENTITY);
+    }
     const disabledIdentities = new Set(defaultExtensions.filter((extension) => disabledIds.has(extension.id)).flatMap(defaultExtensionPackageIdentities));
     const packages = Array.isArray(next.packages) ? next.packages : [];
     next.packages = [
@@ -193,6 +201,23 @@ function applyHarnessPackageDedupes(settings, ensuredSource, changes) {
         return;
     for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
         changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
+    }
+}
+function applyNonCanonicalHarnessCleanup(settings, ensuredSource, changes) {
+    // When re-installing or updating from a non-canonical source (local path,
+    // file: URL, etc.) over a profile that already contains the canonical TLH
+    // package entry, remove that canonical entry. Without this, mergePackages
+    // carries the canonical entry forward from existing settings alongside the
+    // non-canonical ensured source, producing the same dual-registration and
+    // tool-conflict launch failure.
+    // Revert: remove this function and its call in main() to restore prior behaviour.
+    if (packageIdentity(ensuredSource) === HARNESS_PACKAGE_IDENTITY)
+        return;
+    if (!Array.isArray(settings.packages))
+        return;
+    let removedSource;
+    while ((removedSource = removePackageByIdentity(settings, HARNESS_PACKAGE_IDENTITY))) {
+        changes.push(`remove canonical TLH package superseded by local source: ${removedSource}`);
     }
 }
 function applyReplacedDefaultExtensions(settings, defaultExtensions, disabledIds, changes, { force }) {
@@ -618,6 +643,7 @@ function main() {
     const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
     const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
     applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
+    applyNonCanonicalHarnessCleanup(next, ensuredHarnessSource, changes);
     const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
     const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
         force: args.force,

--- a/scripts/merge-settings.mts
+++ b/scripts/merge-settings.mts
@@ -218,6 +218,14 @@ function prepareDefaults(
 			.map((extension) => extension.source),
 	];
 	const ensuredIdentities = new Set(ensuredPackages.map(packageIdentity).filter((value): value is string => Boolean(value)));
+	// When the ensured source is non-canonical (local path, file: URL, etc.), add the
+	// canonical TLH identity to the exclusion set so the defaults' canonical entry is
+	// not carried through into packages. Without this, two TLH entries reach the
+	// profile and Pi clones both, failing at launch with a tool-registration conflict.
+	// Revert: remove the block below to restore the prior inclusive behaviour.
+	if (HARNESS_PACKAGE_IDENTITY && packageIdentity(ensuredSource) !== HARNESS_PACKAGE_IDENTITY) {
+		ensuredIdentities.add(HARNESS_PACKAGE_IDENTITY);
+	}
 	const disabledIdentities = new Set(
 		defaultExtensions.filter((extension) => disabledIds.has(extension.id)).flatMap(defaultExtensionPackageIdentities),
 	);
@@ -264,6 +272,26 @@ function applyHarnessPackageDedupes(settings: JsonObject, ensuredSource: string,
 	if (!Array.isArray(settings.packages)) return;
 	for (const removedSource of removeDuplicatePackagesByIdentity(settings, HARNESS_PACKAGE_IDENTITY)) {
 		changes.push(`remove duplicate harness package: ${removedSource} (same identity as ${ensuredSource})`);
+	}
+}
+
+function applyNonCanonicalHarnessCleanup(
+	settings: JsonObject,
+	ensuredSource: string,
+	changes: string[],
+): void {
+	// When re-installing or updating from a non-canonical source (local path,
+	// file: URL, etc.) over a profile that already contains the canonical TLH
+	// package entry, remove that canonical entry. Without this, mergePackages
+	// carries the canonical entry forward from existing settings alongside the
+	// non-canonical ensured source, producing the same dual-registration and
+	// tool-conflict launch failure.
+	// Revert: remove this function and its call in main() to restore prior behaviour.
+	if (packageIdentity(ensuredSource) === HARNESS_PACKAGE_IDENTITY) return;
+	if (!Array.isArray(settings.packages)) return;
+	let removedSource: string | undefined;
+	while ((removedSource = removePackageByIdentity(settings, HARNESS_PACKAGE_IDENTITY))) {
+		changes.push(`remove canonical TLH package superseded by local source: ${removedSource}`);
 	}
 }
 
@@ -758,6 +786,7 @@ function main(): void {
 	const defaults = prepareDefaults(rawDefaults, args.packageSource, defaultExtensions, disabledIds, existing, { force: args.force });
 	const { next, changes } = mergeSettings(existing, defaults, { force: args.force });
 	applyHarnessPackageDedupes(next, ensuredHarnessSource, changes);
+	applyNonCanonicalHarnessCleanup(next, ensuredHarnessSource, changes);
 	const managedDefaultExtensionProvenance = readDefaultExtensionProvenance(next).managedPackageIdentities;
 	const sourceUpdatedIdentities = applyDefaultExtensionSourceUpdates(next, defaultExtensions, disabledIds, changes, {
 		force: args.force,

--- a/scripts/run-subagents-tests.mjs
+++ b/scripts/run-subagents-tests.mjs
@@ -89,6 +89,31 @@ function relayFailureOutput(result) {
 	if (result.stderr) process.stderr.write(result.stderr);
 }
 
+/**
+ * Build the child process environment for a suite run.
+ *
+ * Strips PI_SUBAGENT_* / PI_SUBAGENTS_* keys that must not bleed across
+ * process boundaries, resets the test-context sentinel, pins the isolated
+ * agent dir, and – when CI is set – injects TLH_TEST_TIMEOUT_SCALE so that
+ * spawn-heavy wait helpers in the integration suites have enough headroom on
+ * slow GitHub-hosted macOS runners.
+ *
+ * @param {Record<string, string | undefined>} parentEnv   Source env (normally process.env).
+ * @param {string}                             agentDir    Isolated PI_CODING_AGENT_DIR path.
+ * @returns {Record<string, string | undefined>}
+ */
+export function buildChildEnv(parentEnv, agentDir) {
+	const env = { ...parentEnv };
+	for (const key of Object.keys(env)) {
+		if (key.startsWith("PI_SUBAGENT_") || key.startsWith("PI_SUBAGENTS_")) delete env[key];
+	}
+	delete env.NODE_TEST_CONTEXT;
+	env.PI_CODING_AGENT_DIR = agentDir;
+	// Scale spawn-heavy wait budgets on CI runners (see extensions/subagents/test/support/scale-timeout.ts).
+	if (parentEnv.CI) env.TLH_TEST_TIMEOUT_SCALE = "3";
+	return env;
+}
+
 export function runSuite(suite, options = []) {
 	const config = suiteConfigs[suite];
 	if (!config) {
@@ -111,12 +136,7 @@ export function runSuite(suite, options = []) {
 	const root = mkdtempSync(join(tmpdir(), "tlh-subagents-tests-"));
 	const agentDir = join(root, "agent");
 	mkdirSync(agentDir, { recursive: true });
-	const env = { ...process.env };
-	for (const key of Object.keys(env)) {
-		if (key.startsWith("PI_SUBAGENT_") || key.startsWith("PI_SUBAGENTS_")) delete env[key];
-	}
-	delete env.NODE_TEST_CONTEXT;
-	env.PI_CODING_AGENT_DIR = agentDir;
+	const env = buildChildEnv(process.env, agentDir);
 
 	const loader = pathToFileURL(join(repoRoot, "extensions/subagents/test/support/register-loader.mjs")).href;
 	const args = [

--- a/tests/merge-settings.test.mjs
+++ b/tests/merge-settings.test.mjs
@@ -748,6 +748,52 @@ test("merge dedupes duplicate harness entries when rerun from main", () => {
 	]);
 });
 
+// ── Non-canonical (local) package source tests (tlhmf-14h1) ─────────────────
+
+test("merge with a local path source registers exactly one TLH entry and omits the canonical git entry", () => {
+	const localSource = "/Users/test/tlh-repo";
+	const fixture = tempFixture(
+		{ packages: [harnessPackage] },
+		{ packages: [] },
+	);
+
+	runMerge(fixture, { packageSource: localSource });
+
+	const settings = readJson(fixture.settings);
+	assert.equal(settings.packages[0], localSource, "local source is first entry");
+	assert.ok(!settings.packages.includes(harnessPackage), "no canonical git entry");
+	const tlhCount = settings.packages.filter((e) => e === localSource || e === harnessPackage).length;
+	assert.equal(tlhCount, 1, "exactly one TLH package entry");
+});
+
+test("merge with the canonical git source is unchanged by the non-canonical dedup logic", () => {
+	const fixture = tempFixture(
+		{ packages: [harnessPackage] },
+		{ packages: [] },
+	);
+
+	runMerge(fixture);
+
+	const settings = readJson(fixture.settings);
+	assert.deepEqual(settings.packages, [harnessPackage], "canonical entry is the only package");
+});
+
+test("merge with a local path source over existing settings containing the canonical entry removes the canonical entry", () => {
+	const localSource = "/Users/test/tlh-repo";
+	const fixture = tempFixture(
+		{ packages: [harnessPackage] },
+		{ packages: [harnessPackage] },
+	);
+
+	runMerge(fixture, { packageSource: localSource });
+
+	const settings = readJson(fixture.settings);
+	assert.ok(!settings.packages.includes(harnessPackage), "canonical entry removed");
+	assert.ok(settings.packages.includes(localSource), "local source entry present");
+	const tlhCount = settings.packages.filter((e) => e === localSource || e === harnessPackage).length;
+	assert.equal(tlhCount, 1, "exactly one TLH package entry");
+});
+
 test("merge defers bundled pi-web-access when an upstream package is already installed", () => {
 	const fixture = tempFixture(
 		{ packages: [] },

--- a/tests/subagents-test-runner.test.mjs
+++ b/tests/subagents-test-runner.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	buildChildEnv,
 	discoverSuiteFiles,
 	parseTapSummary,
 	repoRoot,
@@ -59,6 +60,29 @@ test("subagents runner rejects missing and zero-file suites before spawning Node
 		() => discoverSuiteFiles("unit", { directory: emptyDir, minimumFiles: 93 }),
 		/unit suite found 0 test files; expected at least 93/,
 	);
+});
+
+test("subagents runner buildChildEnv strips PI_SUBAGENT keys and scales timeouts in CI", () => {
+	const base = {
+		PI_SUBAGENT_SOMETHING: "should-be-removed",
+		PI_SUBAGENTS_EXTRA: "also-removed",
+		KEEP: "preserved",
+		NODE_TEST_CONTEXT: "cleared",
+	};
+
+	// Without CI: no scaling, PI keys stripped.
+	const envNoCI = buildChildEnv(base, "/tmp/agent-dir");
+	assert.equal(envNoCI.TLH_TEST_TIMEOUT_SCALE, undefined, "scale must be absent without CI");
+	assert.equal(envNoCI.PI_SUBAGENT_SOMETHING, undefined, "PI_SUBAGENT_* must be stripped");
+	assert.equal(envNoCI.PI_SUBAGENTS_EXTRA, undefined, "PI_SUBAGENTS_* must be stripped");
+	assert.equal(envNoCI.NODE_TEST_CONTEXT, undefined, "NODE_TEST_CONTEXT must be cleared");
+	assert.equal(envNoCI.KEEP, "preserved", "unrelated keys must be preserved");
+	assert.equal(envNoCI.PI_CODING_AGENT_DIR, "/tmp/agent-dir");
+
+	// With CI: scale factor of 3 is injected.
+	const envCI = buildChildEnv({ ...base, CI: "1" }, "/tmp/agent-dir");
+	assert.equal(envCI.TLH_TEST_TIMEOUT_SCALE, "3", "scale must be 3 when CI is set");
+	assert.equal(envCI.CI, "1", "CI must be preserved");
 });
 
 test("subagents runner rejects skipped TAP and enforces full-run versus shard floors", () => {


### PR DESCRIPTION
## Summary

Fixes the two failures that have been keeping `main` red.

**1. `Startup performance` — deterministic, red on every `main` push since 2026-08-05 08:01 (#452)**

Installing with a non-canonical `TLH_PACKAGE_SOURCE` (local path or `file:` URL) registered the TLH package twice: `prepareDefaults()` prepended the ensured local source but still carried the packaged `git:github.com/diegopetrucci/the-last-harness` default through, because dedupe is identity-based. Pi cloned a second copy into `<agentDir>/git/github.com/...`, the first-party subagents extension loaded from both locations, and the profile failed to launch with `Tool "subagent" conflicts with ...`.

The duplication is long-standing but only became fatal with `b32f3e5` "Integrate subagents runtime extension", which made a tool-registering extension first-party. Last green `Startup performance` run was `cbc4fe2` (2026-08-04 18:41); `b32f3e5` landed at 21:34 the same day. This also broke the documented contributor flow at `docs/local-development.md:166`.

Now the profile ends up with exactly one TLH package entry — the ensured source. Canonical installs are unchanged.

**2. `CI` macOS shard 1/2 — the known flake (#446)**

Spawn and filesystem waits in the imported subagent integration suites overran hardcoded budgets by a small margin (~31s against 30s), never a logic assertion. Adds a single `scaleTestTimeout` helper driven by `TLH_TEST_TIMEOUT_SCALE`, injected as `3` by the suite runner only when `CI` is set, and routes 16 wait/deadline budgets through it across five spawn-heavy files.

Deliberately unscaled: the timeouts that configure the subagent's own run timeout (`async-execution.test.ts:958` `1_500`, `:996` `1_000`). Scaling those would change what the timeout and hard-kill tests assert.

Editing the imported test files is allowed by `docs/subagents-history/HISTORY.md:118`; the immutable archive under `docs/subagents-history/source/` is untouched.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Full pass, exit 0: subagents unit 1070/1070, integration 526/526, e2e 1/1, plus installer smoke, typechecks, lint, `lint:sh`, merge-settings dry-run, and `npm pack --dry-run`.

Targeted evidence for each fix:

**Fix 1 — real temp-dir install** (`TLH_PACKAGE_SOURCE="$PWD"`, temporary `HOME`/`TLH_AGENT_DIR`/`TLH_BIN_DIR`, removed afterwards):

- installed `settings.json` contains zero `git:github.com/diegopetrucci/the-last-harness` entries
- `<agentDir>/git/` is never created
- offline launch produces only `No API key found` — no `Tool "subagent" conflicts`
- `node scripts/check-startup-performance.mjs --runs 6 --budget-ms 2500` completes: warm first-header mean **912.1ms**, PASS

Before the fix the same install produced `["<rel path>", "<abs path>", ...npm defaults..., "git:github.com/diegopetrucci/the-last-harness"]` and a wrapper that refused to start.

**Fix 2:**

- `scaleTestTimeout(30000)` → 30000 unset, 90000 with scale 3, 30000 on invalid input
- `node scripts/run-subagents-tests.mjs integration` → 526/526 both with and without `CI=1`
- `node --test tests/subagents-test-runner.test.mjs` → 4/4

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — no update needed: the documented `TLH_PACKAGE_SOURCE="file:$PWD"` flow simply works again, adding no new caveat, and `CHANGELOG.md` has no `[Unreleased]` section by convention
- [x] Diff contains no secrets, local paths, or unintended generated files

## Notes for review

The settings merge does remove a pre-existing canonical TLH entry when installing from a non-canonical source. That is intentional — leaving it produces the launch failure this PR fixes — and settings are backed up before writes, with the revert path documented in code comments next to both changes.

Known gap, deliberately out of scope and filed as #453: the reverse switch (canonical install over a profile that already carries a local-path TLH entry) still leaves both entries. Pre-existing, not a regression.

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/local-source-package-duplication-and-ci-flake/install.sh | bash -s -- --ref fix/local-source-package-duplication-and-ci-flake --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Harness package registrations when using local or non-canonical sources.
  * Improved cleanup when switching between canonical and local installations.

* **Reliability**
  * Added configurable timeout scaling for integration tests, improving consistency across slower environments.
  * Isolated test processes more reliably by cleaning inherited environment settings and applying CI-specific timeout configuration.

* **Tests**
  * Added coverage for package-source cleanup and isolated test-process environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->