### PR TITLE
Fix developer report and commit contract gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Fixed
 
+- Developer subagent definition now states that the stripped `acceptance-report` block does not replace the prose completion report, requires per-suite validation totals, and defines when committing is in scope. (#436)
 - I believe Pi has a bug causing some unnecessary cache missed. We can't fix it, but we can work around it with a tiny fake message from subagents to the primary agent.
 
 ## [0.34.0] - 2026-08-07

--- a/agents/subagents/developer.md
+++ b/agents/subagents/developer.md
@@ -58,14 +58,23 @@ Do not guess on important decisions. Escalate early and continue only after the 
 - If the assigned ticket defines a specific validation scope, follow the ticket instructions exactly.
 - If validation you were expected to run fails, fix the issue and rerun it until it passes. Do not claim validation you did not perform.
 
+## Version control
+
+- Commit only when the assigned ticket or dispatch explicitly instructs it. That explicit instruction IS the required approval for the profile-level rule against unapproved commits (the architect obtained user approval upstream) — do not defer or re-ask when the instruction is present.
+- When instructed to commit, commit on the current branch. Never push, never open a pull request, and never create or switch branches unless explicitly instructed.
+- When the task does not mention committing, leave the work uncommitted and say so explicitly in the completion report.
+
 ## Completion report
+
+The runtime separately instructs you to end with a fenced `acceptance-report` JSON block. That block is stripped from the output the architect sees — it is routed to the acceptance ledger and does not replace the prose report. Write the prose report in the same final message as the block; prose in earlier messages is not surfaced to the architect either.
 
 Report back to the architect with:
 
 - Summary: 2–4 bullets describing what changed and why.
 - Files changed: list file paths.
-- Validation: exact commands run and outcomes, or note when the assigned ticket explicitly deferred validation.
+- Validation: exact commands run and outcomes, or note when the assigned ticket explicitly deferred validation. Report observed test totals per suite separately (for example unit, integration, e2e) — never collapse them into one number.
 - Problems encountered: unclear, surprising, or worked-around issues.
 - Tradeoffs or risks: only meaningful ones.
+- Commit status: whether a commit was created, and its hash if so.
 
 Do not request code review yourself. The architect owns review and ticket closure.


### PR DESCRIPTION
Closes #436.

Wording-only fix to one agent definition. `agents/subagents/developer.md` was silent about two runtime realities, so a developer run could comply with every written instruction and still hand back something the architect couldn't act on.

## The report could be silently empty

The runtime injects an instruction to end with a fenced `acceptance-report` JSON block (`extensions/subagents/src/runs/shared/acceptance.ts:585`), and that block is then **stripped** before the architect sees the output. It covers substantially the same ground as the prose report the definition asks for, and nothing told the agent the block doesn't discharge the prose obligation. An agent that treats the block as "the report" produces a fully compliant run with a near-empty summary.

The evidence is unusually clean in both directions. Historical runs surfaced artifacts of **17, 97, 113, 157, 236 and 280 bytes** for work that was substantial and correct. A recent session where every dispatch hand-carried the instruction *"include your prose report in the same message as any acceptance-report block"* surfaced **2,330 / 3,511 / 4,716 / 12,390 / 4,433 bytes**, all accurate.

So the fix direction was already proven — it had just been living in the architect's per-dispatch text, where it holds only as long as the architect remembers to type it. This moves it into the definition.

Also requires validation totals to be reported per suite rather than collapsed, after a report claimed "509 unit tests pass" for a command whose real totals were 1121 unit + 509 integration + 1 e2e.

## The commit obligation was undefined

Three sources disagreed: the profile default says *"never create a git commit on your own"*, `developer.md` said nothing at all, and architect tickets routinely say *"commit on the current branch."*

Two runs given equivalent tickets diverged, both defensibly. One finished its work, left it uncommitted, and reported *"the commit step is deferred per TLH default policy"*. The next committed, but only because the dispatch said *"You MUST git commit."* Neither agent misbehaved — the contract was ambiguous.

The new `## Version control` section resolves it: an explicit commit instruction in the ticket or dispatch **is** the required approval, since the architect obtained user approval upstream. Absent that instruction, leave the work uncommitted and say so. Push and PR stay out of scope either way.

## Notes

The implementing agent hit a pre-existing failure at the branch base — `package-runtime-smoke.test.mjs` asserting 166 generated files when #471 had added a ninth without bumping the count — and **escalated rather than editing a test outside its ticket scope**, which is the behaviour this PR is codifying. That failure was already fixed on `main` by `5169714`, so this branch was rebased rather than duplicating the fix. Worth noting its instructions contain a real tension the escalation hatch absorbed: *"if validation fails, fix the issue and rerun until it passes"* read literally would have had it edit that test.

## Validation

Rebased onto `5169714`, clean `npm ci`.

- `npm run lint` — pass
- root `tests/` — **1664/1664**, zero failures, matching the `main` baseline exactly

No test asserts on this file's contents; the six root tests referencing `agents/subagents` are existence and inventory checks only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog for version 0.35.0 with clarified developer workflow guidance.
  - Documented commit scope, branch and push restrictions, and completion-report requirements.
  - Clarified that validation totals must be reported separately for each suite.
  - Specified how acceptance reports are handled alongside prose completion reports.
  - Added the related issue reference for traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->