### PR TITLE
Harden reference bounding and the protected-lifecycle preview contract

### DIFF
--- a/extensions/subagents/src/runs/background/notify.js
+++ b/extensions/subagents/src/runs/background/notify.js
@@ -39,7 +39,27 @@ function resolvePerChildSummaryBudget(displayedChildCount, nonSummaryCostWithinP
     const availableForSummaries = Math.max(ceilingForPreview - nonSummaryCostWithinPreview, 0);
     return Math.min(MAX_SUMMARY_CHARS, Math.floor(availableForSummaries / count));
 }
+function sliceSafe(value, end) {
+    const sliced = value.slice(0, end);
+    const last = sliced.charCodeAt(sliced.length - 1);
+    return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
 export function boundedReference(value) {
+    if (value.length <= MAX_REFERENCE_CHARS)
+        return value;
+    const middleMarker = "… [reference truncated] …";
+    let tailStart = -1;
+    let sep = value.lastIndexOf("/");
+    while (sep >= 0) {
+        if (MAX_REFERENCE_CHARS - middleMarker.length - (value.length - sep) < 1)
+            break;
+        tailStart = sep;
+        sep = value.lastIndexOf("/", sep - 1);
+    }
+    if (tailStart >= 0) {
+        const leadingBudget = MAX_REFERENCE_CHARS - middleMarker.length - (value.length - tailStart);
+        return `${sliceSafe(value, leadingBudget)}${middleMarker}${value.slice(tailStart)}`;
+    }
     return truncateWithMarker(value, MAX_REFERENCE_CHARS, "… [reference truncated]");
 }
 function boundedLabel(value) {
@@ -175,12 +195,12 @@ function countChildStatuses(children) {
 function formatNestedChildren(children, indent = "   ", budget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() }) {
     if (!children?.length)
         return [];
-    const lines = ["Nested subagents:"];
+    const entries = [];
     const markOmitted = (currentIndent, marker) => {
         if (budget.omissionMarkers.has(marker))
             return;
         budget.omissionMarkers.add(marker);
-        lines.push(`${currentIndent}${marker}`);
+        entries.push(`${currentIndent}${marker}`);
     };
     const append = (runs, currentIndent, depth) => {
         if (!runs?.length)
@@ -197,12 +217,12 @@ function formatNestedChildren(children, indent = "   ", budget = { remaining: MA
             budget.remaining--;
             const label = boundedLabel(child.agent ?? child.id ?? "nested");
             const state = child.state ? boundedLabel(child.state) : undefined;
-            lines.push(`${currentIndent}↳ ${label}${state ? ` — ${state}` : ""}`);
+            entries.push(`${currentIndent}↳ ${label}${state ? ` — ${state}` : ""}`);
             append(child.children, `${currentIndent}  `, depth + 1);
         }
     };
     append(children, indent, 0);
-    return lines;
+    return entries.length > 0 ? ["Nested subagents:", ...entries] : [];
 }
 function formatChildReferences(child, privacySafe = false) {
     if (privacySafe)
@@ -212,27 +232,52 @@ function formatChildReferences(child, privacySafe = false) {
         child.sessionPath ? `Session: ${boundedReference(child.sessionPath)}` : undefined,
     ].filter((line) => Boolean(line));
 }
-function formatProtectedLifecyclePreview(result) {
+function formatProtectedLifecyclePreview(result, ceilingForPreview = MAX_COMPLETION_MESSAGE_CHARS) {
     const children = Array.isArray(result.results) ? result.results : [];
-    if (children.length <= 1)
-        return "Paused awaiting supervisor.";
-    const lines = [];
+    if (children.length <= 1) {
+        const sentence = "Paused awaiting supervisor.";
+        return sentence.length <= ceilingForPreview ? sentence : "";
+    }
     const counts = countChildStatuses(children);
-    if (counts)
-        lines.push(`Children: ${counts}`, "");
+    const countsCost = counts ? joinedLineCost([`Children: ${counts}`, ""]) : 0;
     const displayedChildren = ["failed", "paused", "completed", "detached"]
         .flatMap((status) => children
         .map((child, index) => ({ child, index, status: resolveChildStatus(child) }))
         .filter((entry) => entry.status === status))
         .slice(0, MAX_DISPLAYED_CHILDREN);
-    if (children.length > displayedChildren.length)
-        lines.push(`… [${children.length - displayedChildren.length} child results omitted]`, "");
-    for (const { child, index, status } of displayedChildren) {
+    const nestedBudgetForCost = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
+    const childCosts = displayedChildren.map(({ child, index, status }) => {
+        const labelLine = `${index + 1}/${children.length}. ${boundedLabel(child.agent)} — ${status}`;
+        const nested = formatNestedChildren(child.children, "   ", nestedBudgetForCost);
+        return joinedLineCost([labelLine, ...nested, ""]);
+    });
+    let effectiveCount = displayedChildren.length;
+    while (effectiveCount > 0) {
+        const partialScaffold = childCosts.slice(0, effectiveCount).reduce((s, c) => s + c, 0);
+        const effectiveOmitted = children.length - effectiveCount;
+        const omissionCost = effectiveOmitted > 0 ? joinedLineCost([`… [${effectiveOmitted} child results omitted]`, ""]) : 0;
+        if (partialScaffold + countsCost + omissionCost <= ceilingForPreview)
+            break;
+        effectiveCount--;
+    }
+    const effectiveDisplayedChildren = displayedChildren.slice(0, effectiveCount);
+    const effectiveOmittedCount = children.length - effectiveCount;
+    const effectiveOmissionCost = effectiveOmittedCount > 0 ? joinedLineCost([`… [${effectiveOmittedCount} child results omitted]`, ""]) : 0;
+    const optionalLinesAffordable = effectiveCount > 0 || countsCost + effectiveOmissionCost <= ceilingForPreview;
+    const showCountsLine = !!counts && optionalLinesAffordable;
+    const showOmissionLine = effectiveOmittedCount > 0 && optionalLinesAffordable;
+    const nestedBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
+    const lines = [];
+    if (showCountsLine)
+        lines.push(`Children: ${counts}`, "");
+    if (showOmissionLine)
+        lines.push(`… [${effectiveOmittedCount} child results omitted]`, "");
+    for (const { child, index, status } of effectiveDisplayedChildren) {
         lines.push(`${index + 1}/${children.length}. ${boundedLabel(child.agent)} — ${status}`);
-        lines.push(...formatNestedChildren(child.children, "   "));
+        lines.push(...formatNestedChildren(child.children, "   ", nestedBudget));
         lines.push("");
     }
-    return lines.join("\n").trimEnd() || "Paused awaiting supervisor.";
+    return lines.join("\n").trimEnd();
 }
 function formatResultPreview(result, ceilingForPreview = MAX_COMPLETION_MESSAGE_CHARS) {
     const privacySafe = isProtectedPausedLifecycle({
@@ -240,7 +285,7 @@ function formatResultPreview(result, ceilingForPreview = MAX_COMPLETION_MESSAGE_
         pause: result.pause,
     });
     if (privacySafe)
-        return formatProtectedLifecyclePreview(result);
+        return formatProtectedLifecyclePreview(result, ceilingForPreview);
     const children = Array.isArray(result.results) ? result.results : [];
     const nestedBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
     if (children.length === 0)

--- a/extensions/subagents/src/runs/background/notify.js
+++ b/extensions/subagents/src/runs/background/notify.js
@@ -21,7 +21,7 @@ function truncateWithMarker(value, maxChars, marker) {
         return value;
     if (marker.length >= maxChars)
         return marker.slice(0, maxChars);
-    return `${value.slice(0, maxChars - marker.length)}${marker}`;
+    return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
 }
 function boundedSummary(value, maxChars) {
     return truncateWithMarker(value, maxChars, "… [summary truncated]");

--- a/extensions/subagents/src/runs/background/notify.ts
+++ b/extensions/subagents/src/runs/background/notify.ts
@@ -151,7 +151,7 @@ export interface RegisterSubagentNotifyOptions {
 function truncateWithMarker(value: string, maxChars: number, marker: string): string {
 	if (value.length <= maxChars) return value;
 	if (marker.length >= maxChars) return marker.slice(0, maxChars);
-	return `${value.slice(0, maxChars - marker.length)}${marker}`;
+	return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
 }
 
 function boundedSummary(value: string, maxChars: number): string {

--- a/extensions/subagents/src/runs/background/notify.ts
+++ b/extensions/subagents/src/runs/background/notify.ts
@@ -170,8 +170,10 @@ const TRUNCATION_MARKER_LEN = "… [summary truncated]".length; // 21
 // remaining space) must therefore go through boundedSummaryOrSuppress so an
 // impossible budget produces nothing instead of a fragment. Call sites whose budget is
 // a module constant far larger than their marker cannot reach that fallback and may use
-// truncateWithMarker directly: boundedReference (500 vs 23), boundedLabel (160 vs 19),
-// the sendCompletion envelope cut (32 000 vs 33) and the display-cap cut (1 200 vs 21).
+// truncateWithMarker directly: boundedLabel (160 vs 19), the sendCompletion envelope
+// cut (32 000 vs 33), and the display-cap cut (1 200 vs 21). boundedReference applies
+// middle-truncation directly and only calls truncateWithMarker in degenerate fallbacks
+// where 500 >> 23 still holds.
 
 /**
  * Like boundedSummary, but returns "" when the budget is too tight to produce a
@@ -218,7 +220,52 @@ function resolvePerChildSummaryBudget(
 	return Math.min(MAX_SUMMARY_CHARS, Math.floor(availableForSummaries / count));
 }
 
+/**
+ * Returns value.slice(0, end), backing up by one code unit when the last kept code
+ * unit is a UTF-16 high surrogate (U+D800–U+DBFF). A high surrogate without its
+ * paired low surrogate produces an ill-formed string; backing up one code unit keeps
+ * the string well-formed at the cost of one fewer character of context.
+ */
+function sliceSafe(value: string, end: number): string {
+	const sliced = value.slice(0, end);
+	const last = sliced.charCodeAt(sliced.length - 1);
+	return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+
+/**
+ * Bounds a path-like reference to MAX_REFERENCE_CHARS by middle-truncating visibly:
+ * leading root context is kept alongside as many TRAILING path segments as fit,
+ * separated by a visible marker. A head-cut would instead keep the common prefix and
+ * destroy the segment that uniquely identifies the reference.
+ *
+ * Keeping only the final segment is not enough for session pointers, because every
+ * session file is named "session.jsonl"; the identifying information lives in the
+ * run-id directories just above it, as in ".../428b3c62/run-0/session.jsonl". Artifact
+ * filenames are unique per run, so they are already served by the last segment alone.
+ * Extending greedily up the path therefore serves both without special-casing either.
+ *
+ * When no path separator is present, or when the final segment alone saturates the
+ * cap, the function falls back to head truncation rather than emitting a garbled
+ * middle-truncation marker.
+ */
 export function boundedReference(value: string): string {
+	if (value.length <= MAX_REFERENCE_CHARS) return value;
+	const middleMarker = "… [reference truncated] …";
+	// Walk separators from the end, keeping the earliest one whose tail still leaves at
+	// least one leading character of context beside a whole marker.
+	let tailStart = -1;
+	let sep = value.lastIndexOf("/");
+	while (sep >= 0) {
+		if (MAX_REFERENCE_CHARS - middleMarker.length - (value.length - sep) < 1) break;
+		tailStart = sep;
+		sep = value.lastIndexOf("/", sep - 1);
+	}
+	if (tailStart >= 0) {
+		const leadingBudget = MAX_REFERENCE_CHARS - middleMarker.length - (value.length - tailStart);
+		return `${sliceSafe(value, leadingBudget)}${middleMarker}${value.slice(tailStart)}`;
+	}
+	// No path separator present, or the final segment alone saturates the cap.
+	// Fall back to head truncation rather than emitting a garbled middle marker.
 	return truncateWithMarker(value, MAX_REFERENCE_CHARS, "… [reference truncated]");
 }
 
@@ -382,11 +429,11 @@ function formatNestedChildren(
 	budget: NestedFormatBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() },
 ): string[] {
 	if (!children?.length) return [];
-	const lines = ["Nested subagents:"];
+	const entries: string[] = [];
 	const markOmitted = (currentIndent: string, marker: string) => {
 		if (budget.omissionMarkers.has(marker)) return;
 		budget.omissionMarkers.add(marker);
-		lines.push(`${currentIndent}${marker}`);
+		entries.push(`${currentIndent}${marker}`);
 	};
 	const append = (runs: NestedNotifyChild[] | undefined, currentIndent: string, depth: number) => {
 		if (!runs?.length) return;
@@ -402,12 +449,16 @@ function formatNestedChildren(
 			budget.remaining--;
 			const label = boundedLabel(child.agent ?? child.id ?? "nested");
 			const state = child.state ? boundedLabel(child.state) : undefined;
-			lines.push(`${currentIndent}↳ ${label}${state ? ` — ${state}` : ""}`);
+			entries.push(`${currentIndent}↳ ${label}${state ? ` — ${state}` : ""}`);
 			append(child.children, `${currentIndent}  `, depth + 1);
 		}
 	};
 	append(children, indent, 0);
-	return lines;
+	// Emit the heading only when there is content beneath it. When the shared budget is
+	// exhausted and the omission marker was already recorded by an earlier sibling, this
+	// child has no entries to show; emitting the heading alone would produce a bare
+	// 'Nested subagents:' with nothing beneath it.
+	return entries.length > 0 ? ["Nested subagents:", ...entries] : [];
 }
 
 function formatChildReferences(child: ChainStepResult, privacySafe = false): string[] {
@@ -418,12 +469,19 @@ function formatChildReferences(child: ChainStepResult, privacySafe = false): str
 	].filter((line): line is string => Boolean(line));
 }
 
-function formatProtectedLifecyclePreview(result: SubagentResult): string {
+function formatProtectedLifecyclePreview(
+	result: SubagentResult,
+	ceilingForPreview = MAX_COMPLETION_MESSAGE_CHARS,
+): string {
 	const children = Array.isArray(result.results) ? result.results : [];
-	if (children.length <= 1) return "Paused awaiting supervisor.";
-	const lines: string[] = [];
+	if (children.length <= 1) {
+		const sentence = "Paused awaiting supervisor.";
+		// Honour ceilingForPreview for the zero- and one-child shape the same way every
+		// other branch does: suppress rather than emit a partial sentence.
+		return sentence.length <= ceilingForPreview ? sentence : "";
+	}
 	const counts = countChildStatuses(children);
-	if (counts) lines.push(`Children: ${counts}`, "");
+	const countsCost = counts ? joinedLineCost([`Children: ${counts}`, ""]) : 0;
 	const displayedChildren = ["failed", "paused", "completed", "detached"]
 		.flatMap((status) =>
 			children
@@ -431,14 +489,47 @@ function formatProtectedLifecyclePreview(result: SubagentResult): string {
 				.filter((entry) => entry.status === status),
 		)
 		.slice(0, MAX_DISPLAYED_CHILDREN);
-	if (children.length > displayedChildren.length)
-		lines.push(`… [${children.length - displayedChildren.length} child results omitted]`, "");
-	for (const { child, index, status } of displayedChildren) {
+	// Compute per-child scaffold costs using a separate budget so the shared budget
+	// used during rendering is not consumed during cost estimation.
+	const nestedBudgetForCost: NestedFormatBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
+	const childCosts = displayedChildren.map(({ child, index, status }) => {
+		const labelLine = `${index + 1}/${children.length}. ${boundedLabel(child.agent)} — ${status}`;
+		const nested = formatNestedChildren(child.children, "   ", nestedBudgetForCost);
+		return joinedLineCost([labelLine, ...nested, ""]);
+	});
+	// Reduce displayed children when their scaffold alone would exceed the ceiling,
+	// incrementing the omission counter rather than silently tail-cutting a displayed child.
+	let effectiveCount = displayedChildren.length;
+	while (effectiveCount > 0) {
+		const partialScaffold = childCosts.slice(0, effectiveCount).reduce((s, c) => s + c, 0);
+		const effectiveOmitted = children.length - effectiveCount;
+		const omissionCost =
+			effectiveOmitted > 0 ? joinedLineCost([`… [${effectiveOmitted} child results omitted]`, ""]) : 0;
+		if (partialScaffold + countsCost + omissionCost <= ceilingForPreview) break;
+		effectiveCount--;
+	}
+	const effectiveDisplayedChildren = displayedChildren.slice(0, effectiveCount);
+	const effectiveOmittedCount = children.length - effectiveCount;
+	const effectiveOmissionCost =
+		effectiveOmittedCount > 0 ? joinedLineCost([`… [${effectiveOmittedCount} child results omitted]`, ""]) : 0;
+	// The counts header and omission marker carry no recovery pointers. When the reduction
+	// loop suppresses every displayable child, also verify they fit the ceiling; if not,
+	// suppress them rather than breach it.
+	const optionalLinesAffordable = effectiveCount > 0 || countsCost + effectiveOmissionCost <= ceilingForPreview;
+	const showCountsLine = !!counts && optionalLinesAffordable;
+	const showOmissionLine = effectiveOmittedCount > 0 && optionalLinesAffordable;
+	// Shared nested budget across all displayed children; each call to formatNestedChildren
+	// drains from the same pool, matching the pattern at the other multi-child call sites.
+	const nestedBudget: NestedFormatBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
+	const lines: string[] = [];
+	if (showCountsLine) lines.push(`Children: ${counts}`, "");
+	if (showOmissionLine) lines.push(`… [${effectiveOmittedCount} child results omitted]`, "");
+	for (const { child, index, status } of effectiveDisplayedChildren) {
 		lines.push(`${index + 1}/${children.length}. ${boundedLabel(child.agent)} — ${status}`);
-		lines.push(...formatNestedChildren(child.children, "   "));
+		lines.push(...formatNestedChildren(child.children, "   ", nestedBudget));
 		lines.push("");
 	}
-	return lines.join("\n").trimEnd() || "Paused awaiting supervisor.";
+	return lines.join("\n").trimEnd();
 }
 
 /**
@@ -466,7 +557,7 @@ function formatResultPreview(result: SubagentResult, ceilingForPreview = MAX_COM
 		state: result.state,
 		pause: (result as { pause?: { kind?: string } }).pause,
 	});
-	if (privacySafe) return formatProtectedLifecyclePreview(result);
+	if (privacySafe) return formatProtectedLifecyclePreview(result, ceilingForPreview);
 	const children = Array.isArray(result.results) ? result.results : [];
 	const nestedBudget: NestedFormatBudget = { remaining: MAX_NESTED_ENTRIES, omissionMarkers: new Set() };
 	// The budget here is caller-derived, so it can fall below the truncation-marker width.

--- a/extensions/subagents/src/runs/shared/nested-events.js
+++ b/extensions/subagents/src/runs/shared/nested-events.js
@@ -106,6 +106,24 @@ function clampNumber(value) {
 function stringValue(value, max = 512) {
     return typeof value === "string" && value.length > 0 ? value.slice(0, max) : undefined;
 }
+function pathValue(value, max = 512) {
+    if (typeof value !== "string" || value.length === 0)
+        return undefined;
+    if (value.length > max)
+        return undefined;
+    return value;
+}
+function displayStringValue(value, max = 512) {
+    if (typeof value !== "string" || value.length === 0)
+        return undefined;
+    if (value.length <= max)
+        return value;
+    const cut = max - 1;
+    const sliced = value.slice(0, cut);
+    const last = sliced.charCodeAt(sliced.length - 1);
+    const safe = last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+    return `${safe}…`;
+}
 function sanitizeTokenUsage(value) {
     if (!value || typeof value !== "object")
         return undefined;
@@ -172,7 +190,7 @@ function sanitizeStep(input, depth) {
     return {
         agent,
         status,
-        ...(stringValue(raw.sessionFile, 2048) ? { sessionFile: stringValue(raw.sessionFile, 2048) } : {}),
+        ...(pathValue(raw.sessionFile, 2048) ? { sessionFile: pathValue(raw.sessionFile, 2048) } : {}),
         ...(raw.activityState === "active_long_running" || raw.activityState === "needs_attention"
             ? { activityState: raw.activityState }
             : {}),
@@ -181,7 +199,7 @@ function sanitizeStep(input, depth) {
         ...(clampNumber(raw.currentToolStartedAt) !== undefined
             ? { currentToolStartedAt: clampNumber(raw.currentToolStartedAt) }
             : {}),
-        ...(stringValue(raw.currentPath, 2048) ? { currentPath: stringValue(raw.currentPath, 2048) } : {}),
+        ...(displayStringValue(raw.currentPath, 2048) ? { currentPath: displayStringValue(raw.currentPath, 2048) } : {}),
         ...(clampNumber(raw.turnCount) !== undefined ? { turnCount: clampNumber(raw.turnCount) } : {}),
         ...(clampNumber(raw.toolCount) !== undefined ? { toolCount: clampNumber(raw.toolCount) } : {}),
         ...(clampNumber(raw.startedAt) !== undefined ? { startedAt: clampNumber(raw.startedAt) } : {}),
@@ -224,12 +242,12 @@ export function sanitizeSummary(input, depth = 0) {
         depth: Math.min(Math.max(0, clampNumber(raw.depth) ?? 0), MAX_DEPTH),
         path: pathParts,
         state: sanitizeState(raw.state, "running"),
-        ...(stringValue(raw.asyncDir, 2048) ? { asyncDir: stringValue(raw.asyncDir, 2048) } : {}),
+        ...(pathValue(raw.asyncDir, 2048) ? { asyncDir: pathValue(raw.asyncDir, 2048) } : {}),
         ...(clampNumber(raw.pid) !== undefined && clampNumber(raw.pid) > 0 && Number.isInteger(clampNumber(raw.pid))
             ? { pid: clampNumber(raw.pid) }
             : {}),
         ...(stringValue(raw.sessionId, 256) ? { sessionId: stringValue(raw.sessionId, 256) } : {}),
-        ...(stringValue(raw.sessionFile, 2048) ? { sessionFile: stringValue(raw.sessionFile, 2048) } : {}),
+        ...(pathValue(raw.sessionFile, 2048) ? { sessionFile: pathValue(raw.sessionFile, 2048) } : {}),
         ...(stringValue(raw.intercomTarget, 256) ? { intercomTarget: stringValue(raw.intercomTarget, 256) } : {}),
         ...(stringValue(raw.ownerIntercomTarget, 256)
             ? { ownerIntercomTarget: stringValue(raw.ownerIntercomTarget, 256) }
@@ -240,7 +258,7 @@ export function sanitizeSummary(input, depth = 0) {
         ...(raw.ownerState === "live" || raw.ownerState === "gone" || raw.ownerState === "unknown"
             ? { ownerState: raw.ownerState }
             : {}),
-        ...(stringValue(raw.controlInbox, 2048) ? { controlInbox: stringValue(raw.controlInbox, 2048) } : {}),
+        ...(displayStringValue(raw.controlInbox, 2048) ? { controlInbox: displayStringValue(raw.controlInbox, 2048) } : {}),
         ...(stringValue(raw.capabilityToken, 128) ? { capabilityToken: stringValue(raw.capabilityToken, 128) } : {}),
         ...(raw.mode === "single" || raw.mode === "parallel" || raw.mode === "chain" ? { mode: raw.mode } : {}),
         ...(stringValue(raw.agent, 128) ? { agent: stringValue(raw.agent, 128) } : {}),
@@ -262,7 +280,7 @@ export function sanitizeSummary(input, depth = 0) {
         ...(clampNumber(raw.currentToolStartedAt) !== undefined
             ? { currentToolStartedAt: clampNumber(raw.currentToolStartedAt) }
             : {}),
-        ...(stringValue(raw.currentPath, 2048) ? { currentPath: stringValue(raw.currentPath, 2048) } : {}),
+        ...(displayStringValue(raw.currentPath, 2048) ? { currentPath: displayStringValue(raw.currentPath, 2048) } : {}),
         ...(clampNumber(raw.turnCount) !== undefined ? { turnCount: clampNumber(raw.turnCount) } : {}),
         ...(clampNumber(raw.toolCount) !== undefined ? { toolCount: clampNumber(raw.toolCount) } : {}),
         ...(totalTokens ? { totalTokens } : {}),

--- a/extensions/subagents/src/runs/shared/nested-events.ts
+++ b/extensions/subagents/src/runs/shared/nested-events.ts
@@ -196,6 +196,30 @@ function stringValue(value: unknown, max = 512): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value.slice(0, max) : undefined;
 }
 
+// Prefer absence over a silently truncated value for fields that are consumed
+// programmatically (opened, resolved, or used to locate a directory). A truncated
+// path still looks valid and fails later as a confusing not-found; an absent field
+// is detectably absent and can be handled at the point of use.
+function pathValue(value: unknown, max = 512): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	if (value.length > max) return undefined;
+	return value;
+}
+
+// Display-only string fields: visible middle-truncation is acceptable because
+// the value is shown to a human or the model, not used to locate files.
+function displayStringValue(value: unknown, max = 512): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	if (value.length <= max) return value;
+	// Back up by one code unit when the cut would fall between a UTF-16 surrogate
+	// pair, ensuring the returned string is always well-formed.
+	const cut = max - 1;
+	const sliced = value.slice(0, cut);
+	const last = sliced.charCodeAt(sliced.length - 1);
+	const safe = last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+	return `${safe}…`;
+}
+
 function sanitizeTokenUsage(value: unknown): NestedRunSummary["totalTokens"] | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const raw = value as Record<string, unknown>;
@@ -262,7 +286,7 @@ function sanitizeStep(input: unknown, depth: number): NestedStepSummary | undefi
 	return {
 		agent,
 		status,
-		...(stringValue(raw.sessionFile, 2048) ? { sessionFile: stringValue(raw.sessionFile, 2048) } : {}),
+		...(pathValue(raw.sessionFile, 2048) ? { sessionFile: pathValue(raw.sessionFile, 2048) } : {}),
 		...(raw.activityState === "active_long_running" || raw.activityState === "needs_attention"
 			? { activityState: raw.activityState }
 			: {}),
@@ -271,7 +295,7 @@ function sanitizeStep(input: unknown, depth: number): NestedStepSummary | undefi
 		...(clampNumber(raw.currentToolStartedAt) !== undefined
 			? { currentToolStartedAt: clampNumber(raw.currentToolStartedAt) }
 			: {}),
-		...(stringValue(raw.currentPath, 2048) ? { currentPath: stringValue(raw.currentPath, 2048) } : {}),
+		...(displayStringValue(raw.currentPath, 2048) ? { currentPath: displayStringValue(raw.currentPath, 2048) } : {}),
 		...(clampNumber(raw.turnCount) !== undefined ? { turnCount: clampNumber(raw.turnCount) } : {}),
 		...(clampNumber(raw.toolCount) !== undefined ? { toolCount: clampNumber(raw.toolCount) } : {}),
 		...(clampNumber(raw.startedAt) !== undefined ? { startedAt: clampNumber(raw.startedAt) } : {}),
@@ -313,12 +337,12 @@ export function sanitizeSummary(input: unknown, depth = 0): NestedRunSummary | u
 		depth: Math.min(Math.max(0, clampNumber(raw.depth) ?? 0), MAX_DEPTH),
 		path: pathParts,
 		state: sanitizeState(raw.state, "running"),
-		...(stringValue(raw.asyncDir, 2048) ? { asyncDir: stringValue(raw.asyncDir, 2048) } : {}),
+		...(pathValue(raw.asyncDir, 2048) ? { asyncDir: pathValue(raw.asyncDir, 2048) } : {}),
 		...(clampNumber(raw.pid) !== undefined && clampNumber(raw.pid)! > 0 && Number.isInteger(clampNumber(raw.pid))
 			? { pid: clampNumber(raw.pid) }
 			: {}),
 		...(stringValue(raw.sessionId, 256) ? { sessionId: stringValue(raw.sessionId, 256) } : {}),
-		...(stringValue(raw.sessionFile, 2048) ? { sessionFile: stringValue(raw.sessionFile, 2048) } : {}),
+		...(pathValue(raw.sessionFile, 2048) ? { sessionFile: pathValue(raw.sessionFile, 2048) } : {}),
 		...(stringValue(raw.intercomTarget, 256) ? { intercomTarget: stringValue(raw.intercomTarget, 256) } : {}),
 		...(stringValue(raw.ownerIntercomTarget, 256)
 			? { ownerIntercomTarget: stringValue(raw.ownerIntercomTarget, 256) }
@@ -329,7 +353,7 @@ export function sanitizeSummary(input: unknown, depth = 0): NestedRunSummary | u
 		...(raw.ownerState === "live" || raw.ownerState === "gone" || raw.ownerState === "unknown"
 			? { ownerState: raw.ownerState }
 			: {}),
-		...(stringValue(raw.controlInbox, 2048) ? { controlInbox: stringValue(raw.controlInbox, 2048) } : {}),
+		...(displayStringValue(raw.controlInbox, 2048) ? { controlInbox: displayStringValue(raw.controlInbox, 2048) } : {}),
 		...(stringValue(raw.capabilityToken, 128) ? { capabilityToken: stringValue(raw.capabilityToken, 128) } : {}),
 		...(raw.mode === "single" || raw.mode === "parallel" || raw.mode === "chain" ? { mode: raw.mode } : {}),
 		...(stringValue(raw.agent, 128) ? { agent: stringValue(raw.agent, 128) } : {}),
@@ -351,7 +375,7 @@ export function sanitizeSummary(input: unknown, depth = 0): NestedRunSummary | u
 		...(clampNumber(raw.currentToolStartedAt) !== undefined
 			? { currentToolStartedAt: clampNumber(raw.currentToolStartedAt) }
 			: {}),
-		...(stringValue(raw.currentPath, 2048) ? { currentPath: stringValue(raw.currentPath, 2048) } : {}),
+		...(displayStringValue(raw.currentPath, 2048) ? { currentPath: displayStringValue(raw.currentPath, 2048) } : {}),
 		...(clampNumber(raw.turnCount) !== undefined ? { turnCount: clampNumber(raw.turnCount) } : {}),
 		...(clampNumber(raw.toolCount) !== undefined ? { toolCount: clampNumber(raw.toolCount) } : {}),
 		...(totalTokens ? { totalTokens } : {}),

--- a/extensions/subagents/test/unit/nested-events.test.ts
+++ b/extensions/subagents/test/unit/nested-events.test.ts
@@ -11,6 +11,7 @@ import {
 	projectNestedEvents,
 	resolveNestedParentAddressFromEnv,
 	resolveNestedRouteFromEnv,
+	sanitizeSummary,
 	updateAsyncJobNestedProjection,
 	updateForegroundNestedProjection,
 	writeNestedEvent,
@@ -350,6 +351,119 @@ describe("nested event parsing and projection", () => {
 			total: 25,
 		});
 		assert.equal(registry.children.find((item) => item.id === "nested-invalid-tokens")?.totalTokens, undefined);
+	});
+
+	it("omits programmatic path fields (sessionFile, asyncDir) when over the 2048-char limit", () => {
+		const route = trackRoute();
+		const limit = 2048;
+		const atLimit = "a".repeat(limit);
+		const overLimit = "a".repeat(limit + 1);
+
+		// Value exactly at limit passes through unchanged
+		writeNestedEvent(route, {
+			type: "subagent.nested.updated",
+			ts: 100,
+			parentRunId: "root-run",
+			parentStepIndex: 1,
+			child: { ...child("path-limit", "running", 100), sessionFile: atLimit, asyncDir: atLimit },
+		});
+		// Value one char over the limit is omitted entirely (not truncated)
+		writeNestedEvent(route, {
+			type: "subagent.nested.updated",
+			ts: 200,
+			parentRunId: "root-run",
+			parentStepIndex: 1,
+			child: { ...child("path-over", "running", 200), sessionFile: overLimit, asyncDir: overLimit },
+		});
+
+		const registry = projectNestedEvents(route);
+		const atLimitChild = registry.children.find((c) => c.id === "path-limit");
+		const overLimitChild = registry.children.find((c) => c.id === "path-over");
+
+		assert.equal(atLimitChild?.sessionFile, atLimit, "sessionFile at limit must pass through unchanged");
+		assert.equal(atLimitChild?.asyncDir, atLimit, "asyncDir at limit must pass through unchanged");
+		assert.equal(overLimitChild?.sessionFile, undefined, "sessionFile over limit must be omitted, not truncated");
+		assert.equal(overLimitChild?.asyncDir, undefined, "asyncDir over limit must be omitted, not truncated");
+	});
+
+	it("marks display-only path field (currentPath) with an ellipsis when over the 2048-char limit", () => {
+		const route = trackRoute();
+		const limit = 2048;
+		const atLimit = "b".repeat(limit);
+		const overLimit = "b".repeat(limit + 1);
+
+		// Value exactly at limit passes through unchanged
+		writeNestedEvent(route, {
+			type: "subagent.nested.updated",
+			ts: 100,
+			parentRunId: "root-run",
+			parentStepIndex: 1,
+			child: { ...child("disp-limit", "running", 100), currentPath: atLimit },
+		});
+		// Value one char over the limit is truncated with a visible marker
+		writeNestedEvent(route, {
+			type: "subagent.nested.updated",
+			ts: 200,
+			parentRunId: "root-run",
+			parentStepIndex: 1,
+			child: { ...child("disp-over", "running", 200), currentPath: overLimit },
+		});
+
+		const registry = projectNestedEvents(route);
+		const atLimitChild = registry.children.find((c) => c.id === "disp-limit");
+		const overLimitChild = registry.children.find((c) => c.id === "disp-over");
+
+		assert.equal(atLimitChild?.currentPath, atLimit, "currentPath at limit must pass through unchanged");
+		assert.ok(
+			overLimitChild?.currentPath?.endsWith("\u2026"),
+			"currentPath over limit must end with a visible truncation marker",
+		);
+		assert.ok(overLimitChild?.currentPath !== undefined, "currentPath over limit must not be omitted entirely");
+	});
+
+	// controlInbox cannot be exercised through the event-parsing route because
+	// parseRecord overwrites any child-provided controlInbox with route.controlInbox.
+	// Test it directly through sanitizeSummary, which applies displayStringValue
+	// without the route-level override.
+	it("marks display-only field controlInbox with an ellipsis when over the 2048-char limit (via sanitizeSummary)", () => {
+		const limit = 2048;
+		const base = { id: "ctrl-test", parentRunId: "root-run", state: "running", depth: 0, path: [] };
+
+		const atLimit = sanitizeSummary({ ...base, controlInbox: "c".repeat(limit) });
+		assert.equal(atLimit?.controlInbox, "c".repeat(limit), "controlInbox at limit must pass through unchanged");
+
+		const overLimit = sanitizeSummary({ ...base, controlInbox: "c".repeat(limit + 1) });
+		assert.ok(
+			overLimit?.controlInbox?.endsWith("\u2026"),
+			"controlInbox over limit must end with a visible truncation marker",
+		);
+		assert.ok(overLimit?.controlInbox !== undefined, "controlInbox over limit must not be omitted entirely");
+	});
+
+	it("displayStringValue does not emit a lone surrogate when the slice boundary falls between a surrogate pair", () => {
+		// Emoji U+1F600 \uD83D\uDE00 is a UTF-16 surrogate pair (two code units).
+		// Place it so the cut at (max - 1) falls on the high surrogate.
+		// displayStringValue slices at max-1 = 2047 code units, backing up if the last
+		// kept code unit is a high surrogate.
+		const emoji = "\uD83D\uDE00"; // U+1F600
+		// 2046 'a' chars + emoji + 'x' => length 2049, emoji straddles the cut at 2047.
+		const value = "a".repeat(2046) + emoji + "x";
+		const base = { id: "surr-test", parentRunId: "root-run", state: "running", depth: 0, path: [] };
+		const result = sanitizeSummary({ ...base, currentPath: value });
+		assert.ok(result?.currentPath !== undefined, "currentPath must be present");
+		const cp = result!.currentPath!;
+		assert.ok(cp.endsWith("\u2026"), "must end with a visible truncation marker");
+		// Verify no lone surrogate in the result.
+		for (let i = 0; i < cp.length; i++) {
+			const cu = cp.charCodeAt(i);
+			if (cu >= 0xd800 && cu <= 0xdbff) {
+				const next = cp.charCodeAt(i + 1);
+				assert.ok(
+					next >= 0xdc00 && next <= 0xdfff,
+					`lone high surrogate at index ${i}: 0x${cu.toString(16)} not followed by a low surrogate`,
+				);
+			}
+		}
 	});
 
 	it("parses only complete jsonl records", () => {

--- a/extensions/subagents/test/unit/notify.test.ts
+++ b/extensions/subagents/test/unit/notify.test.ts
@@ -2642,3 +2642,138 @@ describe("boundedReference", () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// truncateWithMarker surrogate safety — all four call sites
+//
+// The root cause (tlhm-vxik) is a raw value.slice(0, maxChars - marker.length)
+// inside truncateWithMarker that can leave an unpaired UTF-16 high surrogate
+// (U+D800–U+DBFF) at the cut boundary when an emoji straddles that position.
+// The fix replaces it with sliceSafe, which backs up one code unit when the
+// last retained unit is a high surrogate.
+//
+// CUT-POINT DERIVATION: each cut is maxChars - marker.length, derived directly
+// from the function arguments.  Tests measure this from the constants rather
+// than hardcoding an assumed offset so a constant change immediately breaks
+// the test fixture comment, not just the assertion.
+//
+// COMPLETION-ENVELOPE REACHABILITY NOTE:
+//   The sendCompletion envelope calls truncateWithMarker(formatted, 32000, marker33).
+//   Both formatSingleCompletion and formatGroupedCompletion guarantee
+//   formatted.length <= MAX_COMPLETION_MESSAGE_CHARS - 1 = 31 999 through their
+//   joinedLineCost / trimEnd reservation math (the final trimEnd removes exactly
+//   one trailing '\n' that joinedLineCost counts in reservedChars, leaving one
+//   char of permanent slack).  Therefore truncateWithMarker's value.length check
+//   always exits early for the envelope, and placing an emoji at index 31 966
+//   is structurally impossible under the current formatters.  No envelope test
+//   is written; this comment is the evidence.
+// ---------------------------------------------------------------------------
+
+describe("truncateWithMarker surrogate safety at each call site", () => {
+	const emoji = "\uD83D\uDE00"; // U+1F600 — two UTF-16 code units
+
+	// -----------------------------------------------------------------------
+	// 1. boundedSummary  (marker = '… [summary truncated]', 21 chars)
+	//    maxChars = 8 000 (MAX_SUMMARY_CHARS), cut = 8000 - 21 = 7 979
+	//    High surrogate at index 7 978 is the last unit taken by the raw slice.
+	// -----------------------------------------------------------------------
+	it("boundedSummary: well-formed when an emoji straddles the 7979-char cut", () => {
+		const summaryMarker = "… [summary truncated]";
+		const maxSummaryChars = 8_000; // MAX_SUMMARY_CHARS module constant
+		const cutPoint = maxSummaryChars - summaryMarker.length; // 7979
+		// emoji starts at cutPoint - 1 = 7978 so the high surrogate falls at the
+		// last position taken by slice(0, cutPoint).
+		const summary = "a".repeat(cutPoint - 1) + emoji + "a".repeat(500);
+		assert.equal(summary.length, cutPoint - 1 + 2 + 500, "fixture length sanity");
+
+		const { events, sentMessages } = createPi();
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			id: "surrogate-summary-test",
+			agent: "test-agent",
+			success: true,
+			summary,
+			timestamp: 1,
+			sessionId: "session-1",
+		});
+
+		assert.equal(sentMessages.length, 1, "exactly one message expected");
+		const content = (sentMessages[0]!.message as { content: string }).content;
+		assert.ok(content.isWellFormed(), "boundedSummary output must not contain a lone surrogate");
+		assert.ok(content.length <= MAX_COMPLETION_MESSAGE_CHARS, "ceiling must be respected");
+	});
+
+	// -----------------------------------------------------------------------
+	// 2. boundedReference fallback — no path separator present
+	//    (marker = '… [reference truncated]', 23 chars)
+	//    maxChars = 500 (MAX_REFERENCE_CHARS), cut = 500 - 23 = 477
+	//    High surrogate at index 476 is the last unit taken by the raw slice.
+	// -----------------------------------------------------------------------
+	it("boundedReference (no-separator fallback): well-formed when emoji straddles the 477-char cut", () => {
+		const refMarker = "… [reference truncated]";
+		const maxRefChars = 500; // MAX_REFERENCE_CHARS module constant
+		const cutPoint = maxRefChars - refMarker.length; // 477
+		// No '/' in the value → fallback to truncateWithMarker directly.
+		const value = "a".repeat(cutPoint - 1) + emoji + "a".repeat(100);
+		assert.ok(value.length > maxRefChars, "fixture must exceed the cap");
+		assert.ok(!value.includes("/"), "fixture must have no path separator");
+
+		const result = boundedReference(value);
+		assert.ok(result.length <= maxRefChars, `result length ${result.length} must be <= ${maxRefChars}`);
+		assert.ok(result.isWellFormed(), "boundedReference (no-separator) output must not contain a lone surrogate");
+		assert.ok(result.endsWith(refMarker), "fallback marker must be present");
+	});
+
+	// -----------------------------------------------------------------------
+	// 3. boundedReference fallback — final segment saturates the cap
+	//    Same marker and cut as above (477).  Route reached when the path has a
+	//    separator but the last segment is longer than
+	//    MAX_REFERENCE_CHARS - middleMarker.length - 1 = 474 chars, so no
+	//    leading context can survive alongside the middle marker.
+	// -----------------------------------------------------------------------
+	it("boundedReference (final-segment-saturates fallback): well-formed when emoji straddles the 477-char cut", () => {
+		const refMarker = "… [reference truncated]";
+		const maxRefChars = 500; // MAX_REFERENCE_CHARS module constant
+		const cutPoint = maxRefChars - refMarker.length; // 477
+		// '/' at index 0, then (cutPoint - 2) 'a's, then emoji.
+		// The final segment alone (cutPoint - 2 + 2 + 100 = 577 chars) exceeds
+		// MAX_REFERENCE_CHARS - middleMarker.length - 1 = 474, so the while-loop
+		// breaks immediately and tailStart stays -1 → truncateWithMarker fallback.
+		const value = "/" + "a".repeat(cutPoint - 2) + emoji + "a".repeat(100);
+		// index 0 = '/', indices 1..(cutPoint-2) = 'a', index cutPoint-1 = high surrogate
+		assert.equal(value[cutPoint - 1], "\uD83D", "high surrogate must be at index cutPoint-1");
+		assert.ok(value.length > maxRefChars, "fixture must exceed the cap");
+
+		const result = boundedReference(value);
+		assert.ok(result.length <= maxRefChars, `result length ${result.length} must be <= ${maxRefChars}`);
+		assert.ok(
+			result.isWellFormed(),
+			"boundedReference (final-segment-saturates) output must not contain a lone surrogate",
+		);
+		assert.ok(result.endsWith(refMarker), "fallback marker must be present");
+	});
+
+	// -----------------------------------------------------------------------
+	// 4. boundedLabel  (marker = '… [label truncated]', 19 chars)
+	//    maxChars = 160 (MAX_LABEL_CHARS), cut = 160 - 19 = 141
+	//    High surrogate at index 140 is the last unit taken by the raw slice.
+	// -----------------------------------------------------------------------
+	it("boundedLabel: well-formed when an emoji straddles the 141-char cut", () => {
+		const labelMarker = "… [label truncated]";
+		const maxLabelChars = 160; // MAX_LABEL_CHARS module constant
+		const cutPoint = maxLabelChars - labelMarker.length; // 141
+		// boundedLabel is applied to the agent name inside buildCompletionDetails.
+		const agentName = "a".repeat(cutPoint - 1) + emoji + "a".repeat(50);
+		assert.ok(agentName.length > maxLabelChars, "fixture must exceed the cap");
+
+		const details = buildCompletionDetails({
+			id: "surrogate-label-test",
+			agent: agentName,
+			success: true,
+			summary: "",
+			timestamp: 1,
+		});
+		assert.ok(details.agent.isWellFormed(), "boundedLabel output (details.agent) must not contain a lone surrogate");
+		assert.ok(details.agent.length <= maxLabelChars, "agent label must respect the cap");
+		assert.ok(details.agent.endsWith(labelMarker), "label marker must be present");
+	});
+});

--- a/extensions/subagents/test/unit/notify.test.ts
+++ b/extensions/subagents/test/unit/notify.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import registerSubagentNotify, {
 	MAX_COMPLETION_MESSAGE_CHARS,
 	MAX_DISPLAY_SUMMARY_CHARS,
+	boundedReference,
 	buildCompletionDetails,
 	formatGroupedCompletion,
 	formatSingleCompletion,
@@ -2014,6 +2015,26 @@ describe("completion formatting helpers", () => {
 			}
 		}
 
+		// Structural well-formedness: a 'Nested subagents:' heading must never appear
+		// without content beneath it. A length check cannot see this defect because an
+		// orphaned heading fits within the ceiling while producing meaningless output.
+		function assertNoOrphanedNestedHeading(label: string, ceiling: number, text: string) {
+			const lines = text.split("\n");
+			for (let i = 0; i < lines.length; i++) {
+				if (lines[i]?.trim() !== "Nested subagents:") continue;
+				// Find the next non-empty line.
+				let j = i + 1;
+				while (j < lines.length && lines[j]?.trim() === "") j++;
+				const next = lines[j]?.trim() ?? "";
+				// The next non-empty line must be a nested entry (↳) or an omission marker (…).
+				const hasContent = next.startsWith("↳") || next.startsWith("…");
+				assert.ok(
+					hasContent,
+					`[${label}] ceiling=${ceiling}: orphaned 'Nested subagents:' heading at line ${i} — next non-empty line: ${JSON.stringify(next)}`,
+				);
+			}
+		}
+
 		function checkCeiling(label: string, makeResult: () => object) {
 			it(`${label} — length <= ceiling and no mangled markers for all ${CEILINGS.length} ceilings`, () => {
 				const result = makeResult() as Parameters<typeof buildCompletionDetails>[0];
@@ -2026,6 +2047,7 @@ describe("completion formatting helpers", () => {
 						`[${label}] ceiling=${ceiling}: preview.length=${preview.length} > ceiling`,
 					);
 					assertNoMangledMarker(label, ceiling, preview);
+					assertNoOrphanedNestedHeading(label, ceiling, preview);
 				}
 			});
 		}
@@ -2208,6 +2230,151 @@ describe("completion formatting helpers", () => {
 				index: i,
 			})),
 		}));
+
+		// Protected lifecycle — 2 children with nested subagents (minimal shape).
+		checkCeiling("protected lifecycle 2 children with nested", () => ({
+			id: "sweep-protected-2ch",
+			agent: "parallel:a+b",
+			success: false,
+			state: "paused",
+			pause: { kind: "awaiting_supervisor" },
+			summary: "x".repeat(9_000),
+			timestamp: 1,
+			results: Array.from({ length: 2 }, (_, i) => ({
+				agent: `worker-${i}`,
+				status: "paused",
+				summary: "x".repeat(9_000),
+				index: i,
+				children: Array.from({ length: 5 }, (_, j) => ({
+					agent: `nested-${i}-${j}`,
+					state: "paused",
+				})),
+			})),
+		}));
+
+		// Protected lifecycle — 8 children each with nested subagents (saturated budget shape).
+		checkCeiling("protected lifecycle 8 children with nested", () => ({
+			id: "sweep-protected-8ch",
+			agent: "parallel:8",
+			success: false,
+			state: "paused",
+			pause: { kind: "awaiting_supervisor" },
+			summary: "x".repeat(9_000),
+			timestamp: 1,
+			results: Array.from({ length: 8 }, (_, i) => ({
+				agent: `worker-${i}`,
+				status: "paused",
+				summary: "x".repeat(9_000),
+				index: i,
+				children: Array.from({ length: 5 }, (_, j) => ({
+					agent: `nested-${i}-${j}`,
+					state: "paused",
+				})),
+			})),
+		}));
+
+		// Protected lifecycle — zero children (returns 'Paused awaiting supervisor.').
+		checkCeiling("protected lifecycle 0 children", () => ({
+			id: "sweep-protected-0ch",
+			agent: "parallel:0",
+			success: false,
+			state: "paused",
+			pause: { kind: "awaiting_supervisor" },
+			summary: "done",
+			timestamp: 1,
+			results: [],
+		}));
+
+		// Protected lifecycle — one child (also returns 'Paused awaiting supervisor.').
+		checkCeiling("protected lifecycle 1 child", () => ({
+			id: "sweep-protected-1ch",
+			agent: "parallel:1",
+			success: false,
+			state: "paused",
+			pause: { kind: "awaiting_supervisor" },
+			summary: "done",
+			timestamp: 1,
+			results: [{ agent: "worker-0", status: "paused", summary: "x".repeat(9_000), index: 0 }],
+		}));
+	});
+
+	// =========================================================================
+	// Orphaned-heading regression: 8 protected children with 5 nested entries each
+	// at the default ceiling (32 000). The shared nested budget is exhausted after
+	// two children; without the fix, children 3–8 each rendered a bare
+	// 'Nested subagents:' heading with nothing beneath it (six orphaned headings).
+	// =========================================================================
+	it("no orphaned 'Nested subagents:' heading with 8 protected children and 5 nested entries each at the default ceiling", () => {
+		const result = {
+			id: "orphan-regression",
+			agent: "parallel:8",
+			success: false,
+			state: "paused" as const,
+			pause: { kind: "awaiting_supervisor" },
+			summary: "paused",
+			timestamp: 1,
+			results: Array.from({ length: 8 }, (_, i) => ({
+				agent: `w${i + 1}`,
+				status: "failed" as const,
+				summary: "summary",
+				children: Array.from({ length: 5 }, (_, j) => ({
+					agent: `nested-${i + 1}-${j + 1}`,
+					id: `id-${i + 1}-${j + 1}`,
+					state: "completed",
+				})),
+			})),
+		};
+		const details = buildCompletionDetails(result as Parameters<typeof buildCompletionDetails>[0]);
+		const preview = details._reformatPreview!(32_000);
+		const lines = preview.split("\n");
+		for (let i = 0; i < lines.length; i++) {
+			if (lines[i]?.trim() !== "Nested subagents:") continue;
+			let j = i + 1;
+			while (j < lines.length && lines[j]?.trim() === "") j++;
+			const next = lines[j]?.trim() ?? "";
+			assert.ok(
+				next.startsWith("↳") || next.startsWith("…"),
+				`orphaned 'Nested subagents:' at line ${i}; next non-empty: ${JSON.stringify(next)}`,
+			);
+		}
+	});
+
+	// =========================================================================
+	// Protected-lifecycle privacy: no summary text in output.
+	//
+	// The protected-lifecycle path deliberately omits child and outer summaries
+	// so no sensitive context leaks in the preview. This test asserts that the
+	// privacy guarantee holds across ceilings and is never broken by the fix.
+	// =========================================================================
+	it("protected lifecycle preview contains no child or outer summary text", () => {
+		const SENTINEL = "SENTINEL_SECRET_TEXT";
+		const result = {
+			id: "privacy-check",
+			agent: "parallel:a+b",
+			success: false,
+			state: "paused",
+			pause: { kind: "awaiting_supervisor" },
+			summary: `Outer: ${SENTINEL}`,
+			timestamp: 1,
+			results: Array.from({ length: 4 }, (_, i) => ({
+				agent: `worker-${i}`,
+				status: "paused",
+				summary: `Child ${i}: ${SENTINEL}`,
+				index: i,
+				children: Array.from({ length: 3 }, (_, j) => ({
+					agent: `nested-${i}-${j}`,
+					state: "paused",
+				})),
+			})),
+		};
+		const details = buildCompletionDetails(result as Parameters<typeof buildCompletionDetails>[0]);
+		for (const ceiling of [32_000, 1_000, 100, 0]) {
+			const preview = details._reformatPreview!(ceiling);
+			assert.ok(
+				!preview.includes(SENTINEL),
+				`ceiling=${ceiling}: preview must not contain summary sentinel text, got: ${JSON.stringify(preview.slice(0, 200))}`,
+			);
+		}
 	});
 
 	// =========================================================================
@@ -2359,5 +2526,119 @@ describe("completion formatting helpers", () => {
 
 		// 4. Outer session also present.
 		assert.ok(content.includes(`Session: ${shareUrl}`), "outer session pointer must be present");
+	});
+});
+
+// MAX_REFERENCE_CHARS is 500; tests use the literal value so they remain sensitive
+// to changes in the constant.
+const MAX_REF = 500;
+
+describe("boundedReference", () => {
+	it("returns a value of exactly MAX_REFERENCE_CHARS bytes unchanged with no marker", () => {
+		const prefix = "/Users/diego/.the-last-harness/agent/sessions/run-0/";
+		const filename = "session.jsonl";
+		// Build a value padded to exactly 500 chars.
+		const padding = MAX_REF - prefix.length - filename.length;
+		const value = prefix + "x".repeat(padding) + filename;
+		assert.equal(value.length, MAX_REF);
+		assert.equal(boundedReference(value), value);
+	});
+
+	it("truncates a value of MAX_REFERENCE_CHARS + 1 with a middle marker", () => {
+		// Put padding in the directory portion so the last segment is a recognisable filename.
+		const filename = "session.jsonl";
+		const base = "/Users/diego/.the-last-harness/agent/sessions/run-0-";
+		// One char over the cap: padding fills the directory name, then '/' then filename.
+		const padding = MAX_REF + 1 - base.length - 1 - filename.length;
+		const value = `${base}${"x".repeat(padding)}/${filename}`;
+		assert.equal(value.length, MAX_REF + 1);
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF, `result length ${result.length} must be <= ${MAX_REF}`);
+		assert.ok(result.includes("… [reference truncated] …"), "middle marker must appear in the truncated result");
+		assert.ok(result.endsWith(`/${filename}`), "trailing filename must be preserved after middle truncation");
+		// At least one leading character of root context must survive before the marker.
+		// The exact amount varies: the tail is extended greedily, so a deeper kept tail
+		// legitimately leaves a shorter head.
+		const markerIndex = result.indexOf("… [reference truncated] …");
+		assert.ok(markerIndex >= 1, `at least one leading character must precede the marker; got index ${markerIndex}`);
+		assert.ok(value.startsWith(result.slice(0, markerIndex)), "the leading portion must be a true prefix of the input");
+	});
+
+	it("preserves the trailing filename for a long path with many directory segments", () => {
+		// Construct a path whose directory portion is very long.
+		const tail = "/artifact-output.md";
+		const directory = "/Users/diego/.the-last-harness/agent/sessions/" + "nested/".repeat(80);
+		const value = directory + tail.slice(1); // remove leading "/" already in directory
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF);
+		assert.ok(result.endsWith("/artifact-output.md"), `trailing filename must survive: got '${result.slice(-30)}'`);
+	});
+
+	it("retains the run-id directories above a session filename, not just the final segment", () => {
+		// Every session pointer in the system is named "session.jsonl", so the final segment
+		// alone identifies nothing. The run-id directories above it are the discriminating part.
+		const identifyingTail = "/428b3c62/run-0/session.jsonl";
+		const deepPrefix = `/Users/diego/.the-last-harness/agent/sessions/${"deeply-nested-directory/".repeat(25)}`;
+		const value = deepPrefix + identifyingTail.slice(1);
+		assert.ok(value.length > MAX_REF, "fixture must exceed the cap to exercise truncation");
+
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF, `result length ${result.length} must be <= ${MAX_REF}`);
+		// The property that matters: the run id survives, not merely the shared filename.
+		assert.ok(result.includes("428b3c62"), `run-id directory must survive: got '${result.slice(-60)}'`);
+		assert.ok(result.endsWith(identifyingTail), `full identifying tail must survive: got '${result.slice(-60)}'`);
+		assert.ok(result.includes("… [reference truncated] …"), "middle marker must be present");
+		assert.ok(result.startsWith("/Users/"), "leading root context must be preserved");
+	});
+
+	it("handles a value with no path separator by falling back to head truncation with a marker", () => {
+		// A non-path reference longer than the cap.
+		const value = "share-error-detail-".repeat(40); // 760 chars, no "/"
+		assert.ok(value.length > MAX_REF);
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF);
+		// With no separator the fallback emits the original end-of-string marker.
+		assert.ok(result.endsWith("… [reference truncated]"), "no-separator fallback must end with the standard marker");
+		// Must not emit the middle marker whose trailing '…' implies a segment follows.
+		assert.ok(!result.includes("… [reference truncated] …"), "no-separator fallback must not emit the middle marker");
+	});
+
+	it("handles a value whose final segment alone exceeds the cap by falling back to head truncation", () => {
+		// A path whose filename segment is itself larger than MAX_REFERENCE_CHARS.
+		const hugeFilename = "x".repeat(MAX_REF + 10);
+		const value = `/Users/diego/sessions/${hugeFilename}`;
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF, `result must be within cap; got ${result.length}`);
+		// The middle marker must not appear since it cannot be formed with a well-formed tail.
+		assert.ok(
+			!result.includes("… [reference truncated] …"),
+			"oversized final segment must not produce a garbled middle marker",
+		);
+	});
+
+	it("does not emit a lone surrogate when the slice boundary falls between a surrogate pair", () => {
+		// Emoji U+1F600 😀 is encoded as a UTF-16 surrogate pair (two code units).
+		// Construct a path where the leading budget of the middle-truncation cut falls
+		// between the high and low surrogate, which would yield an ill-formed string.
+		// The path must be long enough to trigger middle-truncation (> MAX_REFERENCE_CHARS).
+		const emoji = "\uD83D\uDE00"; // U+1F600, two code units
+		// 373 'a' chars + emoji + 40 'b' chars + '/' + 100 'z' chars
+		// so the last segment is 101 chars, and the split falls just before the emoji
+		const value = "a".repeat(373) + emoji + "b".repeat(40) + "/" + "z".repeat(100);
+		assert.ok(value.length > MAX_REF, "fixture must exceed the cap");
+		const result = boundedReference(value);
+		assert.ok(result.length <= MAX_REF, `result must fit the cap; got ${result.length}`);
+		// Verify no lone surrogate: every code unit in [0xD800, 0xDBFF] must be followed by
+		// a code unit in [0xDC00, 0xDFFF].
+		for (let i = 0; i < result.length; i++) {
+			const cu = result.charCodeAt(i);
+			if (cu >= 0xd800 && cu <= 0xdbff) {
+				const next = result.charCodeAt(i + 1);
+				assert.ok(
+					next >= 0xdc00 && next <= 0xdfff,
+					`lone high surrogate at index ${i}: 0x${cu.toString(16)} not followed by a low surrogate (got 0x${next.toString(16)})`,
+				);
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up hardening to #474. That PR fixed one bug species in subagent completion notices — a budget allocated against a limit without reserving the fixed scaffolding that must travel with it, followed by end-truncation that destroys exactly the recovery pointers a reader needs. Seven occurrences were found and fixed there. This PR closes three remaining instances of the same species, plus one regression it introduced along the way.

All three original defects were **latent**: unreachable at current production values. They are fixed because each contradicts a contract this codebase now documents, and because the guard that should have caught them could not see them.

**1. `formatProtectedLifecyclePreview` ignored its ceiling and over-nested.**

It returned a fixed-size string regardless of `ceilingForPreview` (measured: 13,418 chars at ceilings of 1,000, 100 and even 0), and called `formatNestedChildren` without a shared budget, so each displayed child drew its own pool of 8 nested entries instead of sharing one. Every other call site passes a shared budget.

Severity stayed low for a specific reason: this path is privacy-safe and carries **no recovery pointers by design** — `buildCompletionDetails` sets `session` to `undefined` when `privacySafe` is true — so caller-side truncation cost status lines only, never a pointer.

**2. `boundedReference` destroyed the identifying part of a path.**

It head-truncated, keeping the prefix every path shares and discarding the filename. Measured on a real profile: **496 of 496 session pointers are named exactly `session.jsonl`**, so preserving only the final segment would have identified nothing. It now truncates in the middle, greedily keeping as many trailing segments as fit, so a deep path retains `…/428b3c62/run-0/session.jsonl` — the run id and index survive.

`boundedLabel` is deliberately unchanged: for a human-readable label the head *is* the meaningful part, so head-truncation is correct there.

**3. `nested-events` `stringValue` silently sliced path fields.**

`value.slice(0, max)` with no marker, applied at 2,048 chars to `sessionFile`, `asyncDir`, `currentPath` and `controlInbox`. A silently sliced path still *looks* valid, so a consumer cannot distinguish it from a real one and fails later with a confusing not-found instead of an immediate, legible error.

Fields are now split by how they are actually consumed, traced to their call sites rather than inferred from names:

| Field | Consumption | Over-limit behaviour |
|---|---|---|
| `sessionFile` | programmatic — opened/resumed via `async-resume.ts` | **omitted** |
| `asyncDir` | programmatic — used to locate a directory | **omitted** |
| `currentPath` | display-only | visible marker |
| `controlInbox` | display-only (the routing value is `route.controlInbox`, a different object) | visible marker |

Absence is detectable and can be handled at the point of use; a truncated path masquerades as valid. This mirrors the suppress-rather-than-mangle rule already adopted in `notify.ts`.

### The regression this PR caught in its own fix

Sharing one nested budget was correct, but the `Nested subagents:` heading was still emitted unconditionally. Once the pool drained, later children rendered a bare heading with nothing beneath it — **six orphaned headings at the default 32,000 ceiling**, fully reachable, unlike everything else here.

The existing ceiling-contract sweep passed cleanly while this was happening, because it asserted output length and marker well-formedness and an orphaned heading is short and well-formed. The sweep now also asserts **structural** well-formedness: no heading without content beneath it. That assertion was confirmed to fail against the pre-fix output before being accepted.

Also fixed: the zero/one-child sentence ignored its ceiling (27 chars returned at ceiling 0); two slice boundaries could split a UTF-16 surrogate pair and emit an ill-formed string; a `nested-events` test was named for `controlInbox` coverage it never provided (`parseRecord` overwrites any child-supplied value, so it is now tested through `sanitizeSummary` with that limitation documented); and two comments carried machine-local or inaccurate rationale.

### Deliberately out of scope

`intercom/result-intercom.ts` loses recovery pointers at **6+ foreground children** (5/6, 5/7, 5/8 artifact and session refs at an 8,000-char envelope). It is the same species and, unlike everything in this PR, it is **reachable in ordinary use**. `AgentToolResult.details` is documented upstream as "for logs or UI rendering", so the dropped paths never reach the model — and the truncation marker tells the model to "inspect retained details", which it cannot do. That deserves its own PR rather than being folded in here.

## Change type

- [x] Extension / skill / prompt / theme
- [ ] Installer / wrapper
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passes end to end, exit 0:

| Step | Result |
|---|---|
| check:package-versions | pass |
| check:package-contents | pass (445 files) |
| typecheck / typecheck:subagents-test-support / typecheck:runtime | pass |
| check:runtime | pass (188 generated files fresh) |
| check-installer-smoke.sh | pass |
| test (installer) | pass |
| test:subagents:unit | **1039/1039** (87 files) |
| test:subagents:integration | **530/530** (25 files) |
| test:subagents:e2e | **1/1** |
| lint (biome) / lint:sh (shellcheck) | pass |
| merge-settings --dry-run / npm pack --dry-run | pass |

Behavioural verification run directly against the exported formatters, not inferred from source:

- Protected-lifecycle path across 6 shapes × 15 ceilings: **0 ceiling breaches, 0 orphaned headings, 0 mangled markers, 0 summary leaks**. The default-ceiling case that produced six orphaned headings now produces none.
- `boundedReference`: exact-cap value returned byte-identical, cap+1 truncated, output never exceeds 500, the retained head is always a true prefix of the input, run id survives in a deep session path, and the separator walk terminates on all-separator, leading-separator and multibyte inputs.
- Surrogate safety: **0 lone surrogates** at both cited call sites, including an 80-offset emoji sweep.
- `nested-events`: at-limit values pass through unchanged and over-limit values are omitted or marked per classification, verified per field.
- No regression to the property #474 exists to protect: non-protected shapes still carry **8/8** artifact and session pointers, and a grouped batch of 40 saturated entries fits at 31,967 chars with 64 inner artifact references intact.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer surface touched)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — no user-visible behaviour change at production values; all three defects are latent
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of long paths and references by preserving useful identifying details and preventing broken characters.
  - Prevented empty nested-section headings from appearing in previews.
  - Ensured protected lifecycle previews stay within message limits by adapting displayed content and metadata.
  - Omitted invalid or oversized path values where necessary.

- **Tests**
  - Added coverage for truncation limits, Unicode safety, preview formatting, and lifecycle display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->