### PR TITLE
Add TypeScript boundary guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ npm-debug.log*
 !.pi/skills/hunk-review/
 .pi/skills/hunk-review/*
 !.pi/skills/hunk-review/SKILL.md
+!.pi/skills/tlh-typescript-boundaries/
+.pi/skills/tlh-typescript-boundaries/*
+!.pi/skills/tlh-typescript-boundaries/SKILL.md
 !.pi/skills/visual-explainer/
 .pi/skills/visual-explainer/*
 !.pi/skills/visual-explainer/SKILL.md

--- a/.pi/skills/tlh-typescript-boundaries/SKILL.md
+++ b/.pi/skills/tlh-typescript-boundaries/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: tlh-typescript-boundaries
+description: Use when changing TypeScript boundary parsing, object-shape decisions, or related test fixtures in The Last Harness.
+---
+
+# TypeScript Boundaries
+
+- Treat data crossing an external I/O boundary as `unknown` immediately, then
+  validate and narrow it before use. Avoid unchecked `JSON.parse` assertions.
+- Use concrete types for TLH-owned formats. In intentionally open settings,
+  tool/schema, or upstream data, validate fields TLH consumes; preserve unknown fields.
+- Do not chase zero `Record<string, unknown>` occurrences. Avoid cosmetic aliases
+  that only rename an existing shape.
+- Type normal test fixtures from production types so drift is caught; malformed
+  fixtures may remain `unknown` when testing rejection paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ git diff --cached
 - After finishing a task, run `gn help review`.
 - Before final handoff or review for TLH repository work, load and apply the repo-local hygiene skill at `.pi/skills/tlh-dev-hygiene/SKILL.md`.
 - The `tlh-dev-hygiene` checklist is for TLH repository contributors only; it is not part of the packaged end-user tlh workflow.
+- For TypeScript boundary parsing or open-object decisions, load `.pi/skills/tlh-typescript-boundaries/SKILL.md`.
 - This project uses a CLI ticket system for task management. Run `tk help` when you need to use it.
 - If the human links you a PR comments, or pastes you one, do not take it at face value — instead, investigate if valid and report back first. Do not start fixing it immediately.
 - If the human asks you to open a PR, after creating it check CI/status checks and investigate PR comments/review comments. Address valid findings; resolve or dismiss invalid or non-actionable comments with rationale.


### PR DESCRIPTION
## Summary

Add a brief contributor-only TypeScript boundary guidance skill. It documents when to validate external data, when open object shapes are appropriate, and why zero `Record<string, unknown>` occurrences is not a goal. `AGENTS.md` now loads the guidance for matching work, while `.gitignore` narrowly allowlists the repo-local skill.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Docs/skill-focused validation:

- Skill frontmatter and required-content assertions passed
- Markdownlint passed with MD013 disabled
- `npm run check:package-contents`
- `npm pack --dry-run --json` confirmed no `.pi` files are published
- `git diff --check`
- Final code review reported no findings

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants; installer/runtime behavior is untouched
- [x] Relevant focused checks pass
- [x] No end-user documentation or changelog update is warranted for contributor-only guidance
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

Not applicable: this is a contributor-only `.pi` skill and is intentionally excluded from the tlh package.
