### PR TITLE
Remove parent intercom compatibility alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to The Last Harness will be documented in this file.
 
 ### Removed
 
+- Removed the native parent-side `intercom` alias from the bundled subagents runtime. `subagent_supervisor` remains the canonical parent tool, while the child-side `intercom` fallback remains available for compatibility.
 - Removed ~4,400 lines of unreachable fork-era code from the subagents runtime: the prompt-template delegation bridge, the worktree isolation feature, and dead chain-era exports/config surface. No user-facing behavior changes.
 
 ## [0.35.0] - 2026-08-09

--- a/extensions/subagents/src/intercom/native-supervisor-channel.js
+++ b/extensions/subagents/src/intercom/native-supervisor-channel.js
@@ -255,7 +255,7 @@ export function registerNativeSupervisorClient(pi, options = {}) {
                     return sendSupervisorRequest({ reason: "progress_update", message: params.message ?? "" }, signal);
                 if (action === "ask")
                     return sendSupervisorRequest({ reason: "need_decision", message: params.message ?? "" }, signal);
-                throw new Error("Native child intercom supports status, list, send, and ask. Use parent intercom reply from the supervisor session.");
+                throw new Error("Native child intercom supports status, list, send, and ask. Use parent subagent_supervisor reply from the supervisor session.");
             },
         });
     }
@@ -563,13 +563,11 @@ function publicPendingRequests(pending) {
         expectsReply: request.expectsReply,
     }));
 }
-function buildParentIntercomTool(pending, state, name = "intercom") {
+function buildParentSupervisorTool(pending, state) {
     return {
-        name,
-        label: name === "intercom" ? "Intercom" : "Subagent Supervisor",
-        description: name === "intercom"
-            ? "Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only."
-            : "Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests without overriding pi-intercom, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only.",
+        name: NATIVE_SUPERVISOR_TOOL_NAME,
+        label: "Subagent Supervisor",
+        description: "Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only.",
         parameters: IntercomParamsSchema,
         async execute(_id, params) {
             refreshPendingRequests(pending, state, state.lastUiContext ?? undefined);
@@ -603,7 +601,7 @@ function buildParentIntercomTool(pending, state, name = "intercom") {
                 };
             }
             if (input.action === "send" || input.action === "ask") {
-                throw new Error("Native pi-subagents intercom currently handles supervisor replies. Child agents initiate asks with contact_supervisor.");
+                throw new Error("Native pi-subagents supervisor channel currently handles supervisor replies. Child agents initiate asks with contact_supervisor.");
             }
             throw new Error(`Unsupported intercom action: ${input.action}`);
         },
@@ -617,9 +615,7 @@ export function createNativeSupervisorChannel(pi, state) {
     const registerTool = pi.registerTool.bind(pi);
     const registerParentTools = () => {
         if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME))
-            registerTool(buildParentIntercomTool(pending, state, NATIVE_SUPERVISOR_TOOL_NAME));
-        if (!hasTool(pi, "intercom"))
-            registerTool(buildParentIntercomTool(pending, state));
+            registerTool(buildParentSupervisorTool(pending, state));
     };
     const cleanupStaleChannelsIfDue = () => {
         const nowMs = Date.now();

--- a/extensions/subagents/src/intercom/native-supervisor-channel.ts
+++ b/extensions/subagents/src/intercom/native-supervisor-channel.ts
@@ -374,7 +374,7 @@ export function registerNativeSupervisorClient(
 						signal,
 					);
 				throw new Error(
-					"Native child intercom supports status, list, send, and ask. Use parent intercom reply from the supervisor session.",
+					"Native child intercom supports status, list, send, and ask. Use parent subagent_supervisor reply from the supervisor session.",
 				);
 			},
 		});
@@ -704,18 +704,12 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentIntercomTool(
-	pending: Map<string, PendingSupervisorRequest>,
-	state: SubagentState,
-	name = "intercom",
-) {
+function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest>, state: SubagentState) {
 	return {
-		name,
-		label: name === "intercom" ? "Intercom" : "Subagent Supervisor",
+		name: NATIVE_SUPERVISOR_TOOL_NAME,
+		label: "Subagent Supervisor",
 		description:
-			name === "intercom"
-				? "Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only."
-				: "Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests without overriding pi-intercom, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only.",
+			"Native pi-subagents supervisor channel. Use pending/status to inspect paused child requests, then resume them with subagent resume or cancel them with interrupt; reply remains legacy live-session compatibility only.",
 		parameters: IntercomParamsSchema,
 		async execute(_id: string, params: unknown) {
 			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined);
@@ -752,7 +746,7 @@ function buildParentIntercomTool(
 			}
 			if (input.action === "send" || input.action === "ask") {
 				throw new Error(
-					"Native pi-subagents intercom currently handles supervisor replies. Child agents initiate asks with contact_supervisor.",
+					"Native pi-subagents supervisor channel currently handles supervisor replies. Child agents initiate asks with contact_supervisor.",
 				);
 			}
 			throw new Error(`Unsupported intercom action: ${input.action}`);
@@ -770,14 +764,12 @@ export function createNativeSupervisorChannel(
 	let lastStaleCleanupAt = 0;
 	const registerTool = (
 		(pi as unknown as Record<string, unknown>).registerTool as (
-			tool: ReturnType<typeof buildParentIntercomTool>,
+			tool: ReturnType<typeof buildParentSupervisorTool>,
 		) => void
 	).bind(pi);
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME))
-			registerTool(buildParentIntercomTool(pending, state, NATIVE_SUPERVISOR_TOOL_NAME));
-		if (!hasTool(pi, "intercom")) registerTool(buildParentIntercomTool(pending, state));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) registerTool(buildParentSupervisorTool(pending, state));
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {

--- a/extensions/subagents/test/unit/native-supervisor-channel.test.ts
+++ b/extensions/subagents/test/unit/native-supervisor-channel.test.ts
@@ -155,7 +155,7 @@ describe("native supervisor channel", () => {
 		channel.start();
 		channel.dispose();
 
-		assert.deepEqual(registeredTools, [NATIVE_SUPERVISOR_TOOL_NAME, "intercom"]);
+		assert.deepEqual(registeredTools, [NATIVE_SUPERVISOR_TOOL_NAME]);
 		assert.deepEqual(
 			sent.map((message) => message.details?.id),
 			[matchingId],
@@ -777,6 +777,34 @@ describe("native supervisor channel", () => {
 				/durably pause the child until the parent resumes or cancels it/i,
 			);
 			assert.match(registeredTools.get("intercom")?.description ?? "", /no child process keeps running while paused/i);
+		} finally {
+			restoreEnv();
+		}
+	});
+
+	it("does not override an installed child intercom when fallback is enabled", () => {
+		const installedIntercom = { name: "intercom", description: "Installed intercom" };
+		const registeredTools = new Map<string, { name: string; description?: string }>([["intercom", installedIntercom]]);
+		const runId = `run-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(runId, "worker", 0);
+		createdChannels.push(channelDir);
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; description?: string }) => {
+				registeredTools.set(tool.name, tool);
+			},
+		};
+		process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV] = "shared-name";
+		process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = "session-parent";
+		process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
+		process.env[SUBAGENT_RUN_ID_ENV] = runId;
+		process.env[SUBAGENT_CHILD_AGENT_ENV] = "worker";
+		process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+
+		try {
+			registerNativeSupervisorClient(pi as never, { includeIntercomFallback: true });
+			assert.equal(registeredTools.get("intercom"), installedIntercom);
+			assert.equal(registeredTools.has("contact_supervisor"), true);
 		} finally {
 			restoreEnv();
 		}


### PR DESCRIPTION
## Summary

Remove the bundled subagents runtime's native parent-side `intercom` compatibility alias so parent sessions expose only the canonical `subagent_supervisor` tool. The child-side non-overriding `intercom` fallback remains available for older child prompts and scripts.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed, including 1013 subagent unit tests, 518 integration tests, and 1 E2E test. Generated runtime outputs are fresh and the final diff passed independent review.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/remove-parent-intercom-alias/install.sh | bash -s -- --ref remove-parent-intercom-alias --track ref
```
