### PR TITLE
Wrap subagent TUI output without truncation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -173,6 +173,7 @@ extensions/subagents/src/shared/jsonl-writer.js linguist-generated=true
 extensions/subagents/src/shared/model-info.js linguist-generated=true
 extensions/subagents/src/shared/post-exit-stdio-guard.js linguist-generated=true
 extensions/subagents/src/shared/profile.js linguist-generated=true
+extensions/subagents/src/shared/recent-progress.js linguist-generated=true
 extensions/subagents/src/shared/session-identity.js linguist-generated=true
 extensions/subagents/src/shared/session-tokens.js linguist-generated=true
 extensions/subagents/src/shared/settings.js linguist-generated=true

--- a/VALIDATING.md
+++ b/VALIDATING.md
@@ -30,7 +30,7 @@ npm run test:subagents:integration
 npm run test:subagents:e2e
 ```
 
-On Node 22.19.0, full imported runs must report every discovered test as passed with zero failures, cancellations, skips, or todo tests. The runner also requires at least 87 unit files, 22 integration files, and 1 E2E file, preventing missing globs or zero-test runs from passing. After removing the agent-memory, mcpDirectTools, and wait-tool tests (61 cases across 2 deleted files plus targeted it() removals), the baseline is 979 unit tests, 529 integration tests, and 1 E2E test; observed actual runs are 980 and 530 respectively (TLH raises unit coverage by 1 solely with the Node 22 referenced-cleanup-timer regression).
+On Node 22.19.0, full imported runs must report every discovered test as passed with zero failures, cancellations, skips, or todo tests. The runner requires at least 84 unit files/1012 tests, 25 integration files/518 tests, and 1 E2E file/test, preventing missing globs or zero-test runs from passing; current observed totals are 85 unit files/1025 tests, 25 integration files/520 tests, and 1 E2E file/test.
 
 CI runs the suites on Linux and macOS with Node 22.19.0. Its unit and integration shards must each execute at least one test and retain the same zero-non-pass requirement; together they cover the full counts.
 

--- a/extensions/subagents/src/extension/index.js
+++ b/extensions/subagents/src/extension/index.js
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { CONFIG_DIR_NAME, defineTool, getAgentDir, keyText, } from "@earendil-works/pi-coding-agent";
-import { Box, Container, Spacer, Text, isKeyRelease, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, } from "@earendil-works/pi-tui";
+import { Box, Container, Spacer, Text, isKeyRelease, matchesKey, visibleWidth, wrapTextWithAnsi, } from "@earendil-works/pi-tui";
 import { discoverAgents } from "../agents/agents.js";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.js";
 import { resolveCurrentSessionId } from "../shared/session-identity.js";
@@ -196,17 +196,19 @@ class SubagentControlNoticeComponent {
     render(width) {
         const eventLabel = this.details.event.type.replaceAll("_", " ");
         if (width < 3)
-            return [truncateToWidth(`Subagent ${eventLabel}`, width)];
+            return wrapTextWithAnsi(`Subagent ${eventLabel}`, Math.max(1, width));
         const bodyWidth = Math.max(1, width - 2);
         const borderChar = "─";
         const header = ` ⚠ Subagent ${eventLabel}: ${this.details.event.agent} `;
-        const headerText = truncateToWidth(header, bodyWidth, "");
-        const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
-        const lines = [this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`)];
+        const headerLines = wrapTextWithAnsi(header, bodyWidth);
+        const padLine = (line) => `${line}${" ".repeat(Math.max(0, bodyWidth - visibleWidth(line)))}`;
+        const firstHeaderLine = headerLines[0] ?? "";
+        const topBorderPadding = borderChar.repeat(Math.max(0, bodyWidth - visibleWidth(firstHeaderLine)));
+        const lines = [this.theme.fg("accent", `╭${firstHeaderLine}${topBorderPadding}╮`)];
+        for (const line of headerLines.slice(1))
+            lines.push(this.theme.fg("accent", `│${padLine(line)}│`));
         for (const line of wrapTextWithAnsi(formatSubagentControlNotice(this.details), bodyWidth)) {
-            const text = truncateToWidth(line, bodyWidth, "");
-            const padding = Math.max(0, bodyWidth - visibleWidth(text));
-            lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+            lines.push(this.theme.fg("accent", `│${padLine(line)}│`));
         }
         lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
         return lines;

--- a/extensions/subagents/src/extension/index.ts
+++ b/extensions/subagents/src/extension/index.ts
@@ -31,7 +31,6 @@ import {
 	Text,
 	isKeyRelease,
 	matchesKey,
-	truncateToWidth,
 	visibleWidth,
 	wrapTextWithAnsi,
 	type Component,
@@ -322,18 +321,19 @@ class SubagentControlNoticeComponent implements Component {
 
 	render(width: number): string[] {
 		const eventLabel = this.details.event.type.replaceAll("_", " ");
-		if (width < 3) return [truncateToWidth(`Subagent ${eventLabel}`, width)];
+		if (width < 3) return wrapTextWithAnsi(`Subagent ${eventLabel}`, Math.max(1, width));
 		const bodyWidth = Math.max(1, width - 2);
 		const borderChar = "─";
 		const header = ` ⚠ Subagent ${eventLabel}: ${this.details.event.agent} `;
-		const headerText = truncateToWidth(header, bodyWidth, "");
-		const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
-		const lines = [this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`)];
+		const headerLines = wrapTextWithAnsi(header, bodyWidth);
+		const padLine = (line: string): string => `${line}${" ".repeat(Math.max(0, bodyWidth - visibleWidth(line)))}`;
+		const firstHeaderLine = headerLines[0] ?? "";
+		const topBorderPadding = borderChar.repeat(Math.max(0, bodyWidth - visibleWidth(firstHeaderLine)));
+		const lines = [this.theme.fg("accent", `╭${firstHeaderLine}${topBorderPadding}╮`)];
+		for (const line of headerLines.slice(1)) lines.push(this.theme.fg("accent", `│${padLine(line)}│`));
 
 		for (const line of wrapTextWithAnsi(formatSubagentControlNotice(this.details), bodyWidth)) {
-			const text = truncateToWidth(line, bodyWidth, "");
-			const padding = Math.max(0, bodyWidth - visibleWidth(text));
-			lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+			lines.push(this.theme.fg("accent", `│${padLine(line)}│`));
 		}
 		lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
 		return lines;

--- a/extensions/subagents/src/runs/background/subagent-runner.js
+++ b/extensions/subagents/src/runs/background/subagent-runner.js
@@ -25,6 +25,7 @@ import { createStructuredOutputRuntime, readStructuredOutput } from "../shared/s
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent, } from "../shared/nested-events.js";
 import { formatModelAttemptNote, isRetryableModelFailure, sanitizeModelFallbackNotice, } from "../shared/model-fallback.js";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.js";
+import { appendRecentProgressItem } from "../../shared/recent-progress.js";
 import { scheduleDeadline } from "../shared/deadline-timer.js";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, formatErrorWithOutput, getFinalOutput, readStatus, synthesizeChildExitDiagnostic, } from "../../shared/utils.js";
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.js";
@@ -2014,7 +2015,11 @@ async function runSubagent(config) {
         else if (event.type === "tool_execution_end") {
             if (step.currentTool) {
                 step.recentTools ??= [];
-                step.recentTools.push({ tool: step.currentTool, args: step.currentToolArgs || "", endMs: now });
+                appendRecentProgressItem(step.recentTools, {
+                    tool: step.currentTool,
+                    args: step.currentToolArgs || "",
+                    endMs: now,
+                });
             }
             step.currentTool = undefined;
             step.currentToolArgs = undefined;

--- a/extensions/subagents/src/runs/background/subagent-runner.ts
+++ b/extensions/subagents/src/runs/background/subagent-runner.ts
@@ -91,6 +91,7 @@ import {
 	sanitizeModelFallbackNotice,
 } from "../shared/model-fallback.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
+import { appendRecentProgressItem } from "../../shared/recent-progress.ts";
 import { scheduleDeadline, type DeadlineTimer } from "../shared/deadline-timer.ts";
 import {
 	detectSubagentError,
@@ -2511,7 +2512,11 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		} else if (event.type === "tool_execution_end") {
 			if (step.currentTool) {
 				step.recentTools ??= [];
-				step.recentTools.push({ tool: step.currentTool, args: step.currentToolArgs || "", endMs: now });
+				appendRecentProgressItem(step.recentTools, {
+					tool: step.currentTool,
+					args: step.currentToolArgs || "",
+					endMs: now,
+				});
 			}
 			step.currentTool = undefined;
 			step.currentToolArgs = undefined;

--- a/extensions/subagents/src/runs/foreground/execution.js
+++ b/extensions/subagents/src/runs/foreground/execution.js
@@ -10,6 +10,7 @@ import { buildSkillInjection, resolveSkillsWithFallback } from "../../agents/ski
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.js";
 import { buildSubagentSpawnEnv, getPiSpawnCommand } from "../shared/pi-spawn.js";
 import { createJsonlWriter } from "../../shared/jsonl-writer.js";
+import { appendRecentProgressItem } from "../../shared/recent-progress.js";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.js";
 import { scheduleDeadline } from "../shared/deadline-timer.js";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, getThinkingLevelDropNote } from "../shared/pi-args.js";
@@ -789,7 +790,7 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
             if (evt.type === "tool_execution_end") {
                 pendingSupervisorPause = undefined;
                 if (progress.currentTool) {
-                    progress.recentTools.push({
+                    appendRecentProgressItem(progress.recentTools, {
                         tool: progress.currentTool,
                         args: progress.currentToolArgs || "",
                         endMs: now,

--- a/extensions/subagents/src/runs/foreground/execution.ts
+++ b/extensions/subagents/src/runs/foreground/execution.ts
@@ -43,6 +43,7 @@ import { buildSkillInjection, resolveSkillsWithFallback } from "../../agents/ski
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
 import { buildSubagentSpawnEnv, getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
+import { appendRecentProgressItem } from "../../shared/recent-progress.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { scheduleDeadline, type DeadlineTimer } from "../shared/deadline-timer.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, getThinkingLevelDropNote } from "../shared/pi-args.ts";
@@ -966,7 +967,7 @@ async function runSingleAttempt(
 			if (evt.type === "tool_execution_end") {
 				pendingSupervisorPause = undefined;
 				if (progress.currentTool) {
-					progress.recentTools.push({
+					appendRecentProgressItem(progress.recentTools, {
 						tool: progress.currentTool,
 						args: progress.currentToolArgs || "",
 						endMs: now,

--- a/extensions/subagents/src/runs/shared/tk-ticket.js
+++ b/extensions/subagents/src/runs/shared/tk-ticket.js
@@ -1,10 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { visibleWidth } from "@earendil-works/pi-tui";
 const TK_SHOW_PATTERN = /\btk\s+show\s+([A-Za-z0-9][A-Za-z0-9-]*)\b/;
 const TK_TICKET_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
-const MAX_TK_TICKET_TITLE_WIDTH = 72;
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 export function detectTkTicketId(task) {
     if (!task)
         return undefined;
@@ -69,13 +66,11 @@ function sanitizeTerminalText(raw) {
     }
     return cleaned;
 }
-export function sanitizeTkTicketTitle(raw, maxWidth = MAX_TK_TICKET_TITLE_WIDTH) {
+export function sanitizeTkTicketTitle(raw) {
     const cleaned = sanitizeTerminalText(raw).replace(/\s+/g, " ").trim();
-    if (!cleaned)
-        return undefined;
-    return truncatePlainTextToWidth(cleaned, maxWidth);
+    return cleaned || undefined;
 }
-export function normalizeTkTicketMetadata(raw, maxWidth = MAX_TK_TICKET_TITLE_WIDTH) {
+export function normalizeTkTicketMetadata(raw) {
     if (!raw || typeof raw !== "object")
         return undefined;
     const { id, title } = raw;
@@ -83,7 +78,7 @@ export function normalizeTkTicketMetadata(raw, maxWidth = MAX_TK_TICKET_TITLE_WI
         return undefined;
     if (typeof title !== "string")
         return undefined;
-    const sanitizedTitle = sanitizeTkTicketTitle(title, maxWidth);
+    const sanitizedTitle = sanitizeTkTicketTitle(title);
     if (!sanitizedTitle)
         return undefined;
     return { id, title: sanitizedTitle };
@@ -142,19 +137,4 @@ function findTicketsDir(cwd) {
             return undefined;
         dir = parent;
     }
-}
-function truncatePlainTextToWidth(text, maxWidth) {
-    if (maxWidth <= 0 || visibleWidth(text) <= maxWidth)
-        return text;
-    const targetWidth = Math.max(1, maxWidth - 1);
-    let width = 0;
-    let result = "";
-    for (const { segment } of segmenter.segment(text)) {
-        const nextWidth = visibleWidth(segment);
-        if (width + nextWidth > targetWidth)
-            return `${result}…`;
-        result += segment;
-        width += nextWidth;
-    }
-    return text;
 }

--- a/extensions/subagents/src/runs/shared/tk-ticket.ts
+++ b/extensions/subagents/src/runs/shared/tk-ticket.ts
@@ -1,13 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { visibleWidth } from "@earendil-works/pi-tui";
-
 import type { TkTicketMetadata } from "../../shared/types.ts";
 
 const TK_SHOW_PATTERN = /\btk\s+show\s+([A-Za-z0-9][A-Za-z0-9-]*)\b/;
 const TK_TICKET_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
-const MAX_TK_TICKET_TITLE_WIDTH = 72;
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 export interface ResolveTkTicketMetadataOptions {
 	cwd?: string;
@@ -104,21 +100,17 @@ function sanitizeTerminalText(raw: string): string {
 	return cleaned;
 }
 
-export function sanitizeTkTicketTitle(raw: string, maxWidth = MAX_TK_TICKET_TITLE_WIDTH): string | undefined {
+export function sanitizeTkTicketTitle(raw: string): string | undefined {
 	const cleaned = sanitizeTerminalText(raw).replace(/\s+/g, " ").trim();
-	if (!cleaned) return undefined;
-	return truncatePlainTextToWidth(cleaned, maxWidth);
+	return cleaned || undefined;
 }
 
-export function normalizeTkTicketMetadata(
-	raw: unknown,
-	maxWidth = MAX_TK_TICKET_TITLE_WIDTH,
-): TkTicketMetadata | undefined {
+export function normalizeTkTicketMetadata(raw: unknown): TkTicketMetadata | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
 	const { id, title } = raw as Partial<TkTicketMetadata>;
 	if (typeof id !== "string" || !TK_TICKET_ID_PATTERN.test(id)) return undefined;
 	if (typeof title !== "string") return undefined;
-	const sanitizedTitle = sanitizeTkTicketTitle(title, maxWidth);
+	const sanitizedTitle = sanitizeTkTicketTitle(title);
 	if (!sanitizedTitle) return undefined;
 	return { id, title: sanitizedTitle };
 }
@@ -175,18 +167,4 @@ function findTicketsDir(cwd?: string): string | undefined {
 		if (parent === dir) return undefined;
 		dir = parent;
 	}
-}
-
-function truncatePlainTextToWidth(text: string, maxWidth: number): string {
-	if (maxWidth <= 0 || visibleWidth(text) <= maxWidth) return text;
-	const targetWidth = Math.max(1, maxWidth - 1);
-	let width = 0;
-	let result = "";
-	for (const { segment } of segmenter.segment(text)) {
-		const nextWidth = visibleWidth(segment);
-		if (width + nextWidth > targetWidth) return `${result}…`;
-		result += segment;
-		width += nextWidth;
-	}
-	return text;
 }

--- a/extensions/subagents/src/shared/child-transcript.js
+++ b/extensions/subagents/src/shared/child-transcript.js
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { extractTextFromContent, extractToolArgsPreview } from "./utils.js";
 export const CHILD_TRANSCRIPT_ARTIFACT_VERSION = 1;
 const DEFAULT_MAX_CHILD_TRANSCRIPT_BYTES = 50 * 1024 * 1024;
+const MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS = 32 * 1024;
+const CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER = " … [truncated for child transcript storage]";
 function errorMessage(error) {
     return error instanceof Error ? error.message : String(error);
 }
@@ -29,6 +31,13 @@ function eventArgs(event) {
     return event.args && typeof event.args === "object" && !Array.isArray(event.args)
         ? event.args
         : {};
+}
+function childTranscriptArgsPreview(args) {
+    const preview = extractToolArgsPreview(args);
+    if (preview.length <= MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS)
+        return preview;
+    const retainedLength = Math.max(0, MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS - CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER.length);
+    return `${preview.slice(0, retainedLength)}${CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER}`;
 }
 export function createChildTranscriptWriter(input) {
     let bytesWritten = 0;
@@ -138,7 +147,7 @@ export function createChildTranscriptWriter(input) {
                     ...baseRecord("tool_start"),
                     sourceEventType: event.type,
                     toolName: event.toolName,
-                    ...(Object.keys(args).length > 0 ? { argsPreview: extractToolArgsPreview(args) } : {}),
+                    ...(Object.keys(args).length > 0 ? { argsPreview: childTranscriptArgsPreview(args) } : {}),
                 });
                 return;
             }

--- a/extensions/subagents/src/shared/child-transcript.ts
+++ b/extensions/subagents/src/shared/child-transcript.ts
@@ -5,6 +5,8 @@ import { extractTextFromContent, extractToolArgsPreview } from "./utils.ts";
 
 export const CHILD_TRANSCRIPT_ARTIFACT_VERSION = 1;
 const DEFAULT_MAX_CHILD_TRANSCRIPT_BYTES = 50 * 1024 * 1024;
+const MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS = 32 * 1024;
+const CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER = " … [truncated for child transcript storage]";
 
 type ChildTranscriptSource = "foreground" | "async";
 type ChildTranscriptRecordType = "message" | "tool_start" | "tool_end" | "stdout" | "stderr" | "truncated";
@@ -74,6 +76,16 @@ function eventArgs(event: ChildTranscriptEvent): Record<string, unknown> {
 	return event.args && typeof event.args === "object" && !Array.isArray(event.args)
 		? (event.args as Record<string, unknown>)
 		: {};
+}
+
+function childTranscriptArgsPreview(args: Record<string, unknown>): string {
+	const preview = extractToolArgsPreview(args);
+	if (preview.length <= MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS) return preview;
+	const retainedLength = Math.max(
+		0,
+		MAX_CHILD_TRANSCRIPT_ARGS_PREVIEW_CHARS - CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER.length,
+	);
+	return `${preview.slice(0, retainedLength)}${CHILD_TRANSCRIPT_ARGS_PREVIEW_MARKER}`;
 }
 
 export function createChildTranscriptWriter(input: ChildTranscriptWriterInput): ChildTranscriptWriter {
@@ -185,7 +197,7 @@ export function createChildTranscriptWriter(input: ChildTranscriptWriterInput): 
 					...baseRecord("tool_start"),
 					sourceEventType: event.type,
 					toolName: event.toolName,
-					...(Object.keys(args).length > 0 ? { argsPreview: extractToolArgsPreview(args) } : {}),
+					...(Object.keys(args).length > 0 ? { argsPreview: childTranscriptArgsPreview(args) } : {}),
 				});
 				return;
 			}

--- a/extensions/subagents/src/shared/formatters.js
+++ b/extensions/subagents/src/shared/formatters.js
@@ -39,12 +39,11 @@ export function formatDuration(ms) {
         return `${(ms / 1000).toFixed(1)}s`;
     return `${Math.floor(ms / 60000)}m${Math.floor((ms % 60000) / 1000)}s`;
 }
-export function formatToolCall(name, args, expanded = false) {
+export function formatToolCall(name, args, _expanded = false) {
     switch (name) {
         case "bash": {
             const command = typeof args.command === "string" ? args.command : "";
-            const maxLength = expanded ? 240 : 60;
-            return `$ ${command.slice(0, maxLength)}${command.length > maxLength ? "..." : ""}`;
+            return `$ ${command}`;
         }
         case "read":
         case "write":
@@ -53,9 +52,8 @@ export function formatToolCall(name, args, expanded = false) {
             return `${name} ${shortenPath(target)}`;
         }
         default: {
-            const s = JSON.stringify(args);
-            const maxLength = expanded ? 160 : 40;
-            return `${name} ${s.slice(0, maxLength)}${s.length > maxLength ? "..." : ""}`;
+            const serialized = JSON.stringify(args);
+            return `${name} ${serialized ?? ""}`;
         }
     }
 }

--- a/extensions/subagents/src/shared/formatters.ts
+++ b/extensions/subagents/src/shared/formatters.ts
@@ -49,14 +49,16 @@ export function formatDuration(ms: number): string {
 }
 
 /**
- * Format a tool call for display
+ * Format a tool call for display.
+ *
+ * Keep argument values complete here. Renderers own width fitting and must
+ * wrap these strings instead of losing command, path, or payload text.
  */
-export function formatToolCall(name: string, args: Record<string, unknown>, expanded = false): string {
+export function formatToolCall(name: string, args: Record<string, unknown>, _expanded = false): string {
 	switch (name) {
 		case "bash": {
 			const command = typeof args.command === "string" ? args.command : "";
-			const maxLength = expanded ? 240 : 60;
-			return `$ ${command.slice(0, maxLength)}${command.length > maxLength ? "..." : ""}`;
+			return `$ ${command}`;
 		}
 		case "read":
 		case "write":
@@ -66,9 +68,8 @@ export function formatToolCall(name: string, args: Record<string, unknown>, expa
 			return `${name} ${shortenPath(target)}`;
 		}
 		default: {
-			const s = JSON.stringify(args);
-			const maxLength = expanded ? 160 : 40;
-			return `${name} ${s.slice(0, maxLength)}${s.length > maxLength ? "..." : ""}`;
+			const serialized = JSON.stringify(args);
+			return `${name} ${serialized ?? ""}`;
 		}
 	}
 }

--- a/extensions/subagents/src/shared/recent-progress.js
+++ b/extensions/subagents/src/shared/recent-progress.js
@@ -1,0 +1,7 @@
+export const RECENT_PROGRESS_ITEM_LIMIT = 50;
+export function appendRecentProgressItem(items, item) {
+    items.push(item);
+    if (items.length > RECENT_PROGRESS_ITEM_LIMIT) {
+        items.splice(0, items.length - RECENT_PROGRESS_ITEM_LIMIT);
+    }
+}

--- a/extensions/subagents/src/shared/recent-progress.ts
+++ b/extensions/subagents/src/shared/recent-progress.ts
@@ -1,0 +1,12 @@
+/**
+ * Retain the same bounded window for completed tool records as live output.
+ * Arguments stay exact; only entries older than the newest 50 are discarded.
+ */
+export const RECENT_PROGRESS_ITEM_LIMIT = 50;
+
+export function appendRecentProgressItem<T>(items: T[], item: T): void {
+	items.push(item);
+	if (items.length > RECENT_PROGRESS_ITEM_LIMIT) {
+		items.splice(0, items.length - RECENT_PROGRESS_ITEM_LIMIT);
+	}
+}

--- a/extensions/subagents/src/shared/types.ts
+++ b/extensions/subagents/src/shared/types.ts
@@ -405,7 +405,7 @@ export interface AgentProgress {
 
 export interface ToolCallSummary {
 	text: string;
-	expandedText: string;
+	expandedText?: string;
 }
 
 interface ProgressSummary {

--- a/extensions/subagents/src/shared/utils.js
+++ b/extensions/subagents/src/shared/utils.js
@@ -218,6 +218,14 @@ function compactCompletedProgress(progress) {
         recentOutput: [],
     };
 }
+function toolCallSummary(text, expandedText) {
+    return expandedText === text ? { text } : { text, expandedText };
+}
+function normalizeToolCallSummaries(toolCalls) {
+    return toolCalls.map((toolCall) => toolCall.expandedText !== undefined && toolCall.expandedText === toolCall.text
+        ? { text: toolCall.text }
+        : { ...toolCall });
+}
 function extractToolCallSummaries(messages) {
     if (!messages?.length)
         return [];
@@ -231,10 +239,9 @@ function extractToolCallSummaries(messages) {
             const args = typeof part.arguments === "object" && part.arguments !== null && !Array.isArray(part.arguments)
                 ? part.arguments
                 : {};
-            summaries.push({
-                text: formatToolCall(part.name, args),
-                expandedText: formatToolCall(part.name, args, true),
-            });
+            const text = formatToolCall(part.name, args);
+            const expandedText = formatToolCall(part.name, args, true);
+            summaries.push(toolCallSummary(text, expandedText));
         }
     }
     return summaries;
@@ -277,7 +284,9 @@ export function sumResultsCost(results) {
 export function compactForegroundResult(result) {
     if (result.progress?.status === "running")
         return result;
-    const toolCalls = result.toolCalls?.length ? result.toolCalls : extractToolCallSummaries(result.messages);
+    const toolCalls = result.toolCalls?.length
+        ? normalizeToolCallSummaries(result.toolCalls)
+        : extractToolCallSummaries(result.messages);
     return {
         ...result,
         messages: undefined,
@@ -355,7 +364,6 @@ export function detectSubagentError(messages) {
     return { hasError: false };
 }
 export function extractToolArgsPreview(args) {
-    const truncatePreview = (value, maxLength) => value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
     const stringifyPreviewValue = (value) => {
         if (typeof value === "string" && value.trim().length > 0)
             return value;
@@ -374,38 +382,34 @@ export function extractToolArgsPreview(args) {
     };
     if (args.tool && typeof args.tool === "string") {
         const server = args.server && typeof args.server === "string" ? `${args.server}/` : "";
-        const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args.slice(0, 40)}` : "";
+        const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args}` : "";
         return `${server}${args.tool}${toolArgs}`;
     }
     const queriesPreview = previewArray(args.queries);
     if (queriesPreview)
-        return truncatePreview(queriesPreview, 60);
+        return queriesPreview;
     if (typeof args.query === "string" && args.query.trim().length > 0)
-        return truncatePreview(args.query, 60);
+        return args.query;
     if (typeof args.workflow === "string" && args.workflow.trim().length > 0)
-        return `workflow=${truncatePreview(args.workflow, 48)}`;
+        return `workflow=${args.workflow}`;
     if (typeof args.url === "string" && args.url.trim().length > 0)
-        return truncatePreview(args.url, 60);
+        return args.url;
     const urlsPreview = previewArray(args.urls);
     if (urlsPreview)
-        return truncatePreview(urlsPreview, 60);
+        return urlsPreview;
     if (typeof args.prompt === "string" && args.prompt.trim().length > 0)
-        return truncatePreview(args.prompt, 60);
+        return args.prompt;
     const previewKeys = ["command", "path", "file_path", "pattern", "query", "url", "task", "describe", "search"];
     for (const key of previewKeys) {
-        if (args[key] && typeof args[key] === "string") {
-            const value = args[key];
-            return truncatePreview(value, 60);
-        }
+        if (args[key] && typeof args[key] === "string")
+            return args[key];
     }
     for (const [key, value] of Object.entries(args)) {
         const arrayPreview = previewArray(value);
         if (arrayPreview)
-            return `${key}=${truncatePreview(arrayPreview, 50)}`;
-        if (typeof value === "string" && value.length > 0) {
-            const preview = truncatePreview(value, 50);
-            return `${key}=${preview}`;
-        }
+            return `${key}=${arrayPreview}`;
+        if (typeof value === "string" && value.length > 0)
+            return `${key}=${value}`;
     }
     return "";
 }

--- a/extensions/subagents/src/shared/utils.ts
+++ b/extensions/subagents/src/shared/utils.ts
@@ -283,6 +283,18 @@ function compactCompletedProgress(progress: AgentProgress): AgentProgress {
 	};
 }
 
+function toolCallSummary(text: string, expandedText: string): ToolCallSummary {
+	return expandedText === text ? { text } : { text, expandedText };
+}
+
+function normalizeToolCallSummaries(toolCalls: ToolCallSummary[]): ToolCallSummary[] {
+	return toolCalls.map((toolCall) =>
+		toolCall.expandedText !== undefined && toolCall.expandedText === toolCall.text
+			? { text: toolCall.text }
+			: { ...toolCall },
+	);
+}
+
 function extractToolCallSummaries(messages: Message[] | undefined): ToolCallSummary[] {
 	if (!messages?.length) return [];
 	const summaries: ToolCallSummary[] = [];
@@ -294,10 +306,9 @@ function extractToolCallSummaries(messages: Message[] | undefined): ToolCallSumm
 				typeof part.arguments === "object" && part.arguments !== null && !Array.isArray(part.arguments)
 					? part.arguments
 					: {};
-			summaries.push({
-				text: formatToolCall(part.name, args),
-				expandedText: formatToolCall(part.name, args, true),
-			});
+			const text = formatToolCall(part.name, args);
+			const expandedText = formatToolCall(part.name, args, true);
+			summaries.push(toolCallSummary(text, expandedText));
 		}
 	}
 	return summaries;
@@ -343,7 +354,9 @@ export function sumResultsCost(results: SingleResult[]): NonNullable<Details["to
 
 export function compactForegroundResult(result: SingleResult): SingleResult {
 	if (result.progress?.status === "running") return result;
-	const toolCalls = result.toolCalls?.length ? result.toolCalls : extractToolCallSummaries(result.messages);
+	const toolCalls = result.toolCalls?.length
+		? normalizeToolCallSummaries(result.toolCalls)
+		: extractToolCallSummaries(result.messages);
 	return {
 		...result,
 		messages: undefined,
@@ -438,12 +451,13 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 }
 
 /**
- * Extract a preview of tool arguments for display
+ * Extract a semantic summary of tool arguments for display.
+ *
+ * Selected string values stay complete here so expanded renderers can show the
+ * original argument. Callers that need to fit a terminal width should wrap the
+ * rendered value while preserving the source value in progress state.
  */
 export function extractToolArgsPreview(args: Record<string, unknown>): string {
-	const truncatePreview = (value: string, maxLength: number): string =>
-		value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
-
 	const stringifyPreviewValue = (value: unknown): string | undefined => {
 		if (typeof value === "string" && value.trim().length > 0) return value;
 		if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -461,37 +475,30 @@ export function extractToolArgsPreview(args: Record<string, unknown>): string {
 	// Handle MCP tool calls - show server/tool info
 	if (args.tool && typeof args.tool === "string") {
 		const server = args.server && typeof args.server === "string" ? `${args.server}/` : "";
-		const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args.slice(0, 40)}` : "";
+		const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args}` : "";
 		return `${server}${args.tool}${toolArgs}`;
 	}
 
 	const queriesPreview = previewArray(args.queries);
-	if (queriesPreview) return truncatePreview(queriesPreview, 60);
-	if (typeof args.query === "string" && args.query.trim().length > 0) return truncatePreview(args.query, 60);
-	if (typeof args.workflow === "string" && args.workflow.trim().length > 0)
-		return `workflow=${truncatePreview(args.workflow, 48)}`;
+	if (queriesPreview) return queriesPreview;
+	if (typeof args.query === "string" && args.query.trim().length > 0) return args.query;
+	if (typeof args.workflow === "string" && args.workflow.trim().length > 0) return `workflow=${args.workflow}`;
 
-	if (typeof args.url === "string" && args.url.trim().length > 0) return truncatePreview(args.url, 60);
+	if (typeof args.url === "string" && args.url.trim().length > 0) return args.url;
 	const urlsPreview = previewArray(args.urls);
-	if (urlsPreview) return truncatePreview(urlsPreview, 60);
-	if (typeof args.prompt === "string" && args.prompt.trim().length > 0) return truncatePreview(args.prompt, 60);
+	if (urlsPreview) return urlsPreview;
+	if (typeof args.prompt === "string" && args.prompt.trim().length > 0) return args.prompt;
 
 	const previewKeys = ["command", "path", "file_path", "pattern", "query", "url", "task", "describe", "search"];
 	for (const key of previewKeys) {
-		if (args[key] && typeof args[key] === "string") {
-			const value = args[key] as string;
-			return truncatePreview(value, 60);
-		}
+		if (args[key] && typeof args[key] === "string") return args[key] as string;
 	}
 
 	// Fallback: show first string value found
 	for (const [key, value] of Object.entries(args)) {
 		const arrayPreview = previewArray(value);
-		if (arrayPreview) return `${key}=${truncatePreview(arrayPreview, 50)}`;
-		if (typeof value === "string" && value.length > 0) {
-			const preview = truncatePreview(value, 50);
-			return `${key}=${preview}`;
-		}
+		if (arrayPreview) return `${key}=${arrayPreview}`;
+		if (typeof value === "string" && value.length > 0) return `${key}=${value}`;
 	}
 	return "";
 }

--- a/extensions/subagents/src/tui/render-helpers.js
+++ b/extensions/subagents/src/tui/render-helpers.js
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 function fuzzyScore(query, text) {
     const lq = query.toLowerCase();
     const lt = text.toLowerCase();
@@ -37,19 +37,37 @@ export function pad(s, len) {
     return s + " ".repeat(Math.max(0, len - vis));
 }
 export function row(content, width, theme) {
+    if (width <= 0)
+        return "";
+    const normalized = content.replace(/\t/g, "  ");
+    if (width < 3)
+        return wrapTextWithAnsi(normalized, width).join("\n");
     const innerW = width - 2;
-    const singleLine = content.replace(/[\r\n]+/g, " ").replace(/\t/g, "  ");
-    const clipped = truncateToWidth(singleLine, innerW);
-    return theme.fg("border", "│") + pad(clipped, innerW) + theme.fg("border", "│");
+    return wrapTextWithAnsi(normalized, innerW)
+        .map((line) => theme.fg("border", "│") + pad(line, innerW) + theme.fg("border", "│"))
+        .join("\n");
 }
 export function renderHeader(text, width, theme) {
+    if (width <= 0)
+        return "";
+    if (width < 3)
+        return wrapTextWithAnsi(text, width).join("\n");
     const innerW = width - 2;
-    const padLen = Math.max(0, innerW - visibleWidth(text));
-    const padLeft = Math.floor(padLen / 2);
-    const padRight = padLen - padLeft;
-    return (theme.fg("border", "╭" + "─".repeat(padLeft)) +
-        theme.fg("accent", text) +
-        theme.fg("border", "─".repeat(padRight) + "╮"));
+    return wrapTextWithAnsi(text, innerW)
+        .map((line, index) => {
+        const padLen = Math.max(0, innerW - visibleWidth(line));
+        const padLeft = Math.floor(padLen / 2);
+        const padRight = padLen - padLeft;
+        if (index === 0) {
+            return (theme.fg("border", "╭" + "─".repeat(padLeft)) +
+                theme.fg("accent", line) +
+                theme.fg("border", "─".repeat(padRight) + "╮"));
+        }
+        return (theme.fg("border", "│" + " ".repeat(padLeft)) +
+            theme.fg("accent", line) +
+            theme.fg("border", " ".repeat(padRight) + "│"));
+    })
+        .join("\n");
 }
 export function formatPath(filePath) {
     const home = process.env.HOME;
@@ -66,11 +84,25 @@ export function formatScrollInfo(above, below) {
     return info;
 }
 export function renderFooter(text, width, theme) {
+    if (width <= 0)
+        return "";
+    if (width < 3)
+        return wrapTextWithAnsi(text, width).join("\n");
     const innerW = width - 2;
-    const padLen = Math.max(0, innerW - visibleWidth(text));
-    const padLeft = Math.floor(padLen / 2);
-    const padRight = padLen - padLeft;
-    return (theme.fg("border", "╰" + "─".repeat(padLeft)) +
-        theme.fg("dim", text) +
-        theme.fg("border", "─".repeat(padRight) + "╯"));
+    const lines = wrapTextWithAnsi(text, innerW);
+    return lines
+        .map((line, index) => {
+        const padLen = Math.max(0, innerW - visibleWidth(line));
+        const padLeft = Math.floor(padLen / 2);
+        const padRight = padLen - padLeft;
+        if (index === lines.length - 1) {
+            return (theme.fg("border", "╰" + "─".repeat(padLeft)) +
+                theme.fg("dim", line) +
+                theme.fg("border", "─".repeat(padRight) + "╯"));
+        }
+        return (theme.fg("border", "│" + " ".repeat(padLeft)) +
+            theme.fg("dim", line) +
+            theme.fg("border", " ".repeat(padRight) + "│"));
+    })
+        .join("\n");
 }

--- a/extensions/subagents/src/tui/render-helpers.ts
+++ b/extensions/subagents/src/tui/render-helpers.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 
 function fuzzyScore(query: string, text: string): number {
 	const lq = query.toLowerCase();
@@ -46,22 +46,38 @@ export function pad(s: string, len: number): string {
 }
 
 export function row(content: string, width: number, theme: Theme): string {
+	if (width <= 0) return "";
+	const normalized = content.replace(/\t/g, "  ");
+	if (width < 3) return wrapTextWithAnsi(normalized, width).join("\n");
 	const innerW = width - 2;
-	const singleLine = content.replace(/[\r\n]+/g, " ").replace(/\t/g, "  ");
-	const clipped = truncateToWidth(singleLine, innerW);
-	return theme.fg("border", "│") + pad(clipped, innerW) + theme.fg("border", "│");
+	return wrapTextWithAnsi(normalized, innerW)
+		.map((line) => theme.fg("border", "│") + pad(line, innerW) + theme.fg("border", "│"))
+		.join("\n");
 }
 
 export function renderHeader(text: string, width: number, theme: Theme): string {
+	if (width <= 0) return "";
+	if (width < 3) return wrapTextWithAnsi(text, width).join("\n");
 	const innerW = width - 2;
-	const padLen = Math.max(0, innerW - visibleWidth(text));
-	const padLeft = Math.floor(padLen / 2);
-	const padRight = padLen - padLeft;
-	return (
-		theme.fg("border", "╭" + "─".repeat(padLeft)) +
-		theme.fg("accent", text) +
-		theme.fg("border", "─".repeat(padRight) + "╮")
-	);
+	return wrapTextWithAnsi(text, innerW)
+		.map((line, index) => {
+			const padLen = Math.max(0, innerW - visibleWidth(line));
+			const padLeft = Math.floor(padLen / 2);
+			const padRight = padLen - padLeft;
+			if (index === 0) {
+				return (
+					theme.fg("border", "╭" + "─".repeat(padLeft)) +
+					theme.fg("accent", line) +
+					theme.fg("border", "─".repeat(padRight) + "╮")
+				);
+			}
+			return (
+				theme.fg("border", "│" + " ".repeat(padLeft)) +
+				theme.fg("accent", line) +
+				theme.fg("border", " ".repeat(padRight) + "│")
+			);
+		})
+		.join("\n");
 }
 
 export function formatPath(filePath: string): string {
@@ -78,13 +94,27 @@ export function formatScrollInfo(above: number, below: number): string {
 }
 
 export function renderFooter(text: string, width: number, theme: Theme): string {
+	if (width <= 0) return "";
+	if (width < 3) return wrapTextWithAnsi(text, width).join("\n");
 	const innerW = width - 2;
-	const padLen = Math.max(0, innerW - visibleWidth(text));
-	const padLeft = Math.floor(padLen / 2);
-	const padRight = padLen - padLeft;
-	return (
-		theme.fg("border", "╰" + "─".repeat(padLeft)) +
-		theme.fg("dim", text) +
-		theme.fg("border", "─".repeat(padRight) + "╯")
-	);
+	const lines = wrapTextWithAnsi(text, innerW);
+	return lines
+		.map((line, index) => {
+			const padLen = Math.max(0, innerW - visibleWidth(line));
+			const padLeft = Math.floor(padLen / 2);
+			const padRight = padLen - padLeft;
+			if (index === lines.length - 1) {
+				return (
+					theme.fg("border", "╰" + "─".repeat(padLeft)) +
+					theme.fg("dim", line) +
+					theme.fg("border", "─".repeat(padRight) + "╯")
+				);
+			}
+			return (
+				theme.fg("border", "│" + " ".repeat(padLeft)) +
+				theme.fg("dim", line) +
+				theme.fg("border", " ".repeat(padRight) + "│")
+			);
+		})
+		.join("\n");
 }

--- a/extensions/subagents/src/tui/render.js
+++ b/extensions/subagents/src/tui/render.js
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { getMarkdownTheme } from "@earendil-works/pi-coding-agent";
-import { Container, Markdown, Spacer, Text, visibleWidth } from "@earendil-works/pi-tui";
+import { Container, Markdown, Spacer, Text, visibleWidth, wrapTextWithAnsi, } from "@earendil-works/pi-tui";
 import { liveDetailShortcutDisplay } from "../shared/subagent-shortcuts.js";
 import { MAX_WIDGET_JOBS, WIDGET_KEY, } from "../shared/types.js";
 import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, shortenPath, } from "../shared/formatters.js";
@@ -21,124 +21,68 @@ function liveDetailHintText() {
 function getTermWidth() {
     return process.stdout.columns || 120;
 }
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-const ANSI_SGR_PATTERN = new RegExp(`^${String.fromCharCode(0x1b)}\\[[0-9;]*m`);
-const ANSI_ESCAPE = String.fromCharCode(0x1b);
-function truncLine(text, maxWidth) {
-    if (visibleWidth(text) <= maxWidth)
-        return text;
-    const targetWidth = maxWidth - 1;
-    let result = "";
-    let currentWidth = 0;
-    let activeStyles = [];
-    let i = 0;
-    while (i < text.length) {
-        const ansiMatch = text.slice(i).match(ANSI_SGR_PATTERN);
-        if (ansiMatch) {
-            const code = ansiMatch[0];
-            result += code;
-            if (code === `${ANSI_ESCAPE}[0m` || code === `${ANSI_ESCAPE}[m`) {
-                activeStyles = [];
-            }
-            else {
-                activeStyles.push(code);
-            }
-            i += code.length;
-            continue;
-        }
-        let end = i;
-        while (end < text.length && !text.slice(end).match(ANSI_SGR_PATTERN)) {
-            end++;
-        }
-        const textPortion = text.slice(i, end);
-        for (const seg of segmenter.segment(textPortion)) {
-            const grapheme = seg.segment;
-            const graphemeWidth = visibleWidth(grapheme);
-            if (currentWidth + graphemeWidth > targetWidth) {
-                return result + activeStyles.join("") + "…";
-            }
-            result += grapheme;
-            currentWidth += graphemeWidth;
-        }
-        i = end;
+function wrapDisplayLine(text, maxWidth) {
+    return wrapTextWithAnsi(text, Math.max(1, maxWidth));
+}
+function wrapDisplayLines(lines, maxWidth) {
+    return lines.flatMap((line) => wrapDisplayLine(line, maxWidth));
+}
+function addWrappedText(container, text, maxWidth) {
+    for (const line of wrapDisplayLine(text, maxWidth))
+        container.addChild(new Text(line, 0, 0));
+}
+function collapsedForegroundLineBudget() {
+    const rows = process.stdout.rows || 30;
+    return Math.max(5, Math.min(14, Math.floor(rows * 0.4)));
+}
+function collapsedForegroundSummaryLines(hiddenCount, theme, width, maxLines) {
+    const key = liveDetailKeyText();
+    const variants = [
+        `… ${hiddenCount} lines hidden · ${key} expands`,
+        `… ${hiddenCount} hidden · ${key} expands`,
+        `${hiddenCount} ${key}`,
+        `${key} expands`,
+        key,
+    ];
+    const firstLines = wrapDisplayLine(theme.fg("dim", variants[0]), width);
+    for (const variant of variants) {
+        const summaryLines = wrapDisplayLine(theme.fg("dim", variant), width);
+        if (summaryLines.length <= maxLines)
+            return summaryLines;
     }
-    return result + activeStyles.join("") + "…";
+    return firstLines;
+}
+function fitCollapsedForegroundLines(lines, theme, width) {
+    const budget = collapsedForegroundLineBudget();
+    if (lines.length <= budget)
+        return lines;
+    for (let visibleCount = Math.min(lines.length, budget - 1); visibleCount >= 0; visibleCount--) {
+        const hiddenCount = lines.length - visibleCount;
+        const summaryLines = wrapDisplayLine(theme.fg("dim", `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`), width);
+        if (visibleCount + summaryLines.length <= budget) {
+            return [...lines.slice(0, visibleCount), ...summaryLines];
+        }
+    }
+    return collapsedForegroundSummaryLines(lines.length, theme, width, budget);
+}
+function collapsedForegroundComponent(logicalLines, theme) {
+    return {
+        render(width) {
+            const contentWidth = Math.max(1, width);
+            const physicalLines = wrapDisplayLines(logicalLines, contentWidth);
+            return fitCollapsedForegroundLines(physicalLines, theme, contentWidth);
+        },
+        invalidate() { },
+    };
 }
 function fitInlineThinkingActivity(prefix, phrase, freshness, theme, maxWidth) {
     const separator = ` ${theme.fg("dim", "·")} `;
-    const dimPhrase = theme.fg("dim", phrase);
-    const dimFreshness = theme.fg("dim", freshness);
-    const freshnessSuffix = `${separator}${dimFreshness}`;
-    const fullLine = `${prefix}${separator}${dimPhrase}${freshnessSuffix}`;
-    if (visibleWidth(fullLine) <= maxWidth)
-        return fullLine;
-    const prefixAndFreshness = `${prefix}${freshnessSuffix}`;
-    if (visibleWidth(prefixAndFreshness) > maxWidth) {
-        if (visibleWidth(freshnessSuffix) >= maxWidth)
-            return truncLine(dimFreshness, maxWidth);
-        return `${truncLine(prefix, maxWidth - visibleWidth(freshnessSuffix))}${freshnessSuffix}`;
-    }
-    const phraseWidth = maxWidth - visibleWidth(prefix) - visibleWidth(separator) - visibleWidth(freshnessSuffix);
-    return phraseWidth > 1
-        ? `${prefix}${separator}${truncLine(dimPhrase, phraseWidth)}${freshnessSuffix}`
-        : prefixAndFreshness;
+    const fullLine = `${prefix}${separator}${theme.fg("dim", phrase)}${separator}${theme.fg("dim", freshness)}`;
+    return wrapDisplayLine(fullLine, maxWidth);
 }
 function fitInlineActivity(prefix, activity, theme, maxWidth) {
     const separator = ` ${theme.fg("dim", "·")} `;
-    const dimActivity = theme.fg("dim", activity);
-    const activitySuffix = `${separator}${dimActivity}`;
-    const fullLine = `${prefix}${activitySuffix}`;
-    if (visibleWidth(fullLine) <= maxWidth)
-        return fullLine;
-    const separatorWidth = visibleWidth(separator);
-    const prefixVisibleWidth = visibleWidth(prefix);
-    const activityVisibleWidth = visibleWidth(dimActivity);
-    const sharedWidth = maxWidth - separatorWidth;
-    if (sharedWidth >= 2 && prefixVisibleWidth > 0 && activityVisibleWidth > 0) {
-        let prefixWidth = Math.min(prefixVisibleWidth, Math.ceil(sharedWidth / 2));
-        let activityWidth = Math.min(activityVisibleWidth, sharedWidth - prefixWidth);
-        let spareWidth = sharedWidth - prefixWidth - activityWidth;
-        if (spareWidth > 0 && prefixWidth < prefixVisibleWidth) {
-            const prefixGrowth = Math.min(spareWidth, prefixVisibleWidth - prefixWidth);
-            prefixWidth += prefixGrowth;
-            spareWidth -= prefixGrowth;
-        }
-        activityWidth += spareWidth;
-        return `${truncLine(prefix, prefixWidth)}${separator}${truncLine(dimActivity, activityWidth)}`;
-    }
-    if (maxWidth >= 2 && prefixVisibleWidth > 0 && activityVisibleWidth > 0) {
-        const prefixWidth = Math.min(prefixVisibleWidth, Math.max(1, Math.ceil(maxWidth / 2)));
-        const activityWidth = maxWidth - prefixWidth;
-        return `${truncLine(prefix, prefixWidth)}${truncLine(dimActivity, activityWidth)}`;
-    }
-    return truncLine(prefixVisibleWidth > 0 ? prefix : dimActivity, Math.max(1, maxWidth));
-}
-function wrapPlainText(text, maxWidth) {
-    if (maxWidth <= 0)
-        return [""];
-    const lines = [];
-    for (const rawLine of text.split("\n")) {
-        if (rawLine.length === 0) {
-            lines.push("");
-            continue;
-        }
-        let current = "";
-        let currentWidth = 0;
-        for (const seg of segmenter.segment(rawLine)) {
-            const grapheme = seg.segment;
-            const graphemeWidth = visibleWidth(grapheme);
-            if (currentWidth > 0 && currentWidth + graphemeWidth > maxWidth) {
-                lines.push(current);
-                current = grapheme;
-                currentWidth = graphemeWidth;
-                continue;
-            }
-            current += grapheme;
-            currentWidth += graphemeWidth;
-        }
-        lines.push(current);
-    }
-    return lines;
+    return wrapDisplayLine(`${prefix}${separator}${theme.fg("dim", activity)}`, maxWidth);
 }
 const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const STATIC_RUNNING_GLYPH = "●";
@@ -191,22 +135,17 @@ function getToolCallLines(result, expanded) {
             .filter((item) => item.type === "tool")
             .map((item) => formatToolCall(item.name, item.args, expanded));
     }
-    return result.toolCalls?.map((toolCall) => (expanded ? toolCall.expandedText : toolCall.text)) ?? [];
+    return (result.toolCalls?.map((toolCall) => (expanded ? (toolCall.expandedText ?? toolCall.text) : toolCall.text)) ?? []);
 }
 function snapshotNowForProgress(progress) {
     if (progress.currentToolStartedAt !== undefined && progress.durationMs !== undefined)
         return progress.currentToolStartedAt + progress.durationMs;
     return progress.lastActivityAt;
 }
-function formatCurrentToolLine(progress, availableWidth, expanded, snapshotNow) {
+function formatCurrentToolLine(progress, _availableWidth, _expanded, snapshotNow) {
     if (!progress.currentTool)
         return undefined;
-    const maxToolArgsLen = Math.max(50, availableWidth - 20);
-    const toolArgsPreview = progress.currentToolArgs
-        ? expanded || progress.currentToolArgs.length <= maxToolArgsLen
-            ? progress.currentToolArgs
-            : `${progress.currentToolArgs.slice(0, maxToolArgsLen)}...`
-        : "";
+    const toolArgsPreview = progress.currentToolArgs ?? "";
     const durationSuffix = progress.currentToolStartedAt !== undefined && snapshotNow !== undefined
         ? ` | ${formatDuration(Math.max(0, snapshotNow - progress.currentToolStartedAt))}`
         : "";
@@ -518,11 +457,10 @@ function widgetStepStatus(status, theme, interruptRequestedAt) {
     return theme.fg("dim", status);
 }
 const TK_TICKET_WIDGET_PREFIX = "working on tk: ";
-function widgetTkTicketText(job, maxWidth = 72) {
+function widgetTkTicketText(job) {
     if (!job.tkTicket || (job.status !== "running" && job.status !== "queued"))
         return undefined;
-    const titleWidth = Math.max(1, maxWidth - visibleWidth(TK_TICKET_WIDGET_PREFIX));
-    const normalizedTkTicket = normalizeTkTicketMetadata(job.tkTicket, titleWidth);
+    const normalizedTkTicket = normalizeTkTicketMetadata(job.tkTicket);
     return normalizedTkTicket ? `${TK_TICKET_WIDGET_PREFIX}${normalizedTkTicket.title}` : undefined;
 }
 function widgetTkTicketLine(job, theme) {
@@ -533,15 +471,14 @@ function widgetTkTicketLines(job, theme) {
     const line = widgetTkTicketLine(job, theme);
     return line ? [line] : [];
 }
-function foregroundTkTicketText(result, maxWidth = 72) {
-    const titleWidth = Math.max(1, maxWidth - visibleWidth("  ") - visibleWidth(TK_TICKET_WIDGET_PREFIX));
-    const normalizedTkTicket = normalizeTkTicketMetadata(result.tkTicket, titleWidth);
+function foregroundTkTicketText(result) {
+    const normalizedTkTicket = normalizeTkTicketMetadata(result.tkTicket);
     return normalizedTkTicket ? `${TK_TICKET_WIDGET_PREFIX}${normalizedTkTicket.title}` : undefined;
 }
-function foregroundTkTicketLine(result, theme, active, maxWidth) {
+function foregroundTkTicketLine(result, theme, active) {
     if (!active)
         return undefined;
-    const ticket = foregroundTkTicketText(result, maxWidth);
+    const ticket = foregroundTkTicketText(result);
     return ticket ? `  ${theme.fg("dim", ticket)}` : undefined;
 }
 function widgetStepActivity(step, snapshotNow, expanded = false) {
@@ -628,10 +565,10 @@ function widgetParallelAgentDetails(job, theme, expanded = false, width = getTer
             : undefined;
         const prefix = `  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme, step.interruptRequestedAt)}${modelDisplay}`)}`;
         if (!expanded && healthWarning) {
-            lines.push(fitInlineActivity(prefix, healthWarning, theme, Math.max(1, width - 6)));
+            lines.push(...fitInlineActivity(prefix, healthWarning, theme, Math.max(1, width - 6)));
         }
         else if (freshness) {
-            lines.push(fitInlineThinkingActivity(prefix, compactThinkingPhrase(step.activityState, step.turnCount), freshness, theme, Math.max(1, width - 6)));
+            lines.push(...fitInlineThinkingActivity(prefix, compactThinkingPhrase(step.activityState, step.turnCount), freshness, theme, Math.max(1, width - 6)));
         }
         else {
             lines.push(`${prefix}${activity ? ` · ${theme.fg("dim", activity)}` : ""}`);
@@ -1091,7 +1028,7 @@ function formatNestedWidgetLines(children, theme, width, expanded, snapshotNow, 
         }
     };
     append(children, 0, "");
-    return lines.map((line) => truncLine(line, width));
+    return wrapDisplayLines(lines, width);
 }
 function singleWidgetStepDisplayStatus(job, step) {
     if (step.status !== "running")
@@ -1130,9 +1067,7 @@ function foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index, tota
             if (output)
                 lines.push(`    ${theme.fg("dim", `output: ${shortenPath(output)}`)}`);
             for (const tool of step.recentTools?.slice(-3) ?? []) {
-                const maxArgsLen = Math.max(40, width - 30);
-                const argsPreview = tool.args.length <= maxArgsLen ? tool.args : `${tool.args.slice(0, maxArgsLen)}...`;
-                lines.push(`      ${theme.fg("dim", `${tool.tool}${argsPreview ? `: ${argsPreview}` : ""}`)}`);
+                lines.push(`      ${theme.fg("dim", `${tool.tool}${tool.args ? `: ${tool.args}` : ""}`)}`);
             }
             for (const line of step.recentOutput?.slice(-5) ?? []) {
                 lines.push(`      ${theme.fg("dim", line)}`);
@@ -1193,12 +1128,9 @@ function parallelWidgetAggregateStats(job, theme, expanded = false) {
         return stats;
     return job.status === "complete" ? "done" : job.status;
 }
-function buildSingleWidgetLines(job, theme, contentWidth, expanded) {
+function singleWidgetHeaderLines(job, theme, expanded) {
     if (job.mode === "single") {
-        return [
-            `${theme.fg("toolTitle", themeBold(theme, "async subagent"))} ${theme.fg("dim", "· background")}`,
-            ...singleWidgetAgentDetails(job, theme, expanded, contentWidth),
-        ].map((line) => truncLine(line, contentWidth));
+        return [`${theme.fg("toolTitle", themeBold(theme, "async subagent"))} ${theme.fg("dim", "· background")}`];
     }
     if (job.mode === "parallel") {
         const count = job.stepsTotal ?? job.agents?.length ?? job.steps?.length ?? 0;
@@ -1206,8 +1138,7 @@ function buildSingleWidgetLines(job, theme, contentWidth, expanded) {
         return [
             `${theme.fg("toolTitle", themeBold(theme, `async subagents (${count})`))} ${theme.fg("dim", "· background")}`,
             `${widgetStatusGlyph(job, theme)}${stats ? ` ${stats}` : ""}`,
-            ...foregroundStyleWidgetDetails(job, theme, expanded, contentWidth),
-        ].map((line) => truncLine(line, contentWidth));
+        ];
     }
     const stats = widgetSummaryStats(job, theme, expanded);
     const count = job.mode === "chain" ? job.chainStepCount : (job.stepsTotal ?? job.agents?.length ?? job.steps?.length);
@@ -1216,18 +1147,26 @@ function buildSingleWidgetLines(job, theme, contentWidth, expanded) {
     return [
         `${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
         `${widgetStatusGlyph(job, theme)} ${themeBold(theme, mode)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-        ...foregroundStyleWidgetDetails(job, theme, expanded, contentWidth),
-    ].map((line) => truncLine(line, contentWidth));
+    ];
+}
+function buildSingleWidgetLines(job, theme, contentWidth, expanded) {
+    const details = job.mode === "single"
+        ? singleWidgetAgentDetails(job, theme, expanded, contentWidth)
+        : foregroundStyleWidgetDetails(job, theme, expanded, contentWidth);
+    return wrapDisplayLines([...singleWidgetHeaderLines(job, theme, expanded), ...details], contentWidth);
 }
 function compactSingleWidgetLines(job, theme, width) {
     const contentWidth = Math.max(1, width - 2);
     const fullLines = buildSingleWidgetLines(job, theme, contentWidth, false);
     if (fullLines.length <= 10 || !job.steps?.length || (job.mode !== "parallel" && !job.activeParallelGroup)) {
-        return fullLines.map((line) => truncLine(line, contentWidth));
+        return fullLines;
     }
     const total = job.stepsTotal ?? job.steps.length;
     const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
-    const lines = [...fullLines.slice(0, 2), ...widgetTkTicketLines(job, theme)];
+    const lines = [
+        ...wrapDisplayLines(singleWidgetHeaderLines(job, theme, false), contentWidth),
+        ...widgetTkTicketLines(job, theme),
+    ];
     for (const [index, step] of job.steps.entries()) {
         const status = widgetStepStatus(step.status, theme, step.interruptRequestedAt);
         const activityLines = widgetStepActivityLines(step, contentWidth, false, job.updatedAt);
@@ -1242,17 +1181,21 @@ function compactSingleWidgetLines(job, theme, width) {
             isHealthActivityState(step.activityState)
             ? activityLines.find((activityLine) => activityLine === buildLiveStatusLine(step, job.updatedAt))
             : undefined;
-        lines.push(healthWarning
-            ? fitInlineActivity(rowPrefix, healthWarning, theme, contentWidth)
-            : step.status === "running" && !step.currentTool && activityLines.length === 2
-                ? fitInlineThinkingActivity(rowPrefix, activityLines[0], activityLines[1], theme, contentWidth)
-                : `${rowPrefix}${activitySuffix}`);
+        if (healthWarning) {
+            lines.push(...fitInlineActivity(rowPrefix, healthWarning, theme, contentWidth));
+        }
+        else if (step.status === "running" && !step.currentTool && activityLines.length === 2) {
+            lines.push(...fitInlineThinkingActivity(rowPrefix, activityLines[0], activityLines[1], theme, contentWidth));
+        }
+        else {
+            lines.push(`${rowPrefix}${activitySuffix}`);
+        }
         for (const nestedLine of formatNestedWidgetLines(step.children, theme, contentWidth, false, job.updatedAt, 1, isProtectedWidgetLifecycle(step.status, step.interruptRequestedAt)))
             lines.push(`    ${nestedLine}`);
     }
     if (job.steps.some((step) => step.status === "running"))
         lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
-    return lines.map((line) => truncLine(line, contentWidth));
+    return wrapDisplayLines(lines, contentWidth);
 }
 const RESERVED_NON_WIDGET_ROWS = 19;
 let widgetLayoutSession;
@@ -1283,11 +1226,32 @@ function widgetHeaderCounts(jobs) {
         paused: jobs.filter((job) => job.status === "paused"),
     };
 }
+function chooseWidgetSummaryVariant(variants, width) {
+    const contentWidth = Math.max(1, width);
+    return variants.find((variant) => visibleWidth(variant) <= contentWidth) ?? variants[variants.length - 1];
+}
+function compactWidgetCountSummary(counts, jobs) {
+    if (counts.running.length > 0 && counts.queued.length > 0)
+        return `${counts.running.length}r ${counts.queued.length}q`;
+    if (counts.running.length > 0)
+        return `${counts.running.length} running`;
+    if (counts.queued.length > 0)
+        return `${counts.queued.length} queued`;
+    if (counts.failed.length > 0)
+        return `${counts.failed.length} failed`;
+    if (counts.paused.length > 0)
+        return `${counts.paused.length} paused`;
+    if (counts.complete.length > 0)
+        return `${counts.complete.length} done`;
+    return `${jobs.length} total`;
+}
 function buildSingleLineWidgetLines(jobs, theme, width) {
     const contentWidth = Math.max(1, width - 2);
     const counts = widgetHeaderCounts(jobs);
     const hasActive = counts.running.length > 0 || counts.queued.length > 0;
     const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+    const coloredGlyph = theme.fg(hasActive ? "accent" : "dim", glyph);
+    const coloredTitle = theme.fg(hasActive ? "accent" : "dim", "subagents");
     const parts = [];
     if (counts.running.length > 0)
         parts.push(`${counts.running.length}/${jobs.length} running`);
@@ -1299,9 +1263,11 @@ function buildSingleLineWidgetLines(jobs, theme, width) {
         parts.push(`${counts.paused.length} paused`);
     if (!hasActive && counts.complete.length > 0)
         parts.push(`${counts.complete.length}/${jobs.length} done`);
-    return [
-        truncLine(`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "subagents")} (${parts.join(", ") || `${jobs.length} total`})`, contentWidth),
-    ];
+    const detailed = `${coloredGlyph} ${coloredTitle} (${parts.join(", ") || `${jobs.length} total`})`;
+    const withoutParenthetical = `${coloredGlyph} ${theme.fg(hasActive ? "accent" : "dim", parts.join(", ") || `${jobs.length} total`)}`;
+    const compact = `${coloredGlyph} ${theme.fg(hasActive ? "accent" : "dim", compactWidgetCountSummary(counts, jobs))}`;
+    const titleOnly = `${coloredGlyph} ${coloredTitle}`;
+    return [chooseWidgetSummaryVariant([detailed, withoutParenthetical, compact, titleOnly, coloredGlyph], contentWidth)];
 }
 function orderedWidgetJobs(jobs) {
     return [
@@ -1362,6 +1328,8 @@ function progressiveHeaderLine(jobs, theme, width) {
     const counts = widgetHeaderCounts(jobs);
     const hasActive = counts.running.length > 0 || counts.queued.length > 0;
     const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+    const coloredGlyph = theme.fg(hasActive ? "accent" : "dim", glyph);
+    const coloredTitle = theme.fg(hasActive ? "accent" : "dim", "Async agents");
     const parts = [];
     if (counts.running.length > 0)
         parts.push(formatAgentRunningLabel(counts.running.length));
@@ -1375,15 +1343,22 @@ function progressiveHeaderLine(jobs, theme, width) {
         if (counts.complete.length > 0)
             parts.push(`${counts.complete.length}/${jobs.length} done`);
     }
+    const coloredParts = theme.fg("dim", parts.join(", ") || `${jobs.length} total`);
+    const compact = theme.fg(hasActive ? "accent" : "dim", compactWidgetCountSummary(counts, jobs));
     const contentWidth = Math.max(1, width - 2);
-    return truncLine(`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(", ") || `${jobs.length} total`)}`, contentWidth);
+    const detailed = `${coloredGlyph} ${coloredTitle} ${theme.fg("dim", "·")} ${coloredParts}`;
+    const withoutTitle = `${coloredGlyph} ${coloredParts}`;
+    const titleOnly = `${coloredGlyph} ${coloredTitle}`;
+    return [
+        chooseWidgetSummaryVariant([detailed, withoutTitle, `${coloredGlyph} ${compact}`, titleOnly, coloredGlyph], contentWidth),
+    ];
 }
 function progressiveJobLine(job, theme, width) {
     const contentWidth = Math.max(1, width - 2);
     const stats = widgetSummaryStats(job, theme);
     const activity = widgetActivity(job);
     const status = job.status === "complete" ? "done" : job.status;
-    const ticket = widgetTkTicketText(job, Math.max(24, width - 32));
+    const ticket = widgetTkTicketText(job);
     const prefixParts = [
         themeBold(theme, widgetJobName(job)),
         theme.fg("dim", status),
@@ -1406,7 +1381,7 @@ function progressiveJobLine(job, theme, width) {
     if (healthWarning)
         return fitInlineActivity(prefix, healthWarning, theme, contentWidth);
     const activitySuffix = activity && activity.toLowerCase() !== status ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
-    return truncLine(`${prefix}${activitySuffix}`, contentWidth);
+    return wrapDisplayLine(`${prefix}${activitySuffix}`, contentWidth);
 }
 function progressiveHiddenLine(hiddenJobs, theme, width) {
     const contentWidth = Math.max(1, width - 2);
@@ -1419,32 +1394,46 @@ function progressiveHiddenLine(hiddenJobs, theme, width) {
     const finished = counts.complete.length + counts.failed.length + counts.paused.length;
     if (finished > 0)
         parts.push(`${finished} finished`);
-    return truncLine(theme.fg("dim", `  +${hiddenJobs.length} more${parts.length ? ` (${parts.join(", ")})` : ""}`), contentWidth);
+    const full = theme.fg("dim", `  +${hiddenJobs.length} more${parts.length ? ` (${parts.join(", ")})` : ""}`);
+    const countSummary = theme.fg("dim", `  +${hiddenJobs.length} more`);
+    const countOnly = theme.fg("dim", `+${hiddenJobs.length}`);
+    const fallback = theme.fg("dim", "+");
+    return [chooseWidgetSummaryVariant([full, countSummary, countOnly, fallback], contentWidth)];
 }
 function buildProgressiveWidgetLines(jobs, theme, width, lockedRows, previousKeys) {
     const rowCount = Math.max(1, lockedRows);
     if (rowCount === 1)
         return { lines: buildSingleLineWidgetLines(jobs, theme, width), visibleJobKeys: [] };
-    const bodyRows = rowCount - 1;
-    let visibleJobKeys = selectProgressiveJobKeys(jobs, previousKeys, bodyRows);
+    const headerLines = progressiveHeaderLine(jobs, theme, width);
     const jobsByKey = new Map(jobs.map((job) => [progressiveJobKey(job), job]));
-    let visibleJobs = visibleJobKeys.map((key) => jobsByKey.get(key)).filter((job) => Boolean(job));
-    let hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
-    const needsHiddenLine = hiddenJobs.length > 0;
-    if (needsHiddenLine && visibleJobs.length >= bodyRows && bodyRows > 0) {
-        visibleJobs = visibleJobs.slice(0, bodyRows - 1);
-        visibleJobKeys = visibleJobs.map(progressiveJobKey);
-        hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+    const candidateKeys = selectProgressiveJobKeys(jobs, previousKeys, jobs.length);
+    const visibleJobKeys = [];
+    const bodyLines = [];
+    for (const key of candidateKeys) {
+        const job = jobsByKey.get(key);
+        if (!job)
+            continue;
+        const jobLines = progressiveJobLine(job, theme, width);
+        const prospectiveKeys = [...visibleJobKeys, key];
+        const prospectiveHiddenJobs = jobs.filter((candidate) => !prospectiveKeys.includes(progressiveJobKey(candidate)));
+        const prospectiveHiddenLines = prospectiveHiddenJobs.length > 0 ? progressiveHiddenLine(prospectiveHiddenJobs, theme, width) : [];
+        if (headerLines.length + bodyLines.length + jobLines.length + prospectiveHiddenLines.length > rowCount)
+            continue;
+        visibleJobKeys.push(key);
+        bodyLines.push(...jobLines);
     }
-    const lines = [
-        progressiveHeaderLine(jobs, theme, width),
-        ...visibleJobs.map((job) => progressiveJobLine(job, theme, width)),
-    ];
-    if (hiddenJobs.length > 0 && lines.length < rowCount)
-        lines.push(progressiveHiddenLine(hiddenJobs, theme, width));
+    const hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+    const hiddenLines = hiddenJobs.length > 0 ? progressiveHiddenLine(hiddenJobs, theme, width) : [];
+    const lines = [...headerLines, ...bodyLines, ...hiddenLines];
+    if (lines.length > rowCount) {
+        const boundedLines = [headerLines[0], ...(hiddenLines.length > 0 ? [hiddenLines[0]] : [])];
+        while (boundedLines.length < rowCount)
+            boundedLines.push("\u200c");
+        return { lines: boundedLines.slice(0, rowCount), visibleJobKeys: [] };
+    }
     while (lines.length < rowCount)
         lines.push("\u200c");
-    return { lines: lines.slice(0, rowCount), visibleJobKeys };
+    return { lines, visibleJobKeys };
 }
 function collapsedWidgetLineBudget(rows) {
     return Math.max(10, Math.min(14, Math.floor(rows * 0.35)));
@@ -1455,12 +1444,18 @@ function fitWidgetLineBudget(lines, theme, width, expanded) {
     const budget = expanded ? Math.max(12, Math.min(24, Math.floor(rows * 0.55))) : collapsedWidgetLineBudget(rows);
     if (lines.length <= budget)
         return lines;
-    const visibleLines = Math.max(1, budget - 1);
-    const hiddenCount = lines.length - visibleLines;
-    const hint = expanded
-        ? `… ${hiddenCount} live-detail lines hidden`
-        : `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`;
-    return [...lines.slice(0, visibleLines), truncLine(theme.fg("dim", hint), contentWidth)];
+    let visibleCount = Math.max(0, budget - 1);
+    while (true) {
+        const hiddenCount = lines.length - visibleCount;
+        const hint = expanded
+            ? `… ${hiddenCount} live-detail lines hidden`
+            : `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`;
+        const hintLines = wrapDisplayLine(theme.fg("dim", hint), contentWidth);
+        const nextVisibleCount = Math.max(0, budget - hintLines.length);
+        if (nextVisibleCount === visibleCount)
+            return [...lines.slice(0, visibleCount), ...hintLines];
+        visibleCount = nextVisibleCount;
+    }
 }
 function fitAdaptiveWidgetLines(jobs, lines, theme, width, expanded) {
     if (expanded) {
@@ -1531,7 +1526,7 @@ export function buildWidgetLines(jobs, theme, width = getTermWidth(), expanded =
     const lines = [];
     const hasActive = running.length > 0 || queued.length > 0;
     const headerGlyph = running.length > 0 ? runningGlyph(widgetJobsRunningSeed(running)) : hasActive ? "●" : "○";
-    lines.push(truncLine(`${theme.fg(hasActive ? "accent" : "dim", headerGlyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "· background")}`, contentWidth));
+    lines.push(...wrapDisplayLine(`${theme.fg(hasActive ? "accent" : "dim", headerGlyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "· background")}`, contentWidth));
     const items = [];
     let hiddenRunning = 0;
     let hiddenFinished = 0;
@@ -1587,9 +1582,9 @@ export function buildWidgetLines(jobs, theme, width = getTermWidth(), expanded =
         const last = i === items.length - 1;
         const branch = last ? "└─" : "├─";
         const continuation = last ? "   " : "│  ";
-        lines.push(truncLine(`${theme.fg("dim", branch)} ${item[0]}`, contentWidth));
+        lines.push(...wrapDisplayLine(`${theme.fg("dim", branch)} ${item[0]}`, contentWidth));
         for (const detail of item.slice(1)) {
-            lines.push(truncLine(`${theme.fg("dim", continuation)} ${detail}`, contentWidth));
+            lines.push(...wrapDisplayLine(`${theme.fg("dim", continuation)} ${detail}`, contentWidth));
         }
     }
     return lines;
@@ -1609,28 +1604,28 @@ function renderSingleCompact(d, r, theme, frame) {
     const output = r.truncation?.text || getSingleResultOutput(r);
     const isRunning = r.progress?.status === "running";
     const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
-    const c = new Container();
+    const lines = [];
     const width = getTermWidth() - 4;
     const modelDisplay = modelThinkingBadge(theme, r.model);
-    c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}`, width), 0, 0));
-    const ticketLine = foregroundTkTicketLine(r, theme, isRunning, width);
+    lines.push(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}`);
+    const ticketLine = foregroundTkTicketLine(r, theme, isRunning);
     if (ticketLine)
-        c.addChild(new Text(truncLine(ticketLine, width), 0, 0));
+        lines.push(ticketLine);
     if (isRunning && r.progress) {
         for (const [activityIndex, activity] of compactProgressActivityLines(r.progress, width).entries()) {
-            c.addChild(new Text(truncLine(theme.fg("dim", activityIndex === 0 ? `  ⎿  ${activity}` : `     ${activity}`), width), 0, 0));
+            lines.push(theme.fg("dim", activityIndex === 0 ? `  ⎿  ${activity}` : `     ${activity}`));
         }
-        c.addChild(new Text(truncLine(theme.fg("accent", `  ${liveDetailHintText()}`), width), 0, 0));
-        return c;
+        lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
+        return collapsedForegroundComponent(lines, theme);
     }
     const preview = compactOutputPreview(output);
-    c.addChild(new Text(truncLine(theme.fg("dim", `  ⎿  ${resultStatusLine(r, preview)}`), width), 0, 0));
+    lines.push(theme.fg("dim", `  ⎿  ${resultStatusLine(r, preview)}`));
     if (preview && r.exitCode === 0 && !hasEmptyTextOutputWithoutOutputTarget(r.task, output)) {
-        c.addChild(new Text(truncLine(theme.fg("dim", `     ${preview}`), width), 0, 0));
+        lines.push(theme.fg("dim", `     ${preview}`));
     }
     if (r.sessionFile)
-        c.addChild(new Text(truncLine(theme.fg("dim", `  session: ${shortenPath(r.sessionFile)}`), width), 0, 0));
-    return c;
+        lines.push(theme.fg("dim", `  session: ${shortenPath(r.sessionFile)}`));
+    return collapsedForegroundComponent(lines, theme);
 }
 function renderMultiCompact(d, theme, frame) {
     const hasRunning = d.progress?.some((p) => p.status === "running") ||
@@ -1670,9 +1665,9 @@ function renderMultiCompact(d, theme, frame) {
                 ? theme.fg("warning", "■")
                 : theme.fg("success", "✓");
     const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
-    const c = new Container();
+    const lines = [];
     const width = getTermWidth() - 4;
-    c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
+    lines.push(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`);
     const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
     const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : d.results.length;
     const chainEntries = buildChainRenderEntries(d, multiLabel);
@@ -1693,9 +1688,9 @@ function renderMultiCompact(d, theme, frame) {
         if (entry.kind === "placeholder") {
             const glyph = widgetStepGlyph(entry.status, theme);
             const statusLabel = widgetStepStatus(entry.status, theme);
-            c.addChild(new Text(truncLine(`  ${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`, width), 0, 0));
+            lines.push(`  ${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`);
             if (entry.error)
-                c.addChild(new Text(truncLine(theme.fg("error", `    ⎿  Error: ${entry.error}`), width), 0, 0));
+                lines.push(theme.fg("error", `    ⎿  Error: ${entry.error}`));
             continue;
         }
         const i = entry.resultIndex;
@@ -1704,7 +1699,7 @@ function renderMultiCompact(d, theme, frame) {
         const agentName = entry.agentName;
         if (!r) {
             const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
-            c.addChild(new Text(truncLine(theme.fg("dim", `  ◦ ${pendingLabel}: ${agentName} · pending`), width), 0, 0));
+            lines.push(theme.fg("dim", `  ◦ ${pendingLabel}: ${agentName} · pending`));
             continue;
         }
         const output = getSingleResultOutput(r);
@@ -1720,24 +1715,24 @@ function renderMultiCompact(d, theme, frame) {
         const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
         const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
         const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${pendingLabel}`;
-        c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
-        const ticketLine = foregroundTkTicketLine(r, theme, rRunning, width);
+        lines.push(`  ${line}`);
+        const ticketLine = foregroundTkTicketLine(r, theme, rRunning);
         if (ticketLine)
-            c.addChild(new Text(truncLine(ticketLine, width), 0, 0));
+            lines.push(ticketLine);
         if (rRunning && liveProgress) {
             for (const [activityIndex, activity] of compactProgressActivityLines(liveProgress, width).entries()) {
-                c.addChild(new Text(truncLine(theme.fg("dim", activityIndex === 0 ? `    ⎿  ${activity}` : `       ${activity}`), width), 0, 0));
+                lines.push(theme.fg("dim", activityIndex === 0 ? `    ⎿  ${activity}` : `       ${activity}`));
             }
-            c.addChild(new Text(truncLine(theme.fg("accent", `    ${liveDetailHintText()}`), width), 0, 0));
+            lines.push(theme.fg("accent", `    ${liveDetailHintText()}`));
         }
         else if (!rPending &&
             (r.exitCode !== 0 || r.interrupted || r.detached || hasEmptyTextOutputWithoutOutputTarget(r.task, output))) {
-            c.addChild(new Text(truncLine(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, output)}`), width), 0, 0));
+            lines.push(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, output)}`));
         }
     }
     if (d.artifacts)
-        c.addChild(new Text(truncLine(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`), width), 0, 0));
-    return c;
+        lines.push(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`));
+    return collapsedForegroundComponent(lines, theme);
 }
 export function renderSubagentResult(result, options, theme, frame) {
     const d = result.details;
@@ -1749,19 +1744,21 @@ export function renderSubagentResult(result, options, theme, frame) {
         const text = t?.type === "text" ? t.text : "(no output)";
         const contextPrefix = d?.context === "fork" ? `${theme.fg("warning", "[fork]")} ` : "";
         const width = getTermWidth() - 4;
-        if (!text.includes("\n"))
-            return new Text(truncLine(`${contextPrefix}${text}`, width), 0, 0);
+        if (!text.includes("\n")) {
+            const c = new Container();
+            addWrappedText(c, `${contextPrefix}${text}`, width);
+            return c;
+        }
         if (d && !options.expanded && !result.isError) {
             const lines = text.split(/\r?\n/);
             const firstNonEmptyLine = lines.find((line) => line.trim())?.trim() || "(no output)";
             const c = new Container();
-            c.addChild(new Text(truncLine(`${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width), 0, 0));
-            c.addChild(new Text(truncLine(theme.fg("accent", `  Press ${liveDetailKeyText()} for full output`), width), 0, 0));
+            addWrappedText(c, `${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width);
+            addWrappedText(c, theme.fg("accent", `  Press ${liveDetailKeyText()} for full output`), width);
             return c;
         }
         const c = new Container();
-        const wrapped = wrapPlainText(`${contextPrefix}${text}`, width);
-        for (const line of wrapped)
+        for (const line of wrapDisplayLine(`${contextPrefix}${text}`, width))
             c.addChild(new Text(line, 0, 0));
         return c;
     }
@@ -1789,45 +1786,40 @@ export function renderSubagentResult(result, options, theme, frame) {
                 ? ` | ${r.progressSummary.toolCount} tools, ${formatTokens(r.progressSummary.tokens)} tok, ${formatDuration(r.progressSummary.durationMs)}`
                 : "";
         const w = getTermWidth() - 4;
-        const fit = (text) => (expanded ? text : truncLine(text, w));
         const toolCallLines = getToolCallLines(r, expanded);
         const c = new Container();
-        c.addChild(new Text(fit(`${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo}`), 0, 0));
-        const ticketLine = foregroundTkTicketLine(r, theme, isRunning, w);
+        c.addChild(new Text(`${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo}`, 0, 0));
+        const ticketLine = foregroundTkTicketLine(r, theme, isRunning);
         if (ticketLine)
-            c.addChild(new Text(fit(ticketLine), 0, 0));
+            c.addChild(new Text(ticketLine, 0, 0));
         c.addChild(new Spacer(1));
-        const taskMaxLen = Math.max(20, w - 8);
-        const taskPreview = expanded || r.task.length <= taskMaxLen ? r.task : `${r.task.slice(0, taskMaxLen)}...`;
-        c.addChild(new Text(fit(theme.fg("dim", `Task: ${taskPreview}`)), 0, 0));
+        c.addChild(new Text(theme.fg("dim", `Task: ${r.task}`), 0, 0));
         c.addChild(new Spacer(1));
         const outputTarget = extractOutputTarget(r.task);
         if (outputTarget) {
-            c.addChild(new Text(fit(theme.fg("dim", `Output: ${outputTarget}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `Output: ${outputTarget}`), 0, 0));
         }
         if (isRunning && r.progress) {
             const progressSnapshotNow = snapshotNowForProgress(r.progress);
             const toolLine = formatCurrentToolLine(r.progress, w, expanded, progressSnapshotNow);
             if (toolLine) {
-                c.addChild(new Text(fit(theme.fg("warning", `> ${toolLine}`)), 0, 0));
+                c.addChild(new Text(theme.fg("warning", `> ${toolLine}`), 0, 0));
             }
             const liveStatusLine = buildLiveStatusLine(r.progress, progressSnapshotNow);
             if (liveStatusLine) {
-                c.addChild(new Text(fit(theme.fg("accent", liveStatusLine)), 0, 0));
+                c.addChild(new Text(theme.fg("accent", liveStatusLine), 0, 0));
             }
-            c.addChild(new Text(fit(theme.fg("accent", liveDetailHintText())), 0, 0));
+            c.addChild(new Text(theme.fg("accent", liveDetailHintText()), 0, 0));
             if (r.artifactPaths) {
-                c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
             }
             if (r.progress.recentTools?.length) {
                 for (const t of r.progress.recentTools.slice(-3)) {
-                    const maxArgsLen = Math.max(40, w - 24);
-                    const argsPreview = expanded || t.args.length <= maxArgsLen ? t.args : `${t.args.slice(0, maxArgsLen)}...`;
-                    c.addChild(new Text(fit(theme.fg("dim", `${t.tool}: ${argsPreview}`)), 0, 0));
+                    c.addChild(new Text(theme.fg("dim", `${t.tool}: ${t.args}`), 0, 0));
                 }
             }
             for (const line of (r.progress.recentOutput ?? []).slice(-5)) {
-                c.addChild(new Text(fit(theme.fg("dim", `  ${line}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `  ${line}`), 0, 0));
             }
             if (toolLine ||
                 liveStatusLine ||
@@ -1839,7 +1831,7 @@ export function renderSubagentResult(result, options, theme, frame) {
         }
         if (expanded) {
             for (const line of toolCallLines) {
-                c.addChild(new Text(fit(theme.fg("muted", line)), 0, 0));
+                c.addChild(new Text(theme.fg("muted", line), 0, 0));
             }
             if (toolCallLines.length)
                 c.addChild(new Spacer(1));
@@ -1848,25 +1840,25 @@ export function renderSubagentResult(result, options, theme, frame) {
             c.addChild(new Markdown(output, 0, 0, mdTheme));
         c.addChild(new Spacer(1));
         if (r.skills?.length) {
-            c.addChild(new Text(fit(theme.fg("dim", `Skills: ${r.skills.join(", ")}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `Skills: ${r.skills.join(", ")}`), 0, 0));
         }
         if (r.skillsWarning) {
-            c.addChild(new Text(fit(theme.fg("warning", `Warning: ${r.skillsWarning}`)), 0, 0));
+            c.addChild(new Text(theme.fg("warning", `Warning: ${r.skillsWarning}`), 0, 0));
         }
         if (r.attemptedModels && r.attemptedModels.length > 1) {
-            c.addChild(new Text(fit(theme.fg("dim", `Fallbacks: ${r.attemptedModels.join(" → ")}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `Fallbacks: ${r.attemptedModels.join(" → ")}`), 0, 0));
         }
-        c.addChild(new Text(fit(theme.fg("dim", formatUsage(r.usage, r.model))), 0, 0));
+        c.addChild(new Text(theme.fg("dim", formatUsage(r.usage, r.model)), 0, 0));
         if (r.sessionFile) {
-            c.addChild(new Text(fit(theme.fg("dim", `Session: ${shortenPath(r.sessionFile)}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `Session: ${shortenPath(r.sessionFile)}`), 0, 0));
         }
         if ((!isRunning && r.artifactPaths) || r.truncation?.artifactPath) {
             c.addChild(new Spacer(1));
             if (!isRunning && r.artifactPaths) {
-                c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
             }
             if (r.truncation?.artifactPath) {
-                c.addChild(new Text(fit(theme.fg("dim", `Full output: ${shortenPath(r.truncation.artifactPath)}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `Full output: ${shortenPath(r.truncation.artifactPath)}`), 0, 0));
             }
         }
         return c;
@@ -1918,9 +1910,8 @@ export function renderSubagentResult(result, options, theme, frame) {
     const multiLabel = buildMultiProgressLabel(d, hasRunning);
     const itemTitle = multiLabel.itemTitle;
     const w = getTermWidth() - 4;
-    const fit = (text) => (expanded ? text : truncLine(text, w));
     const c = new Container();
-    c.addChild(new Text(fit(`${icon} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr}`), 0, 0));
+    c.addChild(new Text(`${icon} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr}`, 0, 0));
     const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
     const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : d.results.length;
     const chainEntries = buildChainRenderEntries(d, multiLabel);
@@ -1940,7 +1931,7 @@ export function renderSubagentResult(result, options, theme, frame) {
     for (const entry of renderEntries) {
         if (entry.kind === "placeholder") {
             const statusLabel = widgetStepStatus(entry.status, theme);
-            c.addChild(new Text(fit(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`), 0, 0));
+            c.addChild(new Text(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`, 0, 0));
             c.addChild(new Text(theme.fg(entry.status === "failed" ? "error" : "dim", `    status: ${entry.status}`), 0, 0));
             if (entry.error)
                 c.addChild(new Text(theme.fg("error", `    error: ${entry.error}`), 0, 0));
@@ -1953,7 +1944,7 @@ export function renderSubagentResult(result, options, theme, frame) {
         const agentName = entry.agentName;
         if (!r) {
             const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
-            c.addChild(new Text(fit(theme.fg("dim", `  ${pendingLabel}: ${agentName}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `  ${pendingLabel}: ${agentName}`), 0, 0));
             c.addChild(new Text(theme.fg("dim", `    status: pending`), 0, 0));
             c.addChild(new Spacer(1));
             continue;
@@ -1980,64 +1971,60 @@ export function renderSubagentResult(result, options, theme, frame) {
             ? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${modelDisplay}${stats}`
             : `${statusIcon} ${stepLabel}: ${theme.bold(r.agent)}${modelDisplay}${stats}`;
         const toolCallLines = getToolCallLines(r, expanded);
-        c.addChild(new Text(fit(stepHeader), 0, 0));
-        const ticketLine = foregroundTkTicketLine(r, theme, rRunning, w);
+        c.addChild(new Text(stepHeader, 0, 0));
+        const ticketLine = foregroundTkTicketLine(r, theme, rRunning);
         if (ticketLine)
-            c.addChild(new Text(fit(ticketLine), 0, 0));
-        const taskMaxLen = Math.max(20, w - 12);
-        const taskPreview = expanded || r.task.length <= taskMaxLen ? r.task : `${r.task.slice(0, taskMaxLen)}...`;
-        c.addChild(new Text(fit(theme.fg("dim", `    task: ${taskPreview}`)), 0, 0));
+            c.addChild(new Text(ticketLine, 0, 0));
+        c.addChild(new Text(theme.fg("dim", `    task: ${r.task}`), 0, 0));
         const outputTarget = extractOutputTarget(r.task);
         if (outputTarget) {
-            c.addChild(new Text(fit(theme.fg("dim", `    output: ${outputTarget}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `    output: ${outputTarget}`), 0, 0));
         }
         if (r.skills?.length) {
-            c.addChild(new Text(fit(theme.fg("dim", `    skills: ${r.skills.join(", ")}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `    skills: ${r.skills.join(", ")}`), 0, 0));
         }
         if (r.skillsWarning) {
-            c.addChild(new Text(fit(theme.fg("warning", `    Warning: ${r.skillsWarning}`)), 0, 0));
+            c.addChild(new Text(theme.fg("warning", `    Warning: ${r.skillsWarning}`), 0, 0));
         }
         if (r.attemptedModels && r.attemptedModels.length > 1) {
-            c.addChild(new Text(fit(theme.fg("dim", `    fallbacks: ${r.attemptedModels.join(" → ")}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `    fallbacks: ${r.attemptedModels.join(" → ")}`), 0, 0));
         }
         if (rRunning && liveProgress) {
             if (liveProgress.skills?.length) {
-                c.addChild(new Text(fit(theme.fg("accent", `    skills: ${liveProgress.skills.join(", ")}`)), 0, 0));
+                c.addChild(new Text(theme.fg("accent", `    skills: ${liveProgress.skills.join(", ")}`), 0, 0));
             }
             const progressSnapshotNow = snapshotNowForProgress(liveProgress);
             const toolLine = formatCurrentToolLine(liveProgress, w, expanded, progressSnapshotNow);
             if (toolLine) {
-                c.addChild(new Text(fit(theme.fg("warning", `    > ${toolLine}`)), 0, 0));
+                c.addChild(new Text(theme.fg("warning", `    > ${toolLine}`), 0, 0));
             }
             const liveStatusLine = buildLiveStatusLine(liveProgress, progressSnapshotNow);
             if (liveStatusLine) {
-                c.addChild(new Text(fit(theme.fg("accent", `    ${liveStatusLine}`)), 0, 0));
+                c.addChild(new Text(theme.fg("accent", `    ${liveStatusLine}`), 0, 0));
             }
-            c.addChild(new Text(fit(theme.fg("accent", `    ${liveDetailHintText()}`)), 0, 0));
+            c.addChild(new Text(theme.fg("accent", `    ${liveDetailHintText()}`), 0, 0));
             if (r.artifactPaths) {
-                c.addChild(new Text(fit(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
             }
             if (liveProgress.recentTools.length) {
                 for (const t of liveProgress.recentTools.slice(-3)) {
-                    const maxArgsLen = Math.max(40, w - 30);
-                    const argsPreview = expanded || t.args.length <= maxArgsLen ? t.args : `${t.args.slice(0, maxArgsLen)}...`;
-                    c.addChild(new Text(fit(theme.fg("dim", `      ${t.tool}: ${argsPreview}`)), 0, 0));
+                    c.addChild(new Text(theme.fg("dim", `      ${t.tool}: ${t.args}`), 0, 0));
                 }
             }
             const recentLines = liveProgress.recentOutput.slice(-5);
             for (const line of recentLines) {
-                c.addChild(new Text(fit(theme.fg("dim", `      ${line}`)), 0, 0));
+                c.addChild(new Text(theme.fg("dim", `      ${line}`), 0, 0));
             }
         }
         if (!rRunning && r.artifactPaths) {
-            c.addChild(new Text(fit(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
         }
         if (r.truncation?.artifactPath) {
-            c.addChild(new Text(fit(theme.fg("dim", `    full output: ${shortenPath(r.truncation.artifactPath)}`)), 0, 0));
+            c.addChild(new Text(theme.fg("dim", `    full output: ${shortenPath(r.truncation.artifactPath)}`), 0, 0));
         }
         if (expanded && !rRunning) {
             for (const line of toolCallLines) {
-                c.addChild(new Text(fit(theme.fg("muted", `      ${line}`)), 0, 0));
+                c.addChild(new Text(theme.fg("muted", `      ${line}`), 0, 0));
             }
             if (toolCallLines.length)
                 c.addChild(new Spacer(1));
@@ -2046,7 +2033,7 @@ export function renderSubagentResult(result, options, theme, frame) {
     }
     if (d.artifacts) {
         c.addChild(new Spacer(1));
-        c.addChild(new Text(fit(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`)), 0, 0));
+        c.addChild(new Text(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), 0, 0));
     }
     return c;
 }

--- a/extensions/subagents/src/tui/render.ts
+++ b/extensions/subagents/src/tui/render.ts
@@ -4,7 +4,15 @@
 
 import * as path from "node:path";
 import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Container, Markdown, Spacer, Text, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import {
+	Container,
+	Markdown,
+	Spacer,
+	Text,
+	visibleWidth,
+	wrapTextWithAnsi,
+	type Component,
+} from "@earendil-works/pi-tui";
 import { liveDetailShortcutDisplay, type SubagentLiveDetailController } from "../shared/subagent-shortcuts.ts";
 import {
 	type ActivityState,
@@ -56,64 +64,67 @@ function getTermWidth(): number {
 	return process.stdout.columns || 120;
 }
 
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-const ANSI_SGR_PATTERN = new RegExp(`^${String.fromCharCode(0x1b)}\\[[0-9;]*m`);
-const ANSI_ESCAPE = String.fromCharCode(0x1b);
+function wrapDisplayLine(text: string, maxWidth: number): string[] {
+	return wrapTextWithAnsi(text, Math.max(1, maxWidth));
+}
 
-/**
- * Truncate a line to maxWidth, preserving ANSI styling through the ellipsis.
- *
- * pi-tui's truncateToWidth adds \x1b[0m before ellipsis which resets all styling,
- * causing background color bleed in the TUI. This implementation tracks active
- * ANSI styles and re-applies them before the ellipsis.
- *
- * Uses Intl.Segmenter for proper Unicode/emoji handling (not char-by-char).
- */
-function truncLine(text: string, maxWidth: number): string {
-	if (visibleWidth(text) <= maxWidth) return text;
+function wrapDisplayLines(lines: readonly string[], maxWidth: number): string[] {
+	return lines.flatMap((line) => wrapDisplayLine(line, maxWidth));
+}
 
-	const targetWidth = maxWidth - 1;
-	let result = "";
-	let currentWidth = 0;
-	let activeStyles: string[] = [];
-	let i = 0;
+function addWrappedText(container: Container, text: string, maxWidth: number): void {
+	for (const line of wrapDisplayLine(text, maxWidth)) container.addChild(new Text(line, 0, 0));
+}
 
-	while (i < text.length) {
-		const ansiMatch = text.slice(i).match(ANSI_SGR_PATTERN);
-		if (ansiMatch) {
-			const code = ansiMatch[0];
-			result += code;
+function collapsedForegroundLineBudget(): number {
+	const rows = process.stdout.rows || 30;
+	return Math.max(5, Math.min(14, Math.floor(rows * 0.4)));
+}
 
-			if (code === `${ANSI_ESCAPE}[0m` || code === `${ANSI_ESCAPE}[m`) {
-				activeStyles = [];
-			} else {
-				activeStyles.push(code);
-			}
-			i += code.length;
-			continue;
+function collapsedForegroundSummaryLines(hiddenCount: number, theme: Theme, width: number, maxLines: number): string[] {
+	const key = liveDetailKeyText();
+	const variants = [
+		`… ${hiddenCount} lines hidden · ${key} expands`,
+		`… ${hiddenCount} hidden · ${key} expands`,
+		`${hiddenCount} ${key}`,
+		`${key} expands`,
+		key,
+	];
+	const firstLines = wrapDisplayLine(theme.fg("dim", variants[0]!), width);
+	for (const variant of variants) {
+		const summaryLines = wrapDisplayLine(theme.fg("dim", variant), width);
+		if (summaryLines.length <= maxLines) return summaryLines;
+	}
+	return firstLines;
+}
+
+function fitCollapsedForegroundLines(lines: string[], theme: Theme, width: number): string[] {
+	const budget = collapsedForegroundLineBudget();
+	if (lines.length <= budget) return lines;
+
+	for (let visibleCount = Math.min(lines.length, budget - 1); visibleCount >= 0; visibleCount--) {
+		const hiddenCount = lines.length - visibleCount;
+		const summaryLines = wrapDisplayLine(
+			theme.fg("dim", `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`),
+			width,
+		);
+		if (visibleCount + summaryLines.length <= budget) {
+			return [...lines.slice(0, visibleCount), ...summaryLines];
 		}
-
-		let end = i;
-		while (end < text.length && !text.slice(end).match(ANSI_SGR_PATTERN)) {
-			end++;
-		}
-
-		const textPortion = text.slice(i, end);
-		for (const seg of segmenter.segment(textPortion)) {
-			const grapheme = seg.segment;
-			const graphemeWidth = visibleWidth(grapheme);
-
-			if (currentWidth + graphemeWidth > targetWidth) {
-				return result + activeStyles.join("") + "…";
-			}
-
-			result += grapheme;
-			currentWidth += graphemeWidth;
-		}
-		i = end;
 	}
 
-	return result + activeStyles.join("") + "…";
+	return collapsedForegroundSummaryLines(lines.length, theme, width, budget);
+}
+
+function collapsedForegroundComponent(logicalLines: readonly string[], theme: Theme): Component {
+	return {
+		render(width: number): string[] {
+			const contentWidth = Math.max(1, width);
+			const physicalLines = wrapDisplayLines(logicalLines, contentWidth);
+			return fitCollapsedForegroundLines(physicalLines, theme, contentWidth);
+		},
+		invalidate(): void {},
+	};
 }
 
 function fitInlineThinkingActivity(
@@ -122,89 +133,15 @@ function fitInlineThinkingActivity(
 	freshness: string,
 	theme: Theme,
 	maxWidth: number,
-): string {
+): string[] {
 	const separator = ` ${theme.fg("dim", "·")} `;
-	const dimPhrase = theme.fg("dim", phrase);
-	const dimFreshness = theme.fg("dim", freshness);
-	const freshnessSuffix = `${separator}${dimFreshness}`;
-	const fullLine = `${prefix}${separator}${dimPhrase}${freshnessSuffix}`;
-	if (visibleWidth(fullLine) <= maxWidth) return fullLine;
-
-	const prefixAndFreshness = `${prefix}${freshnessSuffix}`;
-	if (visibleWidth(prefixAndFreshness) > maxWidth) {
-		if (visibleWidth(freshnessSuffix) >= maxWidth) return truncLine(dimFreshness, maxWidth);
-		return `${truncLine(prefix, maxWidth - visibleWidth(freshnessSuffix))}${freshnessSuffix}`;
-	}
-
-	const phraseWidth = maxWidth - visibleWidth(prefix) - visibleWidth(separator) - visibleWidth(freshnessSuffix);
-	return phraseWidth > 1
-		? `${prefix}${separator}${truncLine(dimPhrase, phraseWidth)}${freshnessSuffix}`
-		: prefixAndFreshness;
+	const fullLine = `${prefix}${separator}${theme.fg("dim", phrase)}${separator}${theme.fg("dim", freshness)}`;
+	return wrapDisplayLine(fullLine, maxWidth);
 }
 
-function fitInlineActivity(prefix: string, activity: string, theme: Theme, maxWidth: number): string {
+function fitInlineActivity(prefix: string, activity: string, theme: Theme, maxWidth: number): string[] {
 	const separator = ` ${theme.fg("dim", "·")} `;
-	const dimActivity = theme.fg("dim", activity);
-	const activitySuffix = `${separator}${dimActivity}`;
-	const fullLine = `${prefix}${activitySuffix}`;
-	if (visibleWidth(fullLine) <= maxWidth) return fullLine;
-
-	const separatorWidth = visibleWidth(separator);
-	const prefixVisibleWidth = visibleWidth(prefix);
-	const activityVisibleWidth = visibleWidth(dimActivity);
-	const sharedWidth = maxWidth - separatorWidth;
-	if (sharedWidth >= 2 && prefixVisibleWidth > 0 && activityVisibleWidth > 0) {
-		// Any overflow needs the same identity reserve, not just warnings that
-		// are wider than the whole row. Start with a balanced split so a long
-		// prefix cannot be reduced to a single glyph, then give unused warning
-		// space back to the prefix when the warning itself is shorter.
-		let prefixWidth = Math.min(prefixVisibleWidth, Math.ceil(sharedWidth / 2));
-		let activityWidth = Math.min(activityVisibleWidth, sharedWidth - prefixWidth);
-		let spareWidth = sharedWidth - prefixWidth - activityWidth;
-		if (spareWidth > 0 && prefixWidth < prefixVisibleWidth) {
-			const prefixGrowth = Math.min(spareWidth, prefixVisibleWidth - prefixWidth);
-			prefixWidth += prefixGrowth;
-			spareWidth -= prefixGrowth;
-		}
-		activityWidth += spareWidth;
-		return `${truncLine(prefix, prefixWidth)}${separator}${truncLine(dimActivity, activityWidth)}`;
-	}
-
-	// There is no room for the normal separator at extremely narrow widths;
-	// still split what fits so neither side is silently discarded.
-	if (maxWidth >= 2 && prefixVisibleWidth > 0 && activityVisibleWidth > 0) {
-		const prefixWidth = Math.min(prefixVisibleWidth, Math.max(1, Math.ceil(maxWidth / 2)));
-		const activityWidth = maxWidth - prefixWidth;
-		return `${truncLine(prefix, prefixWidth)}${truncLine(dimActivity, activityWidth)}`;
-	}
-	return truncLine(prefixVisibleWidth > 0 ? prefix : dimActivity, Math.max(1, maxWidth));
-}
-
-function wrapPlainText(text: string, maxWidth: number): string[] {
-	if (maxWidth <= 0) return [""];
-	const lines: string[] = [];
-	for (const rawLine of text.split("\n")) {
-		if (rawLine.length === 0) {
-			lines.push("");
-			continue;
-		}
-		let current = "";
-		let currentWidth = 0;
-		for (const seg of segmenter.segment(rawLine)) {
-			const grapheme = seg.segment;
-			const graphemeWidth = visibleWidth(grapheme);
-			if (currentWidth > 0 && currentWidth + graphemeWidth > maxWidth) {
-				lines.push(current);
-				current = grapheme;
-				currentWidth = graphemeWidth;
-				continue;
-			}
-			current += grapheme;
-			currentWidth += graphemeWidth;
-		}
-		lines.push(current);
-	}
-	return lines;
+	return wrapDisplayLine(`${prefix}${separator}${theme.fg("dim", activity)}`, maxWidth);
 }
 
 const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -279,7 +216,9 @@ function getToolCallLines(
 			.filter((item): item is { type: "tool"; name: string; args: Record<string, unknown> } => item.type === "tool")
 			.map((item) => formatToolCall(item.name, item.args, expanded));
 	}
-	return result.toolCalls?.map((toolCall) => (expanded ? toolCall.expandedText : toolCall.text)) ?? [];
+	return (
+		result.toolCalls?.map((toolCall) => (expanded ? (toolCall.expandedText ?? toolCall.text) : toolCall.text)) ?? []
+	);
 }
 
 function snapshotNowForProgress(
@@ -292,17 +231,12 @@ function snapshotNowForProgress(
 
 function formatCurrentToolLine(
 	progress: Pick<AgentProgress, "currentTool" | "currentToolArgs" | "currentToolStartedAt">,
-	availableWidth: number,
-	expanded: boolean,
+	_availableWidth: number,
+	_expanded: boolean,
 	snapshotNow?: number,
 ): string | undefined {
 	if (!progress.currentTool) return undefined;
-	const maxToolArgsLen = Math.max(50, availableWidth - 20);
-	const toolArgsPreview = progress.currentToolArgs
-		? expanded || progress.currentToolArgs.length <= maxToolArgsLen
-			? progress.currentToolArgs
-			: `${progress.currentToolArgs.slice(0, maxToolArgsLen)}...`
-		: "";
+	const toolArgsPreview = progress.currentToolArgs ?? "";
 	const durationSuffix =
 		progress.currentToolStartedAt !== undefined && snapshotNow !== undefined
 			? ` | ${formatDuration(Math.max(0, snapshotNow - progress.currentToolStartedAt))}`
@@ -645,10 +579,9 @@ function widgetStepStatus(status: AsyncJobStep["status"], theme: Theme, interrup
 
 const TK_TICKET_WIDGET_PREFIX = "working on tk: ";
 
-function widgetTkTicketText(job: AsyncJobState, maxWidth = 72): string | undefined {
+function widgetTkTicketText(job: AsyncJobState): string | undefined {
 	if (!job.tkTicket || (job.status !== "running" && job.status !== "queued")) return undefined;
-	const titleWidth = Math.max(1, maxWidth - visibleWidth(TK_TICKET_WIDGET_PREFIX));
-	const normalizedTkTicket = normalizeTkTicketMetadata(job.tkTicket, titleWidth);
+	const normalizedTkTicket = normalizeTkTicketMetadata(job.tkTicket);
 	return normalizedTkTicket ? `${TK_TICKET_WIDGET_PREFIX}${normalizedTkTicket.title}` : undefined;
 }
 
@@ -662,20 +595,14 @@ function widgetTkTicketLines(job: AsyncJobState, theme: Theme): string[] {
 	return line ? [line] : [];
 }
 
-function foregroundTkTicketText(result: Details["results"][number], maxWidth = 72): string | undefined {
-	const titleWidth = Math.max(1, maxWidth - visibleWidth("  ") - visibleWidth(TK_TICKET_WIDGET_PREFIX));
-	const normalizedTkTicket = normalizeTkTicketMetadata(result.tkTicket, titleWidth);
+function foregroundTkTicketText(result: Details["results"][number]): string | undefined {
+	const normalizedTkTicket = normalizeTkTicketMetadata(result.tkTicket);
 	return normalizedTkTicket ? `${TK_TICKET_WIDGET_PREFIX}${normalizedTkTicket.title}` : undefined;
 }
 
-function foregroundTkTicketLine(
-	result: Details["results"][number],
-	theme: Theme,
-	active: boolean,
-	maxWidth: number,
-): string | undefined {
+function foregroundTkTicketLine(result: Details["results"][number], theme: Theme, active: boolean): string | undefined {
 	if (!active) return undefined;
-	const ticket = foregroundTkTicketText(result, maxWidth);
+	const ticket = foregroundTkTicketText(result);
 	return ticket ? `  ${theme.fg("dim", ticket)}` : undefined;
 }
 
@@ -765,10 +692,10 @@ function widgetParallelAgentDetails(
 				: undefined;
 		const prefix = `  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme, step.interruptRequestedAt)}${modelDisplay}`)}`;
 		if (!expanded && healthWarning) {
-			lines.push(fitInlineActivity(prefix, healthWarning, theme, Math.max(1, width - 6)));
+			lines.push(...fitInlineActivity(prefix, healthWarning, theme, Math.max(1, width - 6)));
 		} else if (freshness) {
 			lines.push(
-				fitInlineThinkingActivity(
+				...fitInlineThinkingActivity(
 					prefix,
 					compactThinkingPhrase(step.activityState, step.turnCount)!,
 					freshness,
@@ -1336,7 +1263,7 @@ function formatNestedWidgetLines(
 		}
 	};
 	append(children, 0, "");
-	return lines.map((line) => truncLine(line, width));
+	return wrapDisplayLines(lines, width);
 }
 
 function singleWidgetStepDisplayStatus(
@@ -1400,9 +1327,7 @@ function foregroundStyleWidgetStepLines(
 			const output = widgetOutputPath(job, step);
 			if (output) lines.push(`    ${theme.fg("dim", `output: ${shortenPath(output)}`)}`);
 			for (const tool of step.recentTools?.slice(-3) ?? []) {
-				const maxArgsLen = Math.max(40, width - 30);
-				const argsPreview = tool.args.length <= maxArgsLen ? tool.args : `${tool.args.slice(0, maxArgsLen)}...`;
-				lines.push(`      ${theme.fg("dim", `${tool.tool}${argsPreview ? `: ${argsPreview}` : ""}`)}`);
+				lines.push(`      ${theme.fg("dim", `${tool.tool}${tool.args ? `: ${tool.args}` : ""}`)}`);
 			}
 			for (const line of step.recentOutput?.slice(-5) ?? []) {
 				lines.push(`      ${theme.fg("dim", line)}`);
@@ -1509,24 +1434,18 @@ function parallelWidgetAggregateStats(job: AsyncJobState, theme: Theme, expanded
 	return job.status === "complete" ? "done" : job.status;
 }
 
-function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, contentWidth: number, expanded: boolean): string[] {
+function singleWidgetHeaderLines(job: AsyncJobState, theme: Theme, expanded: boolean): string[] {
 	if (job.mode === "single") {
-		return [
-			`${theme.fg("toolTitle", themeBold(theme, "async subagent"))} ${theme.fg("dim", "· background")}`,
-			...singleWidgetAgentDetails(job, theme, expanded, contentWidth),
-		].map((line) => truncLine(line, contentWidth));
+		return [`${theme.fg("toolTitle", themeBold(theme, "async subagent"))} ${theme.fg("dim", "· background")}`];
 	}
-
 	if (job.mode === "parallel") {
 		const count = job.stepsTotal ?? job.agents?.length ?? job.steps?.length ?? 0;
 		const stats = parallelWidgetAggregateStats(job, theme, expanded);
 		return [
 			`${theme.fg("toolTitle", themeBold(theme, `async subagents (${count})`))} ${theme.fg("dim", "· background")}`,
 			`${widgetStatusGlyph(job, theme)}${stats ? ` ${stats}` : ""}`,
-			...foregroundStyleWidgetDetails(job, theme, expanded, contentWidth),
-		].map((line) => truncLine(line, contentWidth));
+		];
 	}
-
 	const stats = widgetSummaryStats(job, theme, expanded);
 	const count = job.mode === "chain" ? job.chainStepCount : (job.stepsTotal ?? job.agents?.length ?? job.steps?.length);
 	const mode = widgetJobName(job);
@@ -1534,20 +1453,30 @@ function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, contentWidth: 
 	return [
 		`${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
 		`${widgetStatusGlyph(job, theme)} ${themeBold(theme, mode)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-		...foregroundStyleWidgetDetails(job, theme, expanded, contentWidth),
-	].map((line) => truncLine(line, contentWidth));
+	];
+}
+
+function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, contentWidth: number, expanded: boolean): string[] {
+	const details =
+		job.mode === "single"
+			? singleWidgetAgentDetails(job, theme, expanded, contentWidth)
+			: foregroundStyleWidgetDetails(job, theme, expanded, contentWidth);
+	return wrapDisplayLines([...singleWidgetHeaderLines(job, theme, expanded), ...details], contentWidth);
 }
 
 function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number): string[] {
 	const contentWidth = Math.max(1, width - 2);
 	const fullLines = buildSingleWidgetLines(job, theme, contentWidth, false);
 	if (fullLines.length <= 10 || !job.steps?.length || (job.mode !== "parallel" && !job.activeParallelGroup)) {
-		return fullLines.map((line) => truncLine(line, contentWidth));
+		return fullLines;
 	}
 
 	const total = job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
-	const lines = [...fullLines.slice(0, 2), ...widgetTkTicketLines(job, theme)];
+	const lines = [
+		...wrapDisplayLines(singleWidgetHeaderLines(job, theme, false), contentWidth),
+		...widgetTkTicketLines(job, theme),
+	];
 	for (const [index, step] of job.steps.entries()) {
 		const status = widgetStepStatus(step.status, theme, step.interruptRequestedAt);
 		const activityLines = widgetStepActivityLines(step, contentWidth, false, job.updatedAt);
@@ -1563,13 +1492,13 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 			isHealthActivityState(step.activityState)
 				? activityLines.find((activityLine) => activityLine === buildLiveStatusLine(step, job.updatedAt))
 				: undefined;
-		lines.push(
-			healthWarning
-				? fitInlineActivity(rowPrefix, healthWarning, theme, contentWidth)
-				: step.status === "running" && !step.currentTool && activityLines.length === 2
-					? fitInlineThinkingActivity(rowPrefix, activityLines[0]!, activityLines[1]!, theme, contentWidth)
-					: `${rowPrefix}${activitySuffix}`,
-		);
+		if (healthWarning) {
+			lines.push(...fitInlineActivity(rowPrefix, healthWarning, theme, contentWidth));
+		} else if (step.status === "running" && !step.currentTool && activityLines.length === 2) {
+			lines.push(...fitInlineThinkingActivity(rowPrefix, activityLines[0]!, activityLines[1]!, theme, contentWidth));
+		} else {
+			lines.push(`${rowPrefix}${activitySuffix}`);
+		}
 		for (const nestedLine of formatNestedWidgetLines(
 			step.children,
 			theme,
@@ -1582,7 +1511,7 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 			lines.push(`    ${nestedLine}`);
 	}
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
-	return lines.map((line) => truncLine(line, contentWidth));
+	return wrapDisplayLines(lines, contentWidth);
 }
 
 type WidgetRenderTier = "full" | "single-line" | "progressive";
@@ -1641,23 +1570,40 @@ function widgetHeaderCounts(jobs: AsyncJobState[]): {
 	};
 }
 
+function chooseWidgetSummaryVariant(variants: readonly string[], width: number): string {
+	const contentWidth = Math.max(1, width);
+	return variants.find((variant) => visibleWidth(variant) <= contentWidth) ?? variants[variants.length - 1]!;
+}
+
+function compactWidgetCountSummary(counts: ReturnType<typeof widgetHeaderCounts>, jobs: AsyncJobState[]): string {
+	if (counts.running.length > 0 && counts.queued.length > 0)
+		return `${counts.running.length}r ${counts.queued.length}q`;
+	if (counts.running.length > 0) return `${counts.running.length} running`;
+	if (counts.queued.length > 0) return `${counts.queued.length} queued`;
+	if (counts.failed.length > 0) return `${counts.failed.length} failed`;
+	if (counts.paused.length > 0) return `${counts.paused.length} paused`;
+	if (counts.complete.length > 0) return `${counts.complete.length} done`;
+	return `${jobs.length} total`;
+}
+
 function buildSingleLineWidgetLines(jobs: AsyncJobState[], theme: Theme, width: number): string[] {
 	const contentWidth = Math.max(1, width - 2);
 	const counts = widgetHeaderCounts(jobs);
 	const hasActive = counts.running.length > 0 || counts.queued.length > 0;
 	const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+	const coloredGlyph = theme.fg(hasActive ? "accent" : "dim", glyph);
+	const coloredTitle = theme.fg(hasActive ? "accent" : "dim", "subagents");
 	const parts: string[] = [];
 	if (counts.running.length > 0) parts.push(`${counts.running.length}/${jobs.length} running`);
 	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
 	if (counts.failed.length > 0) parts.push(`${counts.failed.length} failed`);
 	if (counts.paused.length > 0) parts.push(`${counts.paused.length} paused`);
 	if (!hasActive && counts.complete.length > 0) parts.push(`${counts.complete.length}/${jobs.length} done`);
-	return [
-		truncLine(
-			`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "subagents")} (${parts.join(", ") || `${jobs.length} total`})`,
-			contentWidth,
-		),
-	];
+	const detailed = `${coloredGlyph} ${coloredTitle} (${parts.join(", ") || `${jobs.length} total`})`;
+	const withoutParenthetical = `${coloredGlyph} ${theme.fg(hasActive ? "accent" : "dim", parts.join(", ") || `${jobs.length} total`)}`;
+	const compact = `${coloredGlyph} ${theme.fg(hasActive ? "accent" : "dim", compactWidgetCountSummary(counts, jobs))}`;
+	const titleOnly = `${coloredGlyph} ${coloredTitle}`;
+	return [chooseWidgetSummaryVariant([detailed, withoutParenthetical, compact, titleOnly, coloredGlyph], contentWidth)];
 }
 
 function orderedWidgetJobs(jobs: AsyncJobState[]): AsyncJobState[] {
@@ -1709,10 +1655,12 @@ function selectProgressiveJobKeys(jobs: AsyncJobState[], previousKeys: string[],
 	return selected;
 }
 
-function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: number): string {
+function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: number): string[] {
 	const counts = widgetHeaderCounts(jobs);
 	const hasActive = counts.running.length > 0 || counts.queued.length > 0;
 	const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+	const coloredGlyph = theme.fg(hasActive ? "accent" : "dim", glyph);
+	const coloredTitle = theme.fg(hasActive ? "accent" : "dim", "Async agents");
 	const parts: string[] = [];
 	if (counts.running.length > 0) parts.push(formatAgentRunningLabel(counts.running.length));
 	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
@@ -1721,19 +1669,26 @@ function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: numbe
 		if (counts.paused.length > 0) parts.push(`${counts.paused.length} paused`);
 		if (counts.complete.length > 0) parts.push(`${counts.complete.length}/${jobs.length} done`);
 	}
+	const coloredParts = theme.fg("dim", parts.join(", ") || `${jobs.length} total`);
+	const compact = theme.fg(hasActive ? "accent" : "dim", compactWidgetCountSummary(counts, jobs));
 	const contentWidth = Math.max(1, width - 2);
-	return truncLine(
-		`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(", ") || `${jobs.length} total`)}`,
-		contentWidth,
-	);
+	const detailed = `${coloredGlyph} ${coloredTitle} ${theme.fg("dim", "·")} ${coloredParts}`;
+	const withoutTitle = `${coloredGlyph} ${coloredParts}`;
+	const titleOnly = `${coloredGlyph} ${coloredTitle}`;
+	return [
+		chooseWidgetSummaryVariant(
+			[detailed, withoutTitle, `${coloredGlyph} ${compact}`, titleOnly, coloredGlyph],
+			contentWidth,
+		),
+	];
 }
 
-function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number): string {
+function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number): string[] {
 	const contentWidth = Math.max(1, width - 2);
 	const stats = widgetSummaryStats(job, theme);
 	const activity = widgetActivity(job);
 	const status = job.status === "complete" ? "done" : job.status;
-	const ticket = widgetTkTicketText(job, Math.max(24, width - 32));
+	const ticket = widgetTkTicketText(job);
 	const prefixParts = [
 		themeBold(theme, widgetJobName(job)),
 		theme.fg("dim", status),
@@ -1760,10 +1715,10 @@ function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number): st
 	if (healthWarning) return fitInlineActivity(prefix, healthWarning, theme, contentWidth);
 	const activitySuffix =
 		activity && activity.toLowerCase() !== status ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
-	return truncLine(`${prefix}${activitySuffix}`, contentWidth);
+	return wrapDisplayLine(`${prefix}${activitySuffix}`, contentWidth);
 }
 
-function progressiveHiddenLine(hiddenJobs: AsyncJobState[], theme: Theme, width: number): string {
+function progressiveHiddenLine(hiddenJobs: AsyncJobState[], theme: Theme, width: number): string[] {
 	const contentWidth = Math.max(1, width - 2);
 	const counts = widgetHeaderCounts(hiddenJobs);
 	const parts: string[] = [];
@@ -1771,10 +1726,11 @@ function progressiveHiddenLine(hiddenJobs: AsyncJobState[], theme: Theme, width:
 	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
 	const finished = counts.complete.length + counts.failed.length + counts.paused.length;
 	if (finished > 0) parts.push(`${finished} finished`);
-	return truncLine(
-		theme.fg("dim", `  +${hiddenJobs.length} more${parts.length ? ` (${parts.join(", ")})` : ""}`),
-		contentWidth,
-	);
+	const full = theme.fg("dim", `  +${hiddenJobs.length} more${parts.length ? ` (${parts.join(", ")})` : ""}`);
+	const countSummary = theme.fg("dim", `  +${hiddenJobs.length} more`);
+	const countOnly = theme.fg("dim", `+${hiddenJobs.length}`);
+	const fallback = theme.fg("dim", "+");
+	return [chooseWidgetSummaryVariant([full, countSummary, countOnly, fallback], contentWidth)];
 }
 
 function buildProgressiveWidgetLines(
@@ -1787,26 +1743,37 @@ function buildProgressiveWidgetLines(
 	const rowCount = Math.max(1, lockedRows);
 	if (rowCount === 1) return { lines: buildSingleLineWidgetLines(jobs, theme, width), visibleJobKeys: [] };
 
-	const bodyRows = rowCount - 1;
-	let visibleJobKeys = selectProgressiveJobKeys(jobs, previousKeys, bodyRows);
+	const headerLines = progressiveHeaderLine(jobs, theme, width);
 	const jobsByKey = new Map(jobs.map((job) => [progressiveJobKey(job), job]));
-	let visibleJobs = visibleJobKeys.map((key) => jobsByKey.get(key)).filter((job): job is AsyncJobState => Boolean(job));
-	let hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
-	const needsHiddenLine = hiddenJobs.length > 0;
+	const candidateKeys = selectProgressiveJobKeys(jobs, previousKeys, jobs.length);
+	const visibleJobKeys: string[] = [];
+	const bodyLines: string[] = [];
 
-	if (needsHiddenLine && visibleJobs.length >= bodyRows && bodyRows > 0) {
-		visibleJobs = visibleJobs.slice(0, bodyRows - 1);
-		visibleJobKeys = visibleJobs.map(progressiveJobKey);
-		hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+	for (const key of candidateKeys) {
+		const job = jobsByKey.get(key);
+		if (!job) continue;
+		const jobLines = progressiveJobLine(job, theme, width);
+		const prospectiveKeys = [...visibleJobKeys, key];
+		const prospectiveHiddenJobs = jobs.filter((candidate) => !prospectiveKeys.includes(progressiveJobKey(candidate)));
+		const prospectiveHiddenLines =
+			prospectiveHiddenJobs.length > 0 ? progressiveHiddenLine(prospectiveHiddenJobs, theme, width) : [];
+		if (headerLines.length + bodyLines.length + jobLines.length + prospectiveHiddenLines.length > rowCount) continue;
+		visibleJobKeys.push(key);
+		bodyLines.push(...jobLines);
 	}
 
-	const lines = [
-		progressiveHeaderLine(jobs, theme, width),
-		...visibleJobs.map((job) => progressiveJobLine(job, theme, width)),
-	];
-	if (hiddenJobs.length > 0 && lines.length < rowCount) lines.push(progressiveHiddenLine(hiddenJobs, theme, width));
+	const hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+	const hiddenLines = hiddenJobs.length > 0 ? progressiveHiddenLine(hiddenJobs, theme, width) : [];
+	const lines = [...headerLines, ...bodyLines, ...hiddenLines];
+	if (lines.length > rowCount) {
+		// Job rows are optional in a locked-height summary. Keep the one-line
+		// header and explicit hidden-work count if a future detail variant wraps.
+		const boundedLines = [headerLines[0]!, ...(hiddenLines.length > 0 ? [hiddenLines[0]!] : [])];
+		while (boundedLines.length < rowCount) boundedLines.push("\u200c");
+		return { lines: boundedLines.slice(0, rowCount), visibleJobKeys: [] };
+	}
 	while (lines.length < rowCount) lines.push("\u200c");
-	return { lines: lines.slice(0, rowCount), visibleJobKeys };
+	return { lines, visibleJobKeys };
 }
 
 function collapsedWidgetLineBudget(rows: number): number {
@@ -1818,12 +1785,18 @@ function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expan
 	const rows = process.stdout.rows || 30;
 	const budget = expanded ? Math.max(12, Math.min(24, Math.floor(rows * 0.55))) : collapsedWidgetLineBudget(rows);
 	if (lines.length <= budget) return lines;
-	const visibleLines = Math.max(1, budget - 1);
-	const hiddenCount = lines.length - visibleLines;
-	const hint = expanded
-		? `… ${hiddenCount} live-detail lines hidden`
-		: `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`;
-	return [...lines.slice(0, visibleLines), truncLine(theme.fg("dim", hint), contentWidth)];
+
+	let visibleCount = Math.max(0, budget - 1);
+	while (true) {
+		const hiddenCount = lines.length - visibleCount;
+		const hint = expanded
+			? `… ${hiddenCount} live-detail lines hidden`
+			: `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`;
+		const hintLines = wrapDisplayLine(theme.fg("dim", hint), contentWidth);
+		const nextVisibleCount = Math.max(0, budget - hintLines.length);
+		if (nextVisibleCount === visibleCount) return [...lines.slice(0, visibleCount), ...hintLines];
+		visibleCount = nextVisibleCount;
+	}
 }
 
 function fitAdaptiveWidgetLines(
@@ -1926,7 +1899,7 @@ export function buildWidgetLines(
 	const hasActive = running.length > 0 || queued.length > 0;
 	const headerGlyph = running.length > 0 ? runningGlyph(widgetJobsRunningSeed(running)) : hasActive ? "●" : "○";
 	lines.push(
-		truncLine(
+		...wrapDisplayLine(
 			`${theme.fg(hasActive ? "accent" : "dim", headerGlyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "· background")}`,
 			contentWidth,
 		),
@@ -1989,9 +1962,9 @@ export function buildWidgetLines(
 		const last = i === items.length - 1;
 		const branch = last ? "└─" : "├─";
 		const continuation = last ? "   " : "│  ";
-		lines.push(truncLine(`${theme.fg("dim", branch)} ${item[0]}`, contentWidth));
+		lines.push(...wrapDisplayLine(`${theme.fg("dim", branch)} ${item[0]}`, contentWidth));
 		for (const detail of item.slice(1)) {
-			lines.push(truncLine(`${theme.fg("dim", continuation)} ${detail}`, contentWidth));
+			lines.push(...wrapDisplayLine(`${theme.fg("dim", continuation)} ${detail}`, contentWidth));
 		}
 	}
 
@@ -2019,44 +1992,30 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	const output = r.truncation?.text || getSingleResultOutput(r);
 	const isRunning = r.progress?.status === "running";
 	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
-	const c = new Container();
+	const lines: string[] = [];
 	const width = getTermWidth() - 4;
 	const modelDisplay = modelThinkingBadge(theme, r.model);
-	c.addChild(
-		new Text(
-			truncLine(
-				`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}`,
-				width,
-			),
-			0,
-			0,
-		),
+	lines.push(
+		`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}`,
 	);
-	const ticketLine = foregroundTkTicketLine(r, theme, isRunning, width);
-	if (ticketLine) c.addChild(new Text(truncLine(ticketLine, width), 0, 0));
+	const ticketLine = foregroundTkTicketLine(r, theme, isRunning);
+	if (ticketLine) lines.push(ticketLine);
 
 	if (isRunning && r.progress) {
 		for (const [activityIndex, activity] of compactProgressActivityLines(r.progress, width).entries()) {
-			c.addChild(
-				new Text(
-					truncLine(theme.fg("dim", activityIndex === 0 ? `  ⎿  ${activity}` : `     ${activity}`), width),
-					0,
-					0,
-				),
-			);
+			lines.push(theme.fg("dim", activityIndex === 0 ? `  ⎿  ${activity}` : `     ${activity}`));
 		}
-		c.addChild(new Text(truncLine(theme.fg("accent", `  ${liveDetailHintText()}`), width), 0, 0));
-		return c;
+		lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
+		return collapsedForegroundComponent(lines, theme);
 	}
 
 	const preview = compactOutputPreview(output);
-	c.addChild(new Text(truncLine(theme.fg("dim", `  ⎿  ${resultStatusLine(r, preview)}`), width), 0, 0));
+	lines.push(theme.fg("dim", `  ⎿  ${resultStatusLine(r, preview)}`));
 	if (preview && r.exitCode === 0 && !hasEmptyTextOutputWithoutOutputTarget(r.task, output)) {
-		c.addChild(new Text(truncLine(theme.fg("dim", `     ${preview}`), width), 0, 0));
+		lines.push(theme.fg("dim", `     ${preview}`));
 	}
-	if (r.sessionFile)
-		c.addChild(new Text(truncLine(theme.fg("dim", `  session: ${shortenPath(r.sessionFile)}`), width), 0, 0));
-	return c;
+	if (r.sessionFile) lines.push(theme.fg("dim", `  session: ${shortenPath(r.sessionFile)}`));
+	return collapsedForegroundComponent(lines, theme);
 }
 
 function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component {
@@ -2103,17 +2062,10 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 				? theme.fg("warning", "■")
 				: theme.fg("success", "✓");
 	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
-	const c = new Container();
+	const lines: string[] = [];
 	const width = getTermWidth() - 4;
-	c.addChild(
-		new Text(
-			truncLine(
-				`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-				width,
-			),
-			0,
-			0,
-		),
+	lines.push(
+		`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 	);
 
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
@@ -2137,17 +2089,10 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		if (entry.kind === "placeholder") {
 			const glyph = widgetStepGlyph(entry.status as AsyncJobStep["status"], theme);
 			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
-			c.addChild(
-				new Text(
-					truncLine(
-						`  ${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`,
-						width,
-					),
-					0,
-					0,
-				),
+			lines.push(
+				`  ${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`,
 			);
-			if (entry.error) c.addChild(new Text(truncLine(theme.fg("error", `    ⎿  Error: ${entry.error}`), width), 0, 0));
+			if (entry.error) lines.push(theme.fg("error", `    ⎿  Error: ${entry.error}`));
 			continue;
 		}
 		const i = entry.resultIndex;
@@ -2156,7 +2101,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const agentName = entry.agentName;
 		if (!r) {
 			const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
-			c.addChild(new Text(truncLine(theme.fg("dim", `  ◦ ${pendingLabel}: ${agentName} · pending`), width), 0, 0));
+			lines.push(theme.fg("dim", `  ◦ ${pendingLabel}: ${agentName} · pending`));
 			continue;
 		}
 		const output = getSingleResultOutput(r);
@@ -2173,36 +2118,23 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
 		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${pendingLabel}`;
-		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
-		const ticketLine = foregroundTkTicketLine(r, theme, rRunning, width);
-		if (ticketLine) c.addChild(new Text(truncLine(ticketLine, width), 0, 0));
+		lines.push(`  ${line}`);
+		const ticketLine = foregroundTkTicketLine(r, theme, rRunning);
+		if (ticketLine) lines.push(ticketLine);
 		if (rRunning && liveProgress) {
 			for (const [activityIndex, activity] of compactProgressActivityLines(liveProgress, width).entries()) {
-				c.addChild(
-					new Text(
-						truncLine(theme.fg("dim", activityIndex === 0 ? `    ⎿  ${activity}` : `       ${activity}`), width),
-						0,
-						0,
-					),
-				);
+				lines.push(theme.fg("dim", activityIndex === 0 ? `    ⎿  ${activity}` : `       ${activity}`));
 			}
-			c.addChild(new Text(truncLine(theme.fg("accent", `    ${liveDetailHintText()}`), width), 0, 0));
+			lines.push(theme.fg("accent", `    ${liveDetailHintText()}`));
 		} else if (
 			!rPending &&
 			(r.exitCode !== 0 || r.interrupted || r.detached || hasEmptyTextOutputWithoutOutputTarget(r.task, output))
 		) {
-			c.addChild(
-				new Text(
-					truncLine(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, output)}`), width),
-					0,
-					0,
-				),
-			);
+			lines.push(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, output)}`));
 		}
 	}
-	if (d.artifacts)
-		c.addChild(new Text(truncLine(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`), width), 0, 0));
-	return c;
+	if (d.artifacts) lines.push(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`));
+	return collapsedForegroundComponent(lines, theme);
 }
 
 /**
@@ -2224,20 +2156,21 @@ export function renderSubagentResult(
 		const text = t?.type === "text" ? t.text : "(no output)";
 		const contextPrefix = d?.context === "fork" ? `${theme.fg("warning", "[fork]")} ` : "";
 		const width = getTermWidth() - 4;
-		if (!text.includes("\n")) return new Text(truncLine(`${contextPrefix}${text}`, width), 0, 0);
+		if (!text.includes("\n")) {
+			const c = new Container();
+			addWrappedText(c, `${contextPrefix}${text}`, width);
+			return c;
+		}
 		if (d && !options.expanded && !result.isError) {
 			const lines = text.split(/\r?\n/);
 			const firstNonEmptyLine = lines.find((line) => line.trim())?.trim() || "(no output)";
 			const c = new Container();
-			c.addChild(new Text(truncLine(`${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width), 0, 0));
-			c.addChild(
-				new Text(truncLine(theme.fg("accent", `  Press ${liveDetailKeyText()} for full output`), width), 0, 0),
-			);
+			addWrappedText(c, `${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width);
+			addWrappedText(c, theme.fg("accent", `  Press ${liveDetailKeyText()} for full output`), width);
 			return c;
 		}
 		const c = new Container();
-		const wrapped = wrapPlainText(`${contextPrefix}${text}`, width);
-		for (const line of wrapped) c.addChild(new Text(line, 0, 0));
+		for (const line of wrapDisplayLine(`${contextPrefix}${text}`, width)) c.addChild(new Text(line, 0, 0));
 		return c;
 	}
 
@@ -2268,48 +2201,41 @@ export function renderSubagentResult(
 					: "";
 
 		const w = getTermWidth() - 4;
-		const fit = (text: string) => (expanded ? text : truncLine(text, w));
 		const toolCallLines = getToolCallLines(r, expanded);
 		const c = new Container();
-		c.addChild(
-			new Text(fit(`${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo}`), 0, 0),
-		);
-		const ticketLine = foregroundTkTicketLine(r, theme, isRunning, w);
-		if (ticketLine) c.addChild(new Text(fit(ticketLine), 0, 0));
+		c.addChild(new Text(`${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo}`, 0, 0));
+		const ticketLine = foregroundTkTicketLine(r, theme, isRunning);
+		if (ticketLine) c.addChild(new Text(ticketLine, 0, 0));
 		c.addChild(new Spacer(1));
-		const taskMaxLen = Math.max(20, w - 8);
-		const taskPreview = expanded || r.task.length <= taskMaxLen ? r.task : `${r.task.slice(0, taskMaxLen)}...`;
-		c.addChild(new Text(fit(theme.fg("dim", `Task: ${taskPreview}`)), 0, 0));
+		c.addChild(new Text(theme.fg("dim", `Task: ${r.task}`), 0, 0));
 		c.addChild(new Spacer(1));
 
 		const outputTarget = extractOutputTarget(r.task);
 		if (outputTarget) {
-			c.addChild(new Text(fit(theme.fg("dim", `Output: ${outputTarget}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `Output: ${outputTarget}`), 0, 0));
 		}
 
 		if (isRunning && r.progress) {
 			const progressSnapshotNow = snapshotNowForProgress(r.progress);
 			const toolLine = formatCurrentToolLine(r.progress, w, expanded, progressSnapshotNow);
 			if (toolLine) {
-				c.addChild(new Text(fit(theme.fg("warning", `> ${toolLine}`)), 0, 0));
+				c.addChild(new Text(theme.fg("warning", `> ${toolLine}`), 0, 0));
 			}
 			const liveStatusLine = buildLiveStatusLine(r.progress, progressSnapshotNow);
 			if (liveStatusLine) {
-				c.addChild(new Text(fit(theme.fg("accent", liveStatusLine)), 0, 0));
+				c.addChild(new Text(theme.fg("accent", liveStatusLine), 0, 0));
 			}
-			c.addChild(new Text(fit(theme.fg("accent", liveDetailHintText())), 0, 0));
+			c.addChild(new Text(theme.fg("accent", liveDetailHintText()), 0, 0));
 			if (r.artifactPaths) {
-				c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
 			}
 			if (r.progress.recentTools?.length) {
 				for (const t of r.progress.recentTools.slice(-3)) {
-					const maxArgsLen = Math.max(40, w - 24);
-					const argsPreview = expanded || t.args.length <= maxArgsLen ? t.args : `${t.args.slice(0, maxArgsLen)}...`;
-					c.addChild(new Text(fit(theme.fg("dim", `${t.tool}: ${argsPreview}`)), 0, 0));
+					c.addChild(new Text(theme.fg("dim", `${t.tool}: ${t.args}`), 0, 0));
 				}
 			}
 			for (const line of (r.progress.recentOutput ?? []).slice(-5)) {
-				c.addChild(new Text(fit(theme.fg("dim", `  ${line}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `  ${line}`), 0, 0));
 			}
 			if (
 				toolLine ||
@@ -2324,7 +2250,7 @@ export function renderSubagentResult(
 
 		if (expanded) {
 			for (const line of toolCallLines) {
-				c.addChild(new Text(fit(theme.fg("muted", line)), 0, 0));
+				c.addChild(new Text(theme.fg("muted", line), 0, 0));
 			}
 			if (toolCallLines.length) c.addChild(new Spacer(1));
 		}
@@ -2332,26 +2258,26 @@ export function renderSubagentResult(
 		if (output) c.addChild(new Markdown(output, 0, 0, mdTheme));
 		c.addChild(new Spacer(1));
 		if (r.skills?.length) {
-			c.addChild(new Text(fit(theme.fg("dim", `Skills: ${r.skills.join(", ")}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `Skills: ${r.skills.join(", ")}`), 0, 0));
 		}
 		if (r.skillsWarning) {
-			c.addChild(new Text(fit(theme.fg("warning", `Warning: ${r.skillsWarning}`)), 0, 0));
+			c.addChild(new Text(theme.fg("warning", `Warning: ${r.skillsWarning}`), 0, 0));
 		}
 		if (r.attemptedModels && r.attemptedModels.length > 1) {
-			c.addChild(new Text(fit(theme.fg("dim", `Fallbacks: ${r.attemptedModels.join(" → ")}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `Fallbacks: ${r.attemptedModels.join(" → ")}`), 0, 0));
 		}
-		c.addChild(new Text(fit(theme.fg("dim", formatUsage(r.usage, r.model))), 0, 0));
+		c.addChild(new Text(theme.fg("dim", formatUsage(r.usage, r.model)), 0, 0));
 		if (r.sessionFile) {
-			c.addChild(new Text(fit(theme.fg("dim", `Session: ${shortenPath(r.sessionFile)}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `Session: ${shortenPath(r.sessionFile)}`), 0, 0));
 		}
 
 		if ((!isRunning && r.artifactPaths) || r.truncation?.artifactPath) {
 			c.addChild(new Spacer(1));
 			if (!isRunning && r.artifactPaths) {
-				c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
 			}
 			if (r.truncation?.artifactPath) {
-				c.addChild(new Text(fit(theme.fg("dim", `Full output: ${shortenPath(r.truncation.artifactPath)}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `Full output: ${shortenPath(r.truncation.artifactPath)}`), 0, 0));
 			}
 		}
 		return c;
@@ -2421,13 +2347,10 @@ export function renderSubagentResult(
 	const itemTitle = multiLabel.itemTitle;
 
 	const w = getTermWidth() - 4;
-	const fit = (text: string) => (expanded ? text : truncLine(text, w));
 	const c = new Container();
 	c.addChild(
 		new Text(
-			fit(
-				`${icon} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr}`,
-			),
+			`${icon} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr}`,
 			0,
 			0,
 		),
@@ -2455,7 +2378,7 @@ export function renderSubagentResult(
 	for (const entry of renderEntries) {
 		if (entry.kind === "placeholder") {
 			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
-			c.addChild(new Text(fit(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`), 0, 0));
+			c.addChild(new Text(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`, 0, 0));
 			c.addChild(new Text(theme.fg(entry.status === "failed" ? "error" : "dim", `    status: ${entry.status}`), 0, 0));
 			if (entry.error) c.addChild(new Text(theme.fg("error", `    error: ${entry.error}`), 0, 0));
 			c.addChild(new Spacer(1));
@@ -2468,7 +2391,7 @@ export function renderSubagentResult(
 
 		if (!r) {
 			const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
-			c.addChild(new Text(fit(theme.fg("dim", `  ${pendingLabel}: ${agentName}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `  ${pendingLabel}: ${agentName}`), 0, 0));
 			c.addChild(new Text(theme.fg("dim", `    status: pending`), 0, 0));
 			c.addChild(new Spacer(1));
 			continue;
@@ -2498,69 +2421,65 @@ export function renderSubagentResult(
 			? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${modelDisplay}${stats}`
 			: `${statusIcon} ${stepLabel}: ${theme.bold(r.agent)}${modelDisplay}${stats}`;
 		const toolCallLines = getToolCallLines(r, expanded);
-		c.addChild(new Text(fit(stepHeader), 0, 0));
-		const ticketLine = foregroundTkTicketLine(r, theme, rRunning, w);
-		if (ticketLine) c.addChild(new Text(fit(ticketLine), 0, 0));
+		c.addChild(new Text(stepHeader, 0, 0));
+		const ticketLine = foregroundTkTicketLine(r, theme, rRunning);
+		if (ticketLine) c.addChild(new Text(ticketLine, 0, 0));
 
-		const taskMaxLen = Math.max(20, w - 12);
-		const taskPreview = expanded || r.task.length <= taskMaxLen ? r.task : `${r.task.slice(0, taskMaxLen)}...`;
-		c.addChild(new Text(fit(theme.fg("dim", `    task: ${taskPreview}`)), 0, 0));
+		c.addChild(new Text(theme.fg("dim", `    task: ${r.task}`), 0, 0));
 
 		const outputTarget = extractOutputTarget(r.task);
 		if (outputTarget) {
-			c.addChild(new Text(fit(theme.fg("dim", `    output: ${outputTarget}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `    output: ${outputTarget}`), 0, 0));
 		}
 
 		if (r.skills?.length) {
-			c.addChild(new Text(fit(theme.fg("dim", `    skills: ${r.skills.join(", ")}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `    skills: ${r.skills.join(", ")}`), 0, 0));
 		}
 		if (r.skillsWarning) {
-			c.addChild(new Text(fit(theme.fg("warning", `    Warning: ${r.skillsWarning}`)), 0, 0));
+			c.addChild(new Text(theme.fg("warning", `    Warning: ${r.skillsWarning}`), 0, 0));
 		}
 		if (r.attemptedModels && r.attemptedModels.length > 1) {
-			c.addChild(new Text(fit(theme.fg("dim", `    fallbacks: ${r.attemptedModels.join(" → ")}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `    fallbacks: ${r.attemptedModels.join(" → ")}`), 0, 0));
 		}
 
 		if (rRunning && liveProgress) {
 			if (liveProgress.skills?.length) {
-				c.addChild(new Text(fit(theme.fg("accent", `    skills: ${liveProgress.skills.join(", ")}`)), 0, 0));
+				c.addChild(new Text(theme.fg("accent", `    skills: ${liveProgress.skills.join(", ")}`), 0, 0));
 			}
 			const progressSnapshotNow = snapshotNowForProgress(liveProgress);
 			const toolLine = formatCurrentToolLine(liveProgress, w, expanded, progressSnapshotNow);
 			if (toolLine) {
-				c.addChild(new Text(fit(theme.fg("warning", `    > ${toolLine}`)), 0, 0));
+				c.addChild(new Text(theme.fg("warning", `    > ${toolLine}`), 0, 0));
 			}
 			const liveStatusLine = buildLiveStatusLine(liveProgress, progressSnapshotNow);
 			if (liveStatusLine) {
-				c.addChild(new Text(fit(theme.fg("accent", `    ${liveStatusLine}`)), 0, 0));
+				c.addChild(new Text(theme.fg("accent", `    ${liveStatusLine}`), 0, 0));
 			}
-			c.addChild(new Text(fit(theme.fg("accent", `    ${liveDetailHintText()}`)), 0, 0));
+			c.addChild(new Text(theme.fg("accent", `    ${liveDetailHintText()}`), 0, 0));
 			if (r.artifactPaths) {
-				c.addChild(new Text(fit(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
 			}
 			if (liveProgress.recentTools.length) {
 				for (const t of liveProgress.recentTools.slice(-3)) {
-					const maxArgsLen = Math.max(40, w - 30);
-					const argsPreview = expanded || t.args.length <= maxArgsLen ? t.args : `${t.args.slice(0, maxArgsLen)}...`;
-					c.addChild(new Text(fit(theme.fg("dim", `      ${t.tool}: ${argsPreview}`)), 0, 0));
+					c.addChild(new Text(theme.fg("dim", `      ${t.tool}: ${t.args}`), 0, 0));
 				}
 			}
 			const recentLines = liveProgress.recentOutput.slice(-5);
 			for (const line of recentLines) {
-				c.addChild(new Text(fit(theme.fg("dim", `      ${line}`)), 0, 0));
+				c.addChild(new Text(theme.fg("dim", `      ${line}`), 0, 0));
 			}
 		}
 
 		if (!rRunning && r.artifactPaths) {
-			c.addChild(new Text(fit(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `    artifacts: ${shortenPath(r.artifactPaths.outputPath)}`), 0, 0));
 		}
 		if (r.truncation?.artifactPath) {
-			c.addChild(new Text(fit(theme.fg("dim", `    full output: ${shortenPath(r.truncation.artifactPath)}`)), 0, 0));
+			c.addChild(new Text(theme.fg("dim", `    full output: ${shortenPath(r.truncation.artifactPath)}`), 0, 0));
 		}
 
 		if (expanded && !rRunning) {
 			for (const line of toolCallLines) {
-				c.addChild(new Text(fit(theme.fg("muted", `      ${line}`)), 0, 0));
+				c.addChild(new Text(theme.fg("muted", `      ${line}`), 0, 0));
 			}
 			if (toolCallLines.length) c.addChild(new Spacer(1));
 		}
@@ -2570,7 +2489,7 @@ export function renderSubagentResult(
 
 	if (d.artifacts) {
 		c.addChild(new Spacer(1));
-		c.addChild(new Text(fit(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`)), 0, 0));
+		c.addChild(new Text(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`), 0, 0));
 	}
 	return c;
 }

--- a/extensions/subagents/test/integration/foreground-result-size.test.ts
+++ b/extensions/subagents/test/integration/foreground-result-size.test.ts
@@ -190,7 +190,7 @@ describe("foreground result payload compaction", {
 		assert.ok(step?.progress === undefined, "completed foreground results should not inline full progress objects");
 		assert.ok(step?.toolCalls?.length, "completed foreground results should preserve compact tool-call summaries");
 		assert.equal(step?.toolCalls?.[0]?.text, "write /tmp/huge-report.md");
-		assert.equal(step?.toolCalls?.[0]?.expandedText, "write /tmp/huge-report.md");
+		assert.equal(step?.toolCalls?.[0]?.expandedText, undefined);
 
 		const payloadSize = JSON.stringify(result).length;
 		assert.ok(payloadSize < 80_000, `expected compact foreground payload, got ${payloadSize} bytes`);

--- a/extensions/subagents/test/integration/render-fork-badge.test.ts
+++ b/extensions/subagents/test/integration/render-fork-badge.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { finalizeSingleOutput } from "../../src/runs/shared/single-output.ts";
 import { liveDetailShortcutDisplay } from "../../src/shared/subagent-shortcuts.ts";
 import { truncateOutput } from "../../src/shared/types.ts";
@@ -222,8 +223,9 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(text, /Interrupt requested for async run abc123\./);
 	});
 
-	it("collapses multiline structured management output to a first-line summary", () => {
-		const output = `\n${"Managed agents: ".padEnd(220, "x")}\n- reviewer\n- writer`;
+	it("wraps the complete first-line summary for multiline structured management output", () => {
+		const firstLine = "Managed agents: ".padEnd(220, "x");
+		const output = `\n${firstLine}\n- reviewer\n- writer`;
 		const widget = renderSubagentResult!(
 			{
 				content: [{ type: "text", text: output }],
@@ -235,7 +237,9 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const lines = widget.render(120).map((line) => line.trimEnd());
 		assert.match(lines[0]!, /^\[fork\] Managed agents:/);
-		assert.match(lines[0]!, /…$/);
+		assert.ok(lines.every((line) => visibleWidth(line) <= 120));
+		assert.ok(lines.join("").replace(/\s/g, "").includes(`[fork] ${firstLine} · 4 lines`.replace(/\s/g, "")));
+		assert.doesNotMatch(lines.join("\n"), /\.\.\.|…/);
 		const hintLineIndex = lines.findIndex((line) => line.includes(expandHint));
 		assert.ok(hintLineIndex > 0);
 		assert.doesNotMatch(lines[0]!, /reviewer/);

--- a/extensions/subagents/test/integration/render-widget.test.ts
+++ b/extensions/subagents/test/integration/render-widget.test.ts
@@ -85,10 +85,17 @@ function widgetContent(line: string): string {
 	return line.slice(1).trimEnd();
 }
 
-function assertWidgetContentFits(line: string, width: number): void {
+function wrappedText(lines: string[], padded = false): string {
+	return lines
+		.map((line) => (padded ? widgetContent(line) : line))
+		.join("")
+		.replace(/\s/g, "");
+}
+
+function assertWrappedSource(lines: string[], source: string, padded = false): void {
 	assert.ok(
-		visibleWidth(widgetContent(line)) <= Math.max(1, width - 2),
-		`widget content should fit ${Math.max(1, width - 2)} columns: ${JSON.stringify(line)}`,
+		wrappedText(lines, padded).includes(source.replace(/\s/g, "")),
+		`wrapped output should preserve ${JSON.stringify(source)}`,
 	);
 }
 
@@ -934,11 +941,13 @@ describe("subagent async widget rendering", () => {
 				},
 			]);
 
-			const row = renderWidgetLines(ui.widgets.at(-1), 60).find((line) => line.includes("Agent 1/3")) ?? "";
+			const lines = renderWidgetLines(ui.widgets.at(-1), 60);
+			const row = lines.find((line) => line.includes("Agent 1/3")) ?? "";
 			assert.match(row, /Agent 1\/3: reviewer · running/);
-			assert.match(row, /Wining/);
-			assert.match(row.trimEnd(), /active now$/);
-			assertWidgetContentFits(row, 60);
+			assertWrappedSource(lines, whimsicalThinkingPhrase(19));
+			assertWrappedSource(lines, "active now");
+			for (const line of lines)
+				assert.ok(visibleWidth(line) <= 58, `parallel row should fit 58 columns: ${JSON.stringify(line)}`);
 		});
 		resetWidgetLayout();
 	});
@@ -946,8 +955,12 @@ describe("subagent async widget rendering", () => {
 	it("keeps compactSingleWidgetLines health identity in 40/50-column parallel rows", () => {
 		const now = 20_000;
 		const healthCases = [
-			{ state: "needs_attention", turnCount: 27, warning: /no activity for/ },
-			{ state: "active_long_running", turnCount: 28, warning: /active but lon/ },
+			{ state: "needs_attention", turnCount: 27, warning: "no activity for 5s" },
+			{
+				state: "active_long_running",
+				turnCount: 28,
+				warning: "active but long-running · last activity 5s ago",
+			},
 		] as const;
 
 		for (const width of [40, 50]) {
@@ -981,8 +994,8 @@ describe("subagent async widget rendering", () => {
 					const harnessLines = renderWidgetHarnessLines(ui.widgets.at(-1));
 					const harnessRow = harnessLines.find((line) => line.includes("Agent 1/4")) ?? "";
 					assert.match(harnessRow, /Agent 1\/4/);
-					assert.match(harnessRow, warning);
-					assert.doesNotMatch(harnessRow, new RegExp(escapeRegExp(whimsicalThinkingPhrase(turnCount))));
+					assertWrappedSource(harnessLines, warning);
+					assert.doesNotMatch(harnessLines.join(""), new RegExp(escapeRegExp(whimsicalThinkingPhrase(turnCount))));
 					for (const line of harnessLines)
 						assert.ok(
 							visibleWidth(line) <= width - 2,
@@ -997,8 +1010,8 @@ describe("subagent async widget rendering", () => {
 					);
 					const realRow = realLines.find((line) => line.includes("Agent 1/4")) ?? "";
 					assert.match(realRow, /Agent 1\/4/);
-					assert.match(realRow, warning);
-					assert.doesNotMatch(realRow, new RegExp(escapeRegExp(whimsicalThinkingPhrase(turnCount))));
+					assertWrappedSource(realLines, warning, true);
+					assert.doesNotMatch(realLines.join(""), new RegExp(escapeRegExp(whimsicalThinkingPhrase(turnCount))));
 					for (const line of realLines)
 						assert.equal(
 							visibleWidth(line),
@@ -1011,11 +1024,11 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
-	it("keeps progressiveJobLine identity with compact health warnings at 40/50 columns", () => {
+	it("wraps complete progressive health warnings at 40/50 columns", () => {
 		const now = 20_000;
 		for (const width of [40, 50]) {
 			resetWidgetLayout();
-			withStdoutSize(22, width, () => {
+			withStdoutSize(24, width, () => {
 				const ui = createUiContext();
 				renderWidget(ui.ctx as never, [
 					{
@@ -1044,13 +1057,26 @@ describe("subagent async widget rendering", () => {
 						agents: ["editor"],
 						currentTool: "edit",
 					},
+					{
+						asyncId: "progressive-write",
+						asyncDir: "/tmp/progressive-write",
+						status: "running",
+						mode: "single",
+						agents: ["writer"],
+						currentTool: "write",
+					},
 				]);
 
 				const harnessLines = renderWidgetHarnessLines(ui.widgets.at(-1));
 				const harnessRow = harnessLines.find((line) => line.includes("health-job")) ?? "";
 				assert.match(harnessRow, /health-job/);
-				assert.match(harnessRow, /active but long/);
-				assertWidgetContentFits(harnessRow, width);
+				assertWrappedSource(harnessLines, "active but long-running · last activity 5s ago");
+				assert.match(harnessLines.join(""), /\+\d+ more/);
+				for (const line of harnessLines)
+					assert.ok(
+						visibleWidth(line) <= width - 2,
+						`harness row should fit ${width - 2} columns: ${JSON.stringify(line)}`,
+					);
 
 				const realLines = renderWithRealPiTui(harnessLines, width);
 				assert.equal(
@@ -1060,7 +1086,7 @@ describe("subagent async widget rendering", () => {
 				);
 				const realRow = realLines.find((line) => line.includes("health-job")) ?? "";
 				assert.match(realRow, /health-job/);
-				assert.match(realRow, /active but long/);
+				assertWrappedSource(realLines, "active but long-running · last activity 5s ago", true);
 				for (const line of realLines)
 					assert.equal(
 						visibleWidth(line),
@@ -1075,8 +1101,8 @@ describe("subagent async widget rendering", () => {
 	it("keeps widgetParallelAgentDetails identity with compact health warnings at 40/50 columns", () => {
 		const now = 20_000;
 		const healthCases = [
-			{ state: "needs_attention", warning: /no activity/ },
-			{ state: "active_long_running", warning: /active but lon/ },
+			{ state: "needs_attention", warning: "no activity for 5s" },
+			{ state: "active_long_running", warning: "active but long-running · last activity 5s ago" },
 		] as const;
 		for (const width of [40, 50]) {
 			for (const { state, warning } of healthCases) {
@@ -1114,7 +1140,7 @@ describe("subagent async widget rendering", () => {
 				);
 				const harnessRow = lines.find((line) => line.includes("Agent 1/4")) ?? "";
 				assert.match(harnessRow, /Agent 1\/4/);
-				assert.match(harnessRow, warning);
+				assertWrappedSource(lines, warning);
 				for (const line of lines)
 					assert.ok(
 						visibleWidth(line) <= width - 2,
@@ -1129,7 +1155,7 @@ describe("subagent async widget rendering", () => {
 				);
 				const realRow = realLines.find((line) => line.includes("Agent 1/4")) ?? "";
 				assert.match(realRow, /Agent 1\/4/);
-				assert.match(realRow, warning);
+				assertWrappedSource(realLines, warning, true);
 				for (const line of realLines)
 					assert.equal(
 						visibleWidth(line),
@@ -1191,7 +1217,7 @@ describe("subagent async widget rendering", () => {
 		}
 	});
 
-	it("keeps crowded progressive and single-line layouts within real 40-column Text rows", () => {
+	it("locks crowded widget rows at the reviewer narrow-width probes", () => {
 		const now = 20_000;
 		const jobs = Array.from({ length: 8 }, (_, index) => ({
 			asyncId: `crowded-width-${index}`,
@@ -1203,34 +1229,47 @@ describe("subagent async widget rendering", () => {
 			updatedAt: now,
 		}));
 
-		for (const { rows, expectedRows, description } of [
-			{ rows: 22, expectedRows: 3, description: "progressive" },
-			{ rows: 20, expectedRows: 1, description: "single-line" },
+		for (const { rows, columns, expectedRows, description, jobs: probeJobs } of [
+			{ rows: 22, columns: 20, expectedRows: 3, description: "progressive", jobs },
+			{ rows: 6, columns: 20, expectedRows: 1, description: "single-line", jobs: jobs.slice(0, 6) },
 		] as const) {
 			resetWidgetLayout();
-			withStdoutSize(rows, 40, () => {
+			withStdoutSize(rows, columns, () => {
 				const ui = createUiContext();
-				renderWidget(ui.ctx as never, jobs);
+				renderWidget(ui.ctx as never, probeJobs);
 				const harnessLines = renderWidgetHarnessLines(ui.widgets.at(-1));
 				assert.equal(harnessLines.length, expectedRows, `${description} harness row count`);
 				for (const line of harnessLines)
 					assert.ok(
-						visibleWidth(line) <= 38,
-						`${description} harness line should fit 38 columns: ${JSON.stringify(line)}`,
+						visibleWidth(line) <= columns - 2,
+						`${description} harness line should fit ${columns - 2} columns: ${JSON.stringify(line)}`,
 					);
 				if (description === "progressive") assert.match(harnessLines.join("\n"), /\+\d+ more/);
-				if (description === "single-line") assert.match(harnessLines[0] ?? "", /subagents/);
+				if (description === "single-line") assert.match(harnessLines[0] ?? "", /(?:running|subagents)/);
 
-				const realLines = renderWithRealPiTui(harnessLines, 40);
+				const realLines = renderWithRealPiTui(harnessLines, columns);
 				assert.equal(
 					realLines.length,
 					harnessLines.length,
 					`${description} real pi-tui row count must match the harness`,
 				);
 				for (const line of realLines)
-					assert.equal(visibleWidth(line), 40, `${description} real pi-tui row should be padded to 40 columns`);
+					assert.equal(
+						visibleWidth(line),
+						columns,
+						`${description} real pi-tui row should be padded to ${columns} columns`,
+					);
 			});
 		}
+
+		resetWidgetLayout();
+		withStdoutSize(22, 120, () => {
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, jobs);
+			const normalWidthText = renderWidgetHarnessLines(ui.widgets.at(-1)).join("\n");
+			assert.match(normalWidthText, /Async agents · 8 agents running/);
+			assert.match(normalWidthText, /crowded-agent-with-a-long-name-0/);
+		});
 		resetWidgetLayout();
 	});
 
@@ -1297,6 +1336,43 @@ describe("subagent async widget rendering", () => {
 					assert.equal(visibleWidth(line), width, `expanded real pi-tui row should be padded to ${width} columns`);
 			});
 		}
+		resetWidgetLayout();
+	});
+
+	it("reserves every physical row of a wrapped hidden-line label", () => {
+		resetWidgetLayout();
+		withStdoutSize(22, 20, () => {
+			const ui = createUiContext();
+			const liveDetailController = createSubagentLiveDetailController(true);
+			renderWidget(
+				ui.ctx as never,
+				[
+					{
+						asyncId: "expanded-hidden-label",
+						asyncDir: "/tmp/expanded-hidden-label",
+						status: "running",
+						mode: "single",
+						agents: ["worker"],
+						stepsTotal: 1,
+						steps: [
+							{
+								index: 0,
+								agent: "worker",
+								status: "running",
+								recentTools: [],
+								recentOutput: Array.from({ length: 5 }, (_, index) => `output-${index}-${"long-value-".repeat(8)}`),
+							},
+						],
+					},
+				],
+				liveDetailController,
+			);
+
+			const lines = renderWidgetHarnessLines(ui.widgets.at(-1));
+			assert.equal(lines.length, 12);
+			assert.match(wrappedText(lines), /…\d+live-detaillineshidden/);
+			assert.ok(lines.every((line) => visibleWidth(line) <= 18));
+		});
 		resetWidgetLayout();
 	});
 
@@ -1488,10 +1564,10 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
-	it("prioritizes freshness over a long phrase in 40/50/60-column progressive rows", () => {
+	it("wraps complete thinking and freshness text in 40/50/60-column progressive rows", () => {
 		for (const width of [40, 50, 60]) {
 			resetWidgetLayout();
-			withStdoutSize(22, width, () => {
+			withStdoutSize(24, width, () => {
 				const now = 20_000;
 				const ui = createUiContext();
 				renderWidget(ui.ctx as never, [
@@ -1521,17 +1597,31 @@ describe("subagent async widget rendering", () => {
 						agents: ["editor"],
 						currentTool: "edit",
 					},
+					{
+						asyncId: "run-write",
+						asyncDir: "/tmp/run-write",
+						status: "running",
+						mode: "single",
+						agents: ["writer"],
+						currentTool: "write",
+					},
 				]);
 
 				const lines = renderWidgetLines(ui.widgets.at(-1), width);
 				const row = lines.find((line) => line.includes("thinker")) ?? "";
 				assert.match(row, /thinker · running/);
-				assert.match(row.trimEnd(), /active 2s ago$/);
-				assertWidgetContentFits(row, width);
+				assertWrappedSource(lines, whimsicalThinkingPhrase(19));
+				assertWrappedSource(lines, "active 2s ago");
+				assert.match(lines.join(""), /\+\d+ more/);
+				for (const line of lines)
+					assert.ok(
+						visibleWidth(line) <= width - 2,
+						`progressive row should fit ${width - 2} columns: ${JSON.stringify(line)}`,
+					);
 				assert.equal(
-					lines.filter((line) => line.includes("active 2s ago")).length,
+					wrappedText(lines).match(/active2sago/g)?.length,
 					1,
-					`freshness must stay on the thinker row at ${width} columns`,
+					`freshness must appear once at ${width} columns`,
 				);
 			});
 		}
@@ -1578,8 +1668,9 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
-	it("sanitizes unsafe direct tk ticket widget state before rendering", () => {
-		const text = buildWidgetLines(
+	it("sanitizes and wraps complete direct tk ticket widget state", () => {
+		const safeTitle = `Unsafe title now ${"x".repeat(120)}`;
+		const lines = buildWidgetLines(
 			[
 				{
 					asyncId: "run-unsafe-ticket",
@@ -1592,11 +1683,11 @@ describe("subagent async widget rendering", () => {
 			],
 			theme,
 			90,
-		).join("\n");
+		);
 
-		assert.match(text, /working on tk: Unsafe title now x+/);
-		assert.match(text, /working on tk: .*…/);
-		assert.doesNotMatch(text, /\u009b|\u001b\[31m/);
+		assertWrappedSource(lines, safeTitle);
+		assert.ok(lines.every((line) => visibleWidth(line) <= 88));
+		assert.doesNotMatch(lines.join(""), /…|\u009b|\u001b\[31m/);
 	});
 
 	it("uses a single collapsed widget line when the terminal has almost no spare rows", () => {
@@ -1727,8 +1818,9 @@ describe("subagent async widget rendering", () => {
 
 		const row = lines.find((line) => line.includes("Agent 1/2")) ?? "";
 		assert.match(row, /Agent 1\/2: reviewer/);
-		assert.match(row.trimEnd(), /active 2s ago$/);
-		assertWidgetContentFits(row, 60);
+		assertWrappedSource(lines, whimsicalThinkingPhrase(19));
+		assertWrappedSource(lines, "active 2s ago");
+		assert.ok(lines.every((line) => visibleWidth(line) <= 58));
 	});
 
 	it("shows model and thinking for active async widget rows", () => {
@@ -2292,6 +2384,49 @@ describe("subagent async widget rendering", () => {
 
 		assert.deepEqual(second, first);
 		assert.equal(firstGrapheme(first[1] ?? ""), firstGrapheme(second[1] ?? ""));
+	});
+
+	it("wraps complete long arguments and output in narrow compact and expanded widgets", () => {
+		const width = 42;
+		const longArgs = `--path=${"src/deep/".repeat(14)}report.json --query=${"needle-".repeat(18)}`;
+		const longOutput = `recent-output-${"value-".repeat(18)}`;
+		const longTicket = `Wrap ${"complete-ticket-title-".repeat(10)}`;
+		const job = {
+			asyncId: "narrow-wrap",
+			asyncDir: "/tmp/narrow-wrap",
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			stepsTotal: 1,
+			updatedAt: 20_000,
+			tkTicket: { id: "tlh-narrow", title: longTicket },
+			steps: [
+				{
+					index: 0,
+					agent: "worker",
+					status: "running",
+					currentTool: "grep",
+					currentToolArgs: longArgs,
+					recentTools: [{ tool: "grep", args: longArgs }],
+					recentOutput: [longOutput],
+				},
+			],
+		};
+
+		const compact = buildWidgetLines([job], theme, width, false);
+		assert.ok(compact.length > 3);
+		assert.ok(compact.every((line) => visibleWidth(line) <= width - 2));
+		assertWrappedSource(compact, longArgs);
+		assertWrappedSource(compact, longTicket);
+		assert.doesNotMatch(compact.join(""), /…|\.\.\./);
+
+		const expanded = buildWidgetLines([job], theme, width, true);
+		assert.ok(expanded.length > compact.length);
+		assert.ok(expanded.every((line) => visibleWidth(line) <= width - 2));
+		assertWrappedSource(expanded, longArgs);
+		assertWrappedSource(expanded, longOutput);
+		assertWrappedSource(expanded, longTicket);
+		assert.doesNotMatch(expanded.join(""), /…|\.\.\./);
 	});
 
 	it("does not animate queued-only widgets", async () => {

--- a/extensions/subagents/test/integration/slash-live-state.test.ts
+++ b/extensions/subagents/test/integration/slash-live-state.test.ts
@@ -117,11 +117,13 @@ describe("slash live state", { skip: !available ? "slash-live-state.ts not impor
 
 		const collapsed = component.render(180).join("\n");
 		assert.match(collapsed, /Ctrl\+Shift\+D/);
-		assert.doesNotMatch(collapsed, new RegExp(escapeRegExp(longArgs)));
+		assert.match(collapsed, new RegExp(escapeRegExp(longArgs)));
+		assert.doesNotMatch(collapsed, /Task: inspect the active slash result/);
 
 		assert.equal(controller.toggle(), true);
 		const expanded = component.render(180).join("\n");
 		assert.match(expanded, new RegExp(escapeRegExp(longArgs)));
+		assert.match(expanded, /Task: inspect the active slash result/);
 	});
 
 	it("keeps finalized slash results on the live-detail controller", () => {

--- a/extensions/subagents/test/support/ts-loader.mjs
+++ b/extensions/subagents/test/support/ts-loader.mjs
@@ -3,32 +3,23 @@
 // imports and the actual .ts files on disk.
 
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const renderPiCodingAgentShim = `
 export function getMarkdownTheme() { return {}; }
 export function keyText(keybinding) { return keybinding === "app.tools.expand" ? "configured-expand-key" : ""; }
 `;
 
-const renderPiTuiShim = `
-function wrapText(text, width) {
-  if (!width || width <= 0) return [text];
-  const lines = [];
-  for (const rawLine of String(text).split("\\n")) {
-    if (rawLine.length === 0) {
-      lines.push("");
-      continue;
-    }
-    for (let i = 0; i < rawLine.length; i += width) {
-      lines.push(rawLine.slice(i, i + width));
-    }
-  }
-  return lines;
-}
+const realPiTuiUrl = pathToFileURL(createRequire(import.meta.url).resolve("@earendil-works/pi-tui")).href;
 
-export function visibleWidth(text) {
-  return String(text).length;
+const renderPiTuiShim = `
+import { visibleWidth, wrapTextWithAnsi } from ${JSON.stringify(realPiTuiUrl)};
+export { visibleWidth, wrapTextWithAnsi };
+
+function wrapText(text, width) {
+  return wrapTextWithAnsi(String(text), Math.max(1, width || 1));
 }
 
 export class Text {

--- a/extensions/subagents/test/unit/child-transcript.test.ts
+++ b/extensions/subagents/test/unit/child-transcript.test.ts
@@ -134,6 +134,26 @@ describe("createChildTranscriptWriter", () => {
 		assert.equal(records[2]!.toolName, "bash");
 	});
 
+	it("bounds only persisted tool argument previews with an explicit storage marker", () => {
+		const dir = tmpDir();
+		const transcriptPath = path.join(dir, "transcript.jsonl");
+		const writer = createChildTranscriptWriter({
+			transcriptPath,
+			source: "foreground",
+			runId: "run-args-preview",
+			agent: "worker",
+			cwd: "/repo",
+		});
+		const command = `npm run validate -- ${"x".repeat(40_000)}`;
+		writer.writeChildEvent({ type: "tool_execution_start", toolName: "bash", args: { command } });
+
+		const argsPreview = String(readRecords(transcriptPath)[0]!.argsPreview);
+		assert.ok(argsPreview.length <= 32 * 1024);
+		assert.match(argsPreview, /\[truncated for child transcript storage\]$/);
+		assert.ok(argsPreview.startsWith("npm run validate -- "));
+		assert.ok(!argsPreview.includes(command), "the persisted preview should be bounded at the storage boundary");
+	});
+
 	it("skips blank stdout/stderr lines and splits multi-line stderr text", () => {
 		const dir = tmpDir();
 		const transcriptPath = path.join(dir, "transcript.jsonl");

--- a/extensions/subagents/test/unit/foreground-tool-call-compaction.test.ts
+++ b/extensions/subagents/test/unit/foreground-tool-call-compaction.test.ts
@@ -28,20 +28,35 @@ describe("foreground tool-call compaction", () => {
 		});
 
 		assert.equal(result.messages, undefined);
-		assert.deepEqual(result.toolCalls, [
-			{
-				text: "write /tmp/report.md",
-				expandedText: "write /tmp/report.md",
-			},
-		]);
+		assert.deepEqual(result.toolCalls, [{ text: "write /tmp/report.md" }]);
 	});
 
-	it("keeps expanded generic tool-call previews bounded", () => {
-		const collapsed = formatToolCall("custom", { payload: "x".repeat(500) });
-		const expanded = formatToolCall("custom", { payload: "x".repeat(500) }, true);
+	it("preserves complete generic tool-call payloads for both views", () => {
+		const payload = "x".repeat(500);
+		const collapsed = formatToolCall("custom", { payload });
+		const expanded = formatToolCall("custom", { payload }, true);
 
-		assert.ok(expanded.length > collapsed.length);
-		assert.ok(expanded.length < 200);
+		assert.equal(expanded, collapsed);
+		assert.match(expanded, new RegExp(payload));
+	});
+
+	it("stores a duplicate tool-call string only once while retaining distinct expanded text", () => {
+		const result = compactForegroundResult({
+			agent: "tester",
+			task: "run checks",
+			exitCode: 0,
+			messages: [],
+			toolCalls: [
+				{ text: "same complete call", expandedText: "same complete call" },
+				{ text: "compact call", expandedText: "expanded complete call" },
+			],
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+		});
+
+		assert.deepEqual(result.toolCalls, [
+			{ text: "same complete call" },
+			{ text: "compact call", expandedText: "expanded complete call" },
+		]);
 	});
 
 	it("does not keep an empty toolCalls array after compaction", () => {
@@ -66,19 +81,49 @@ describe("foreground tool-call compaction", () => {
 		);
 	});
 
-	it("formats fetch_content urls clearly", () => {
+	it("preserves complete long command arguments", () => {
+		const command = `npm run validate -- --filter=${"x".repeat(100)}`;
+		assert.equal(extractToolArgsPreview({ command }), command);
+		assert.equal(formatToolCall("bash", { command }), `$ ${command}`);
+	});
+
+	it("preserves complete long path arguments", () => {
+		const filePath = `/workspace/${"nested/".repeat(16)}report.json`;
+		assert.equal(extractToolArgsPreview({ path: filePath }), filePath);
+	});
+
+	it("preserves complete URL arguments and array summaries", () => {
+		const url = "https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging";
+		assert.equal(extractToolArgsPreview({ url }), url);
 		assert.equal(
 			extractToolArgsPreview({
-				urls: [
-					"https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging",
-					"https://example.com/backup",
-				],
+				urls: [url, "https://example.com/backup"],
 			}),
-			"https://developer.chrome.com/docs/extensions/develop/conc...",
+			`${url} (+1 more)`,
 		);
 	});
 
-	it("falls back to generic array previews", () => {
-		assert.equal(extractToolArgsPreview({ ids: ["run-a", "run-b", "run-c"] }), "ids=run-a (+2 more)");
+	it("preserves complete prompt arguments", () => {
+		const prompt = `Investigate this behavior and report every relevant detail: ${"context ".repeat(20)}`;
+		assert.equal(extractToolArgsPreview({ prompt }), prompt);
+	});
+
+	it("preserves complete workflow arguments", () => {
+		const workflow = `review-${"phase-".repeat(20)}`;
+		assert.equal(extractToolArgsPreview({ workflow }), `workflow=${workflow}`);
+	});
+
+	it("preserves complete MCP tool arguments", () => {
+		const mcpArgs = `{"query":"${"result-".repeat(20)}"}`;
+		assert.equal(extractToolArgsPreview({ server: "docs", tool: "search", args: mcpArgs }), `docs/search ${mcpArgs}`);
+	});
+
+	it("preserves complete fallback values", () => {
+		const value = "custom-" + "value-".repeat(20);
+		assert.equal(extractToolArgsPreview({ custom: value }), `custom=${value}`);
+		assert.equal(
+			extractToolArgsPreview({ ids: [`run-${"long-".repeat(20)}`, "run-b", "run-c"] }),
+			`ids=run-${"long-".repeat(20)} (+2 more)`,
+		);
 	});
 });

--- a/extensions/subagents/test/unit/notify-renderer.test.ts
+++ b/extensions/subagents/test/unit/notify-renderer.test.ts
@@ -151,6 +151,96 @@ describe("native completion notification renderer", () => {
 		);
 	});
 
+	it("renders wrapped control notices with a connected top border", () => {
+		const script = String.raw`
+			import { createRequire } from "node:module";
+			import { pathToFileURL } from "node:url";
+			import registerSubagentExtension from "./src/extension/index.ts";
+			import { SUBAGENT_CONTROL_MESSAGE_TYPE } from "./src/extension/control-notices.ts";
+			const piCodingAgentEntry = import.meta.resolve("@earendil-works/pi-coding-agent");
+			const piCodingAgentRequire = createRequire(piCodingAgentEntry);
+			const piTuiEntry = piCodingAgentRequire.resolve("@earendil-works/pi-tui");
+			const { visibleWidth } = await import(pathToFileURL(piTuiEntry).href);
+			const events = { on() { return () => {}; }, emit() {} };
+			let controlRenderer;
+			const fakePi = new Proxy({
+				events,
+				on() {},
+				registerTool() {},
+				registerCommand() {},
+				registerShortcut() {},
+				registerMessageRenderer(type, renderer) {
+					if (type === SUBAGENT_CONTROL_MESSAGE_TYPE) controlRenderer = renderer;
+				},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			if (!controlRenderer) throw new Error("control renderer was not registered");
+
+			const theme = {
+				fg(_name, text) { return text; },
+				bg(_name, text) { return text; },
+				bold(text) { return text; },
+			};
+			const width = 38;
+			const agent = "worker-with-a-long-renderer-name";
+			const lines = controlRenderer({
+				content: "worker needs attention",
+				details: {
+					source: "foreground",
+					event: {
+						type: "needs_attention",
+						to: "needs_attention",
+						ts: 1,
+						runId: "run-control",
+						agent,
+						index: 0,
+						message: "worker needs attention",
+						reason: "idle",
+					},
+				},
+			}, { expanded: false }, theme).render(width);
+
+			if (lines.length < 4) throw new Error("expected a wrapped control notice: " + lines.join("\\n"));
+			if (!lines.every((line) => visibleWidth(line) === width)) {
+				throw new Error("every physical line must fit and pad to width " + width + ": " + lines.join("\\n"));
+			}
+			if (!/^╭.*─+╮$/.test(lines[0])) {
+				throw new Error("top header must connect to ╮ with dashes: " + lines[0]);
+			}
+			const middle = lines.slice(1, -1);
+			if (!middle.every((line) => /^│.*│$/.test(line) && !line.includes("─"))) {
+				throw new Error("continuation and body rows must use space padding: " + middle.join("\\n"));
+			}
+			if (!middle.some((line) => / +│$/.test(line))) {
+				throw new Error("expected visible space padding before a continuation/body border");
+			}
+			if (!lines.join("").replace(/\\s/g, "").includes(agent.replace(/\\s/g, ""))) {
+				throw new Error("wrapped header lost the agent name: " + lines.join("\\n"));
+			}
+		`;
+		const env = { ...process.env };
+		delete env[SUBAGENT_CHILD_ENV];
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env, stdio: "pipe" },
+		);
+	});
+
 	it("bounds the display of grouped notices and any other unparsed content at the render-time display cap", () => {
 		// Defect 3: the renderer parser only matches the singular-completion header regex.
 		// Grouped notices use 'Background tasks completed (N):' which does not match, so

--- a/extensions/subagents/test/unit/recent-progress.test.ts
+++ b/extensions/subagents/test/unit/recent-progress.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { appendRecentProgressItem, RECENT_PROGRESS_ITEM_LIMIT } from "../../src/shared/recent-progress.ts";
+
+test("recent progress storage keeps the newest 50 exact tool records", () => {
+	const retained: Array<{ tool: string; args: string; endMs: number }> = [];
+	const records = Array.from({ length: RECENT_PROGRESS_ITEM_LIMIT + 25 }, (_, index) => ({
+		tool: `tool-${index}`,
+		args: `--exact-${index}=${"argument-value-".repeat(200)}tail-${index}`,
+		endMs: index,
+	}));
+
+	for (const record of records) appendRecentProgressItem(retained, record);
+
+	assert.equal(retained.length, RECENT_PROGRESS_ITEM_LIMIT);
+	assert.strictEqual(retained[0], records[25]);
+	assert.strictEqual(retained.at(-1), records.at(-1));
+	assert.equal(retained[0]?.args, records[25]?.args);
+	assert.equal(retained.at(-1)?.args, records.at(-1)?.args);
+});

--- a/extensions/subagents/test/unit/render-helpers.test.ts
+++ b/extensions/subagents/test/unit/render-helpers.test.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { row } from "../../src/tui/render-helpers.ts";
+import { renderFooter, renderHeader, row } from "../../src/tui/render-helpers.ts";
 import { renderSubagentResult } from "../../src/tui/render.ts";
 
 const theme = {
@@ -22,6 +23,35 @@ function componentText(component: unknown): string {
 	return "";
 }
 
+function assertWrappedSource(lines: string[], source: string): void {
+	assert.ok(
+		stripVTControlCharacters(lines.join("")).replace(/\s/g, "").includes(source.replace(/\s/g, "")),
+		`wrapped output should preserve ${JSON.stringify(source)}`,
+	);
+}
+
+function restoreDescriptor(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	Reflect.deleteProperty(target, key);
+}
+
+function withStdoutSize<T>(rows: number, columns: number, fn: () => T): T {
+	const stdout = process.stdout as NodeJS.WriteStream & { rows?: number; columns?: number };
+	const rowsDescriptor = Object.getOwnPropertyDescriptor(stdout, "rows");
+	const columnsDescriptor = Object.getOwnPropertyDescriptor(stdout, "columns");
+	Object.defineProperty(stdout, "rows", { configurable: true, value: rows });
+	Object.defineProperty(stdout, "columns", { configurable: true, value: columns });
+	try {
+		return fn();
+	} finally {
+		restoreDescriptor(stdout, "rows", rowsDescriptor);
+		restoreDescriptor(stdout, "columns", columnsDescriptor);
+	}
+}
+
 function result(agent: string, output: string) {
 	return {
 		agent,
@@ -33,38 +63,78 @@ function result(agent: string, output: string) {
 	};
 }
 
-test("row clips content to the available width", () => {
-	const rendered = row("abcdef", 6, theme as any);
-	assert.equal(visibleWidth(rendered), 6);
+test("row wraps long content without clipping source text", () => {
+	const rendered = row("abcdef", 6, theme as any).split("\n");
+	assert.ok(rendered.length > 1);
+	assert.equal(
+		rendered.map(visibleWidth).every((width) => width === 6),
+		true,
+	);
+	assert.equal(rendered.map((line) => line.replace(/[│ ]/g, "")).join(""), "abcdef");
+	assert.doesNotMatch(rendered.join(""), /…|\.\.\./);
 });
 
-test("row normalizes multiline content before clipping", () => {
-	const rendered = row("bash failed: line 1\nline 2\tvalue", 20, theme as any);
-	assert.equal(visibleWidth(rendered), 20);
-	assert.doesNotMatch(rendered, /[\r\n\t]/);
+test("row preserves content at widths too narrow for borders", () => {
+	const rendered = row("abcdef", 2, theme as any).split("\n");
+	assert.ok(rendered.every((line) => visibleWidth(line) <= 2));
+	assertWrappedSource(rendered, "abcdef");
+	assert.equal(row("abcdef", 0, theme as any), "");
+});
+
+test("row wraps explicit newlines and normalizes tabs", () => {
+	const rendered = row("bash failed: line 1\nline 2\tvalue", 20, theme as any).split("\n");
+	assert.ok(rendered.length >= 2);
+	assert.equal(
+		rendered.map(visibleWidth).every((width) => width === 20),
+		true,
+	);
+	assert.doesNotMatch(rendered.join(""), /[\r\t]/);
+	const normalized = rendered.join("").replace(/[│ ]/g, "");
+	assert.match(normalized, /bashfailed:line1/);
+	assert.match(normalized, /line2value/);
 });
 
 test("row keeps styled multiline content within the available width", () => {
-	const rendered = row("\u001b[31merror line 1\nline 2\tvalue\u001b[39m", 18, theme as any);
-	assert.equal(visibleWidth(rendered), 18);
-	assert.doesNotMatch(rendered, /[\r\n\t]/);
+	const rendered = row("\u001b[31merror line 1\nline 2\tvalue\u001b[39m", 18, theme as any).split("\n");
+	assert.equal(
+		rendered.map(visibleWidth).every((width) => width === 18),
+		true,
+	);
+	assert.doesNotMatch(rendered.join(""), /[\r\n\t]/);
+	const normalized = rendered.join("").replace(/[│ ]/g, "");
+	assert.match(normalized, /errorline1/);
+	assert.match(normalized, /line2value/);
+});
+
+test("headers and footers wrap complete text within the requested width", () => {
+	const source = `complete-${"header-footer-".repeat(8)}`;
+	for (const render of [renderHeader, renderFooter]) {
+		const lines = render(source, 18, theme as any).split("\n");
+		assert.ok(lines.length > 1);
+		assert.ok(lines.every((line) => visibleWidth(line) === 18));
+		const content = lines
+			.join("")
+			.replace(/[╭╮╰╯─│]/g, "")
+			.replace(/\s/g, "");
+		assert.ok(content.includes(source.replace(/\s/g, "")));
+	}
 });
 
 test("compact multi-result rendering shows total cost in the header", () => {
-	const text = componentText(
-		renderSubagentResult(
-			{
-				content: [{ type: "text", text: "done" }],
-				details: {
-					mode: "parallel",
-					results: [result("scout", "a"), result("reviewer", "b")],
-					totalCost: { inputTokens: 30, outputTokens: 12, costUsd: 0.04 },
-				},
+	const text = renderSubagentResult(
+		{
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "parallel",
+				results: [result("scout", "a"), result("reviewer", "b")],
+				totalCost: { inputTokens: 30, outputTokens: 12, costUsd: 0.04 },
 			},
-			{ expanded: false },
-			theme as any,
-		),
-	);
+		},
+		{ expanded: false },
+		theme as any,
+	)
+		.render(120)
+		.join("\n");
 
 	assert.match(text, /2\/2 done/);
 	assert.doesNotMatch(text, /in:30 out:12|token|tool use|duration/);
@@ -87,60 +157,196 @@ test("compact multi-result rendering shows total cost in the header", () => {
 	assert.match(expanded, /in:30 out:12 \$0\.0400/);
 });
 
-test("sequential chain rendering uses result agent names", () => {
-	const sequential = componentText(
-		renderSubagentResult(
-			{
-				content: [{ type: "text", text: "done" }],
-				details: {
-					mode: "chain",
-					totalSteps: 2,
-					results: [result("scout", "a"), result("writer", "b")],
-				},
+test("collapsed foreground single and multi cards budget wrapped physical lines while expanded keeps exact args", () => {
+	const width = 36;
+	const singleCurrentArgs = `--single-current=${"current-segment-".repeat(360)}single-current-tail`;
+	const singleRetainedArgs = `--single-retained=${"retained-segment-".repeat(320)}single-retained-tail`;
+	const multiCurrentArgs = [
+		`--multi-a-current=${"alpha-segment-".repeat(340)}multi-a-current-tail`,
+		`--multi-b-current=${"beta-segment-".repeat(380)}multi-b-current-tail`,
+	];
+	const multiRetainedArgs = [
+		`--multi-a-retained=${"retained-alpha-".repeat(330)}multi-a-retained-tail`,
+		`--multi-b-retained=${"retained-beta-".repeat(370)}multi-b-retained-tail`,
+	];
+	const makeRunningResult = (agent: string, currentArgs: string, retainedArgs: string) => ({
+		agent,
+		task: `Review exact arguments for ${agent}`,
+		exitCode: 0,
+		messages: [],
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+		finalOutput: `${agent} output`,
+		progress: {
+			status: "running" as const,
+			currentTool: "grep",
+			currentToolArgs: currentArgs,
+			recentTools: [{ tool: "read", args: retainedArgs, endMs: 1 }],
+			recentOutput: [],
+			toolCount: 2,
+			tokens: 0,
+			durationMs: 0,
+		},
+	});
+	const singleResult = makeRunningResult("single-worker", singleCurrentArgs, singleRetainedArgs);
+	const singleDetails = { mode: "single" as const, results: [singleResult] };
+	const multiResults = [
+		makeRunningResult("multi-worker-a", multiCurrentArgs[0]!, multiRetainedArgs[0]!),
+		makeRunningResult("multi-worker-b", multiCurrentArgs[1]!, multiRetainedArgs[1]!),
+	];
+	const multiDetails = { mode: "parallel" as const, results: multiResults };
+
+	for (const [name, details] of [
+		["single", singleDetails],
+		["multi", multiDetails],
+	] as const) {
+		const compact = withStdoutSize(12, width + 4, () =>
+			renderSubagentResult(
+				{ content: [{ type: "text", text: "running" }], details },
+				{ expanded: false },
+				theme as any,
+			).render(width),
+		);
+		assert.ok(compact.length <= 5, `${name} compact card should honor the short-terminal budget`);
+		assert.ok(compact.every((line) => visibleWidth(line) <= width));
+		const compactText = stripVTControlCharacters(compact.join("\n"));
+		const hiddenMatch = compactText.match(/… (\d+) lines hidden/);
+		assert.ok(hiddenMatch, `${name} compact card should summarize hidden physical lines`);
+		assert.ok(Number(hiddenMatch[1]) > 100, `${name} compact card should count the multi-KB wrapped overflow`);
+		assert.match(
+			compactText.replace(/\s/g, ""),
+			/Ctrl\+Shift\+Dexpands/,
+			`${name} compact card should retain the expansion affordance`,
+		);
+
+		const expanded = withStdoutSize(12, width + 4, () =>
+			renderSubagentResult(
+				{ content: [{ type: "text", text: "running" }], details },
+				{ expanded: true },
+				theme as any,
+			).render(width),
+		);
+		assert.ok(expanded.every((line) => visibleWidth(line) <= width));
+		assert.doesNotMatch(stripVTControlCharacters(expanded.join("\n")), /lines hidden/);
+		if (name === "single") {
+			assertWrappedSource(expanded, singleCurrentArgs);
+			assertWrappedSource(expanded, singleRetainedArgs);
+		} else {
+			for (const args of [...multiCurrentArgs, ...multiRetainedArgs]) assertWrappedSource(expanded, args);
+		}
+	}
+});
+
+test("renderSubagentResult ANSI wrapping preserves styled source and complete escape sequences", () => {
+	const width = 28;
+	const styledArgs = `--styled=${"ansi value ".repeat(55)}styled-tail`;
+	const ansiTheme = {
+		fg(_name: string, text: string): string {
+			return `\u001b[31m${text}\u001b[39m`;
+		},
+		bold(text: string): string {
+			return `\u001b[1m${text}\u001b[22m`;
+		},
+	};
+	const lines = renderSubagentResult(
+		{
+			content: [{ type: "text", text: "running" }],
+			details: {
+				mode: "single",
+				results: [
+					{
+						agent: "styled-worker",
+						task: "Keep styled arguments exact",
+						exitCode: 0,
+						messages: [],
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+						finalOutput: "running",
+						progress: {
+							status: "running",
+							currentTool: "grep",
+							currentToolArgs: styledArgs,
+							recentTools: [],
+							recentOutput: [],
+							toolCount: 1,
+							tokens: 0,
+							durationMs: 0,
+						},
+					},
+				],
 			},
-			{ expanded: false },
-			theme as any,
-		),
-	);
+		},
+		{ expanded: true },
+		ansiTheme as any,
+	).render(width);
+
+	assert.ok(lines.length > 10);
+	assert.ok(lines.every((line) => visibleWidth(line) <= width));
+	const ansiEscape = String.fromCharCode(27);
+	assert.ok(lines.filter((line) => line.includes(`${ansiEscape}[`)).length > 1);
+	assertWrappedSource(lines, styledArgs);
+	const completeAnsiSequence = new RegExp(`${ansiEscape}\\[[0-?]*[ -/]*[@-~]`, "g");
+	for (const line of lines) {
+		assert.equal(
+			line.replace(completeAnsiSequence, "").includes(ansiEscape),
+			false,
+			`broken ANSI sequence in ${JSON.stringify(line)}`,
+		);
+	}
+});
+
+test("sequential chain rendering uses result agent names", () => {
+	const sequential = renderSubagentResult(
+		{
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "chain",
+				totalSteps: 2,
+				results: [result("scout", "a"), result("writer", "b")],
+			},
+		},
+		{ expanded: false },
+		theme as any,
+	)
+		.render(120)
+		.join("\n");
 	assert.match(sequential, /Step 1: scout/);
 	assert.match(sequential, /Step 2: writer/);
 });
 
 test("parallel chain rendering uses workflowGraph for group labels", () => {
-	const parallel = componentText(
-		renderSubagentResult(
-			{
-				content: [{ type: "text", text: "done" }],
-				details: {
+	const parallel = renderSubagentResult(
+		{
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "chain",
+				totalSteps: 3,
+				results: [result("scout", "a"), result("reviewer", "b"), result("auditor", "c"), result("writer", "d")],
+				workflowGraph: {
+					runId: "test-run",
 					mode: "chain",
-					totalSteps: 3,
-					results: [result("scout", "a"), result("reviewer", "b"), result("auditor", "c"), result("writer", "d")],
-					workflowGraph: {
-						runId: "test-run",
-						mode: "chain",
-						phases: [],
-						nodes: [
-							{ id: "s0", kind: "step", label: "scout", status: "completed", stepIndex: 0, flatIndex: 0 },
-							{
-								id: "p1",
-								kind: "parallel-group",
-								label: "reviewer+auditor",
-								status: "completed",
-								stepIndex: 1,
-								children: [
-									{ id: "p1a", kind: "agent", label: "reviewer", status: "completed", flatIndex: 1 },
-									{ id: "p1b", kind: "agent", label: "auditor", status: "completed", flatIndex: 2 },
-								],
-							},
-							{ id: "s2", kind: "step", label: "writer", status: "completed", stepIndex: 2, flatIndex: 3 },
-						],
-					},
+					phases: [],
+					nodes: [
+						{ id: "s0", kind: "step", label: "scout", status: "completed", stepIndex: 0, flatIndex: 0 },
+						{
+							id: "p1",
+							kind: "parallel-group",
+							label: "reviewer+auditor",
+							status: "completed",
+							stepIndex: 1,
+							children: [
+								{ id: "p1a", kind: "agent", label: "reviewer", status: "completed", flatIndex: 1 },
+								{ id: "p1b", kind: "agent", label: "auditor", status: "completed", flatIndex: 2 },
+							],
+						},
+						{ id: "s2", kind: "step", label: "writer", status: "completed", stepIndex: 2, flatIndex: 3 },
+					],
 				},
 			},
-			{ expanded: false },
-			theme as any,
-		),
-	);
+		},
+		{ expanded: false },
+		theme as any,
+	)
+		.render(120)
+		.join("\n");
 	assert.match(parallel, /Step 1: scout/);
 	assert.match(parallel, /Agent 1\/2: reviewer/);
 	assert.match(parallel, /Agent 2\/2: auditor/);

--- a/extensions/subagents/test/unit/tk-ticket.test.ts
+++ b/extensions/subagents/test/unit/tk-ticket.test.ts
@@ -18,10 +18,10 @@ describe("tk ticket helpers", () => {
 		assert.equal(detectTkTicketId("No ticket here."), undefined);
 	});
 
-	it("parses and sanitizes terminal-safe ticket titles", () => {
+	it("parses and sanitizes terminal-safe ticket titles without clipping", () => {
 		assert.equal(parseTkTicketTitle("---\nid: psr-raw4\n---\n# Show active tk title\n"), "Show active tk title");
 		assert.equal(sanitizeTkTicketTitle("\u001b[31mActive\u001b[0m\n\u0007\u009b ticket title"), "Active ticket title");
-		assert.equal(sanitizeTkTicketTitle("x".repeat(100)), `${"x".repeat(71)}…`);
+		assert.equal(sanitizeTkTicketTitle("x".repeat(100)), "x".repeat(100));
 	});
 
 	it("resolves exactly one ticketed task with its effective child cwd", () => {

--- a/tests/package-runtime-smoke.test.mjs
+++ b/tests/package-runtime-smoke.test.mjs
@@ -101,7 +101,7 @@ Return the deterministic faux child marker exactly.
 	]
 		.map((path) => path.replace(/\.ts$/, ".js"))
 		.sort();
-	assert.equal(generatedExtensionPaths.length, 165);
+	assert.equal(generatedExtensionPaths.length, 166);
 	for (const generatedPath of generatedExtensionPaths) {
 		assert.ok(packedPaths.has(generatedPath), `npm pack omitted generated extension module ${generatedPath}`);
 	}

--- a/tests/runtime-typescript-infra.test.mjs
+++ b/tests/runtime-typescript-infra.test.mjs
@@ -256,7 +256,7 @@ test("dedicated subagents runtime target compiles all production modules and rew
 	const sourcePaths = globSync("extensions/subagents/src/**/*.ts", { cwd: repoRoot }).filter(
 		(path) => !path.endsWith(".d.ts"),
 	);
-	assert.equal(sourcePaths.length, 95);
+	assert.equal(sourcePaths.length, 96);
 	for (const sourcePath of sourcePaths) {
 		const outputPath = sourcePath.replace(/\.ts$/, ".js");
 		assert.equal(existsSync(join(repoRoot, outputPath)), true, `${outputPath} should exist`);


### PR DESCRIPTION
## Summary

- replace horizontal clipping across foreground, background, compact, expanded, management, and error subagent TUI surfaces with ANSI-safe wrapping
- preserve complete commands, paths, arguments, output, and bounded-by-count recent tool history while retaining explicit vertical summaries and expansion affordances
- add narrow-width regressions, storage-only child-transcript preview bounds, generated runtime mirrors, and current validation-suite documentation

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Passed after rebasing onto current `origin/main`. Runtime outputs are fresh (187 files across 3 targets); imported subagent suites passed 1025/1025 unit, 520/520 integration, and 1/1 E2E tests.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [ ] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/subagent-tui-wrapping/install.sh | bash -s -- --ref fix/subagent-tui-wrapping --track ref
```
