### PR TITLE
Preserve foreground recovery pointers and stop misreporting output reachability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -178,6 +178,7 @@ extensions/subagents/src/shared/session-identity.js linguist-generated=true
 extensions/subagents/src/shared/session-tokens.js linguist-generated=true
 extensions/subagents/src/shared/settings.js linguist-generated=true
 extensions/subagents/src/shared/status-format.js linguist-generated=true
+extensions/subagents/src/shared/string-utils.js linguist-generated=true
 extensions/subagents/src/shared/subagent-shortcuts.js linguist-generated=true
 extensions/subagents/src/shared/types.js linguist-generated=true
 extensions/subagents/src/shared/utils.js linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- When a foreground subagent run finishes with many children and the result summary has to be trimmed, every child that appears now keeps both of its recovery paths (artifact and session). Previously the summary was built in full and then cut at the end, which could silently delete whole child blocks — and the only pointers back to their output — from the tail. A child that genuinely cannot fit is now marked with an explicit omission notice instead of disappearing quietly.
+- Truncation notices in subagent output previously told the model to look at details it has no way of reading. They now point only at routes that actually exist: an artifact path, a session path, or a plain statement that the output is unavailable.
+
 ## [0.37.0] - 2026-08-11
 
 ### Model defaults

--- a/extensions/subagents/src/intercom/result-intercom.js
+++ b/extensions/subagents/src/intercom/result-intercom.js
@@ -1,4 +1,5 @@
 import {} from "../shared/types.js";
+import { truncateWithMarker } from "../shared/string-utils.js";
 export function resolveSubagentResultStatus(input) {
     if (input.detached)
         return "detached";
@@ -142,14 +143,6 @@ const MAX_NATIVE_FOREGROUND_REFERENCE_CHARS = 500;
 const MAX_NATIVE_FOREGROUND_ERROR_CHARS = 1_200;
 const MAX_NATIVE_FOREGROUND_NESTED_ENTRIES = 8;
 const MAX_NATIVE_FOREGROUND_NESTED_DEPTH = 2;
-const NATIVE_FOREGROUND_TOTAL_TRUNCATION_MARKER = `… [foreground result truncated at ${MAX_NATIVE_FOREGROUND_CHARS.toString()} chars; inspect retained details, artifacts, or sessions for full output]`;
-function truncateWithMarker(value, maxChars, marker) {
-    if (value.length <= maxChars)
-        return value;
-    if (marker.length >= maxChars)
-        return marker.slice(0, maxChars);
-    return `${value.slice(0, maxChars - marker.length)}${marker}`;
-}
 function boundedNativeForegroundLabel(value) {
     return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_LABEL_CHARS, "… [label truncated]");
 }
@@ -157,13 +150,18 @@ function boundedNativeForegroundReference(value) {
     return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_REFERENCE_CHARS, "… [reference truncated]");
 }
 function boundedNativeForegroundError(value) {
-    return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_ERROR_CHARS, "… [error truncated; inspect retained details for full text]");
+    return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_ERROR_CHARS, "… [error truncated; full text is unavailable]");
 }
-function summarizeNativeForegroundOutput(child) {
+function boundedNativeForegroundSummary(child, maxChars) {
+    const raw = child.summary.trim() || "(no output)";
+    if (raw.length <= maxChars)
+        return raw;
     const marker = child.artifactPath || child.sessionPath
         ? "… [summary truncated; see references below for full output]"
-        : "… [summary truncated; inspect retained details for full output]";
-    return truncateWithMarker(child.summary.trim() || "(no output)", MAX_NATIVE_FOREGROUND_SUMMARY_CHARS, marker);
+        : "… [summary truncated; full output is unavailable]";
+    if (maxChars < marker.length)
+        return "";
+    return truncateWithMarker(raw, maxChars, marker);
 }
 function prioritizedNativeForegroundChildren(children) {
     const statusPriority = new Map([
@@ -186,6 +184,14 @@ function prioritizedNativeForegroundChildren(children) {
         .slice(0, MAX_NATIVE_FOREGROUND_CHILDREN)
         .map(({ child, originalIndex }) => ({ child, originalIndex }));
 }
+function joinedLineCost(lines) {
+    return lines.reduce((total, line) => total + line.length + 1, 0);
+}
+function resolveNativeForegroundPerChildSummaryBudget(count, fixedCost, ceiling) {
+    const effectiveCount = Math.max(count, 1);
+    const available = Math.max(ceiling - fixedCost, 0);
+    return Math.min(MAX_NATIVE_FOREGROUND_SUMMARY_CHARS, Math.floor(available / effectiveCount));
+}
 function formatNativeForegroundNestedLines(children) {
     if (!children?.length)
         return [];
@@ -195,12 +201,12 @@ function formatNativeForegroundNestedLines(children) {
         if (!runs?.length)
             return;
         if (depth >= MAX_NATIVE_FOREGROUND_NESTED_DEPTH) {
-            lines.push(`${indent}… [nested depth limit reached; inspect retained details for full tree]`);
+            lines.push(`${indent}… [nested depth limit reached; full tree is unavailable]`);
             return;
         }
         for (const run of runs) {
             if (remaining <= 0) {
-                lines.push(`${indent}… [additional nested entries omitted; inspect retained details for full tree]`);
+                lines.push(`${indent}… [additional nested entries omitted; full tree is unavailable]`);
                 return;
             }
             remaining--;
@@ -216,11 +222,11 @@ function formatNativeForegroundNestedLines(children) {
         }
     };
     append(children, "", 0);
-    return lines;
+    return lines.length > 1 ? lines : [];
 }
 function formatForegroundNativeSubagentText(input) {
     const counts = countStatuses(input.children);
-    const lines = [
+    const outerLines = [
         "subagent results",
         "",
         `Run: ${boundedNativeForegroundReference(input.runId)}`,
@@ -228,28 +234,69 @@ function formatForegroundNativeSubagentText(input) {
         `Status: ${boundedNativeForegroundLabel(input.status)}`,
         `Children: ${formatStatusCounts(counts)}`,
     ];
-    if (input.mode === "chain" && typeof input.chainSteps === "number")
-        lines.push(`Chain steps: ${input.chainSteps}`);
-    if (input.errorSummary)
-        lines.push("", "Error:", boundedNativeForegroundError(input.errorSummary));
-    const displayedChildren = prioritizedNativeForegroundChildren(input.children);
-    if (input.children.length > displayedChildren.length) {
-        lines.push("", `… [${input.children.length - displayedChildren.length} child results omitted; highest-priority results shown first, inspect retained details for the full set]`);
+    if (input.mode === "chain" && typeof input.chainSteps === "number") {
+        outerLines.push(`Chain steps: ${input.chainSteps}`);
     }
-    for (const { child, originalIndex } of displayedChildren) {
+    if (input.errorSummary) {
+        outerLines.push("", "Error:", boundedNativeForegroundError(input.errorSummary));
+    }
+    const displayedChildren = prioritizedNativeForegroundChildren(input.children);
+    const priorityOmittedCount = input.children.length - displayedChildren.length;
+    const priorityOmissionLine = priorityOmittedCount > 0
+        ? `… [${priorityOmittedCount} child results omitted; highest-priority results shown first; full set is unavailable]`
+        : null;
+    const childFixedData = displayedChildren.map(({ child, originalIndex }) => {
         const displayIndex = child.displayIndex ?? originalIndex + 1;
         const displayTotal = child.displayTotal ?? input.children.length;
-        lines.push("");
-        lines.push(`${displayIndex}/${displayTotal}. ${boundedNativeForegroundLabel(child.agent)} — ${boundedNativeForegroundLabel(child.status)}`);
-        lines.push("Summary:");
-        lines.push(summarizeNativeForegroundOutput(child));
+        const labelLine = `${displayIndex}/${displayTotal}. ${boundedNativeForegroundLabel(child.agent)} — ${boundedNativeForegroundLabel(child.status)}`;
+        const refLines = [];
         if (child.artifactPath)
-            lines.push(`Output artifact: ${boundedNativeForegroundReference(child.artifactPath)}`);
+            refLines.push(`Output artifact: ${boundedNativeForegroundReference(child.artifactPath)}`);
         if (child.sessionPath)
-            lines.push(`Session: ${boundedNativeForegroundReference(child.sessionPath)}`);
-        lines.push(...formatNativeForegroundNestedLines(child.children));
+            refLines.push(`Session: ${boundedNativeForegroundReference(child.sessionPath)}`);
+        const nestedLines = formatNativeForegroundNestedLines(child.children);
+        const fixedCost = joinedLineCost(["", labelLine, "Summary:", ...refLines, ...nestedLines]);
+        return { child, originalIndex, labelLine, refLines, nestedLines, fixedCost };
+    });
+    const outerCost = joinedLineCost(outerLines) + (priorityOmissionLine ? joinedLineCost(["", priorityOmissionLine]) : 0);
+    let effectiveCount = displayedChildren.length;
+    while (effectiveCount > 0) {
+        const partialFixedCost = childFixedData.slice(0, effectiveCount).reduce((s, c) => s + c.fixedCost, 0);
+        const budgetOmittedHere = displayedChildren.length - effectiveCount;
+        const budgetOmissionCostHere = budgetOmittedHere > 0
+            ? joinedLineCost([
+                "",
+                `… [${budgetOmittedHere} additional child results omitted due to display size limit; see listed paths above]`,
+            ])
+            : 0;
+        if (outerCost + partialFixedCost + budgetOmissionCostHere <= MAX_NATIVE_FOREGROUND_CHARS)
+            break;
+        effectiveCount--;
     }
-    return truncateWithMarker(lines.join("\n"), MAX_NATIVE_FOREGROUND_CHARS, NATIVE_FOREGROUND_TOTAL_TRUNCATION_MARKER);
+    const effectiveChildData = childFixedData.slice(0, effectiveCount);
+    const budgetOmittedCount = displayedChildren.length - effectiveCount;
+    const budgetOmissionLine = budgetOmittedCount > 0
+        ? effectiveCount === 0
+            ? `… [${budgetOmittedCount} child results omitted due to display size limit; full output is unavailable]`
+            : `… [${budgetOmittedCount} additional child results omitted due to display size limit; see listed paths above]`
+        : null;
+    const totalFixedCost = outerCost +
+        (budgetOmissionLine ? joinedLineCost(["", budgetOmissionLine]) : 0) +
+        effectiveChildData.reduce((s, c) => s + c.fixedCost, 0);
+    const perChildSummaryBudget = resolveNativeForegroundPerChildSummaryBudget(effectiveCount, totalFixedCost + effectiveCount, MAX_NATIVE_FOREGROUND_CHARS);
+    const lines = [...outerLines];
+    if (priorityOmissionLine)
+        lines.push("", priorityOmissionLine);
+    if (budgetOmissionLine)
+        lines.push("", budgetOmissionLine);
+    for (const { child, labelLine, refLines, nestedLines } of effectiveChildData) {
+        lines.push("", labelLine, "Summary:");
+        const summaryText = boundedNativeForegroundSummary(child, perChildSummaryBudget);
+        if (summaryText)
+            lines.push(summaryText);
+        lines.push(...refLines, ...nestedLines);
+    }
+    return lines.join("\n");
 }
 export function formatForegroundNativeSubagentResult(input) {
     const children = input.children.map((child) => ({

--- a/extensions/subagents/src/intercom/result-intercom.js
+++ b/extensions/subagents/src/intercom/result-intercom.js
@@ -266,7 +266,7 @@ function formatForegroundNativeSubagentText(input) {
         const budgetOmissionCostHere = budgetOmittedHere > 0
             ? joinedLineCost([
                 "",
-                `… [${budgetOmittedHere} additional child results omitted due to display size limit; see listed paths above]`,
+                `… [${budgetOmittedHere} additional child results omitted; their output is not reachable from this envelope]`,
             ])
             : 0;
         if (outerCost + partialFixedCost + budgetOmissionCostHere <= MAX_NATIVE_FOREGROUND_CHARS)
@@ -278,7 +278,7 @@ function formatForegroundNativeSubagentText(input) {
     const budgetOmissionLine = budgetOmittedCount > 0
         ? effectiveCount === 0
             ? `… [${budgetOmittedCount} child results omitted due to display size limit; full output is unavailable]`
-            : `… [${budgetOmittedCount} additional child results omitted due to display size limit; see listed paths above]`
+            : `… [${budgetOmittedCount} additional child results omitted; their output is not reachable from this envelope]`
         : null;
     const totalFixedCost = outerCost +
         (budgetOmissionLine ? joinedLineCost(["", budgetOmissionLine]) : 0) +
@@ -290,10 +290,10 @@ function formatForegroundNativeSubagentText(input) {
     if (budgetOmissionLine)
         lines.push("", budgetOmissionLine);
     for (const { child, labelLine, refLines, nestedLines } of effectiveChildData) {
-        lines.push("", labelLine, "Summary:");
+        lines.push("", labelLine);
         const summaryText = boundedNativeForegroundSummary(child, perChildSummaryBudget);
         if (summaryText)
-            lines.push(summaryText);
+            lines.push("Summary:", summaryText);
         lines.push(...refLines, ...nestedLines);
     }
     return lines.join("\n");

--- a/extensions/subagents/src/intercom/result-intercom.ts
+++ b/extensions/subagents/src/intercom/result-intercom.ts
@@ -352,13 +352,14 @@ function formatForegroundNativeSubagentText(input: {
 	while (effectiveCount > 0) {
 		const partialFixedCost = childFixedData.slice(0, effectiveCount).reduce((s, c) => s + c.fixedCost, 0);
 		const budgetOmittedHere = displayedChildren.length - effectiveCount;
-		// The loop always tests whether effectiveCount >= 1 children fit, so paths ARE
-		// listed above whenever the omission line would appear. Use the with-paths wording.
+		// The loop always tests whether effectiveCount >= 1 children fit. The omitted
+		// children's paths are never emitted; do not direct the reader to paths that
+		// belong to the retained children.
 		const budgetOmissionCostHere =
 			budgetOmittedHere > 0
 				? joinedLineCost([
 						"",
-						`… [${budgetOmittedHere} additional child results omitted due to display size limit; see listed paths above]`,
+						`… [${budgetOmittedHere} additional child results omitted; their output is not reachable from this envelope]`,
 					])
 				: 0;
 		if (outerCost + partialFixedCost + budgetOmissionCostHere <= MAX_NATIVE_FOREGROUND_CHARS) break;
@@ -368,12 +369,13 @@ function formatForegroundNativeSubagentText(input: {
 	const effectiveChildData = childFixedData.slice(0, effectiveCount);
 	const budgetOmittedCount = displayedChildren.length - effectiveCount;
 	// When every child is dropped (effectiveCount === 0) there are no paths above;
-	// state unavailability plainly instead of pointing at an empty list.
+	// state unavailability plainly. When some children are retained, the omitted
+	// children's paths are not emitted, so do not imply they are reachable above.
 	const budgetOmissionLine =
 		budgetOmittedCount > 0
 			? effectiveCount === 0
 				? `… [${budgetOmittedCount} child results omitted due to display size limit; full output is unavailable]`
-				: `… [${budgetOmittedCount} additional child results omitted due to display size limit; see listed paths above]`
+				: `… [${budgetOmittedCount} additional child results omitted; their output is not reachable from this envelope]`
 			: null;
 
 	// Compute total fixed cost and derive per-child summary budget from remaining space.
@@ -398,11 +400,12 @@ function formatForegroundNativeSubagentText(input: {
 	if (budgetOmissionLine) lines.push("", budgetOmissionLine);
 
 	for (const { child, labelLine, refLines, nestedLines } of effectiveChildData) {
-		lines.push("", labelLine, "Summary:");
-		// Emit summary text with per-child budget. Suppress entirely when the budget
-		// cannot hold a well-formed truncation marker to prevent mangled fragments.
+		lines.push("", labelLine);
+		// Emit summary text with per-child budget. Suppress the 'Summary:' heading
+		// entirely when the budget cannot hold a well-formed truncation marker — an
+		// orphaned heading with nothing beneath it is worse than no heading at all.
 		const summaryText = boundedNativeForegroundSummary(child, perChildSummaryBudget);
-		if (summaryText) lines.push(summaryText);
+		if (summaryText) lines.push("Summary:", summaryText);
 		lines.push(...refLines, ...nestedLines);
 	}
 

--- a/extensions/subagents/src/intercom/result-intercom.ts
+++ b/extensions/subagents/src/intercom/result-intercom.ts
@@ -5,6 +5,7 @@ import {
 	type SubagentResultStatus,
 	type SubagentRunMode,
 } from "../shared/types.ts";
+import { truncateWithMarker } from "../shared/string-utils.ts";
 
 export function resolveSubagentResultStatus(input: {
 	exitCode?: number;
@@ -164,13 +165,6 @@ const MAX_NATIVE_FOREGROUND_REFERENCE_CHARS = 500;
 const MAX_NATIVE_FOREGROUND_ERROR_CHARS = 1_200;
 const MAX_NATIVE_FOREGROUND_NESTED_ENTRIES = 8;
 const MAX_NATIVE_FOREGROUND_NESTED_DEPTH = 2;
-const NATIVE_FOREGROUND_TOTAL_TRUNCATION_MARKER = `… [foreground result truncated at ${MAX_NATIVE_FOREGROUND_CHARS.toString()} chars; inspect retained details, artifacts, or sessions for full output]`;
-
-function truncateWithMarker(value: string, maxChars: number, marker: string): string {
-	if (value.length <= maxChars) return value;
-	if (marker.length >= maxChars) return marker.slice(0, maxChars);
-	return `${value.slice(0, maxChars - marker.length)}${marker}`;
-}
 
 function boundedNativeForegroundLabel(value: string): string {
 	return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_LABEL_CHARS, "… [label truncated]");
@@ -181,19 +175,27 @@ function boundedNativeForegroundReference(value: string): string {
 }
 
 function boundedNativeForegroundError(value: string): string {
-	return truncateWithMarker(
-		value,
-		MAX_NATIVE_FOREGROUND_ERROR_CHARS,
-		"… [error truncated; inspect retained details for full text]",
-	);
+	return truncateWithMarker(value, MAX_NATIVE_FOREGROUND_ERROR_CHARS, "… [error truncated; full text is unavailable]");
 }
 
-function summarizeNativeForegroundOutput(child: SubagentResultIntercomChild): string {
+/**
+ * Bounds the per-child summary to maxChars, choosing the appropriate truncation marker.
+ * Returns "" when the budget cannot hold a well-formed marker so that callers can suppress
+ * the summary line entirely rather than emitting a sliced fragment.
+ */
+function boundedNativeForegroundSummary(child: SubagentResultIntercomChild, maxChars: number): string {
+	const raw = child.summary.trim() || "(no output)";
+	if (raw.length <= maxChars) return raw;
+	// Select the marker first, then suppress when the budget cannot hold it.
+	// Comparing against the selected marker's own length avoids suppressing a short
+	// no-references marker (49 chars) because the longer with-references marker (59
+	// chars) does not fit — the two markers have different lengths.
 	const marker =
 		child.artifactPath || child.sessionPath
 			? "… [summary truncated; see references below for full output]"
-			: "… [summary truncated; inspect retained details for full output]";
-	return truncateWithMarker(child.summary.trim() || "(no output)", MAX_NATIVE_FOREGROUND_SUMMARY_CHARS, marker);
+			: "… [summary truncated; full output is unavailable]";
+	if (maxChars < marker.length) return "";
+	return truncateWithMarker(raw, maxChars, marker);
 }
 
 interface NativeForegroundChild extends SubagentResultIntercomChild {
@@ -224,6 +226,26 @@ function prioritizedNativeForegroundChildren(
 		.map(({ child, originalIndex }) => ({ child, originalIndex }));
 }
 
+/**
+ * Character cost of a set of lines once joined with newlines, counted conservatively
+ * (one extra char per line so reserved space is never undersized).
+ */
+function joinedLineCost(lines: string[]): number {
+	return lines.reduce((total, line) => total + line.length + 1, 0);
+}
+
+/**
+ * Divides the space remaining after all fixed scaffolding costs are reserved among the
+ * displayed children for summary text. Reserving fixed scaffolding (labels, reference
+ * lines, nested entries) before the division ensures summary text receives only the
+ * space that remains after every recovery pointer is guaranteed.
+ */
+function resolveNativeForegroundPerChildSummaryBudget(count: number, fixedCost: number, ceiling: number): number {
+	const effectiveCount = Math.max(count, 1);
+	const available = Math.max(ceiling - fixedCost, 0);
+	return Math.min(MAX_NATIVE_FOREGROUND_SUMMARY_CHARS, Math.floor(available / effectiveCount));
+}
+
 function formatNativeForegroundNestedLines(children: PublicNestedRunSummary[] | undefined): string[] {
 	if (!children?.length) return [];
 	const lines = ["Nested subagents:"];
@@ -231,12 +253,12 @@ function formatNativeForegroundNestedLines(children: PublicNestedRunSummary[] | 
 	const append = (runs: PublicNestedRunSummary[] | undefined, indent: string, depth: number): void => {
 		if (!runs?.length) return;
 		if (depth >= MAX_NATIVE_FOREGROUND_NESTED_DEPTH) {
-			lines.push(`${indent}… [nested depth limit reached; inspect retained details for full tree]`);
+			lines.push(`${indent}… [nested depth limit reached; full tree is unavailable]`);
 			return;
 		}
 		for (const run of runs) {
 			if (remaining <= 0) {
-				lines.push(`${indent}… [additional nested entries omitted; inspect retained details for full tree]`);
+				lines.push(`${indent}… [additional nested entries omitted; full tree is unavailable]`);
 				return;
 			}
 			remaining--;
@@ -250,7 +272,11 @@ function formatNativeForegroundNestedLines(children: PublicNestedRunSummary[] | 
 		}
 	};
 	append(children, "", 0);
-	return lines;
+	// Guard: never emit a bare heading with no content beneath it. The append loop
+	// always adds at least one content line for non-empty children, but this guard
+	// is a forward-looking safety net — a future change that emits the heading and
+	// then drops entries without a marker would produce exactly the defect this catches.
+	return lines.length > 1 ? lines : [];
 }
 
 function formatForegroundNativeSubagentText(input: {
@@ -262,7 +288,9 @@ function formatForegroundNativeSubagentText(input: {
 	errorSummary?: string;
 }): string {
 	const counts = countStatuses(input.children);
-	const lines: string[] = [
+
+	// Build the fixed outer header lines.
+	const outerLines: string[] = [
 		"subagent results",
 		"",
 		`Run: ${boundedNativeForegroundReference(input.runId)}`,
@@ -270,31 +298,115 @@ function formatForegroundNativeSubagentText(input: {
 		`Status: ${boundedNativeForegroundLabel(input.status)}`,
 		`Children: ${formatStatusCounts(counts)}`,
 	];
-	if (input.mode === "chain" && typeof input.chainSteps === "number") lines.push(`Chain steps: ${input.chainSteps}`);
-	if (input.errorSummary) lines.push("", "Error:", boundedNativeForegroundError(input.errorSummary));
-
-	const displayedChildren = prioritizedNativeForegroundChildren(input.children);
-	if (input.children.length > displayedChildren.length) {
-		lines.push(
-			"",
-			`… [${input.children.length - displayedChildren.length} child results omitted; highest-priority results shown first, inspect retained details for the full set]`,
-		);
+	if (input.mode === "chain" && typeof input.chainSteps === "number") {
+		outerLines.push(`Chain steps: ${input.chainSteps}`);
 	}
-	for (const { child, originalIndex } of displayedChildren) {
+	if (input.errorSummary) {
+		outerLines.push("", "Error:", boundedNativeForegroundError(input.errorSummary));
+	}
+
+	// Apply priority ordering and cap at MAX_NATIVE_FOREGROUND_CHILDREN.
+	const displayedChildren = prioritizedNativeForegroundChildren(input.children);
+
+	// Top-level omission (children beyond the priority cap).
+	const priorityOmittedCount = input.children.length - displayedChildren.length;
+	const priorityOmissionLine =
+		priorityOmittedCount > 0
+			? `… [${priorityOmittedCount} child results omitted; highest-priority results shown first; full set is unavailable]`
+			: null;
+
+	// Pre-compute per-child fixed lines (everything except the summary body).
+	// These carry the recovery pointers and must be reserved before the summary
+	// budget is divided so end-truncation can never destroy them.
+	interface ChildFixedData {
+		child: NativeForegroundChild;
+		originalIndex: number;
+		labelLine: string;
+		refLines: string[];
+		nestedLines: string[];
+		fixedCost: number;
+	}
+
+	const childFixedData: ChildFixedData[] = displayedChildren.map(({ child, originalIndex }) => {
 		const displayIndex = child.displayIndex ?? originalIndex + 1;
 		const displayTotal = child.displayTotal ?? input.children.length;
-		lines.push("");
-		lines.push(
-			`${displayIndex}/${displayTotal}. ${boundedNativeForegroundLabel(child.agent)} — ${boundedNativeForegroundLabel(child.status)}`,
-		);
-		lines.push("Summary:");
-		lines.push(summarizeNativeForegroundOutput(child));
-		if (child.artifactPath) lines.push(`Output artifact: ${boundedNativeForegroundReference(child.artifactPath)}`);
-		if (child.sessionPath) lines.push(`Session: ${boundedNativeForegroundReference(child.sessionPath)}`);
-		lines.push(...formatNativeForegroundNestedLines(child.children));
+		const labelLine = `${displayIndex}/${displayTotal}. ${boundedNativeForegroundLabel(child.agent)} — ${boundedNativeForegroundLabel(child.status)}`;
+		const refLines: string[] = [];
+		if (child.artifactPath) refLines.push(`Output artifact: ${boundedNativeForegroundReference(child.artifactPath)}`);
+		if (child.sessionPath) refLines.push(`Session: ${boundedNativeForegroundReference(child.sessionPath)}`);
+		const nestedLines = formatNativeForegroundNestedLines(child.children);
+		// Fixed cost: blank separator + label + "Summary:" header + ref lines + nested lines.
+		// The summary body itself is NOT included here — it is conditional on the per-child
+		// budget and must not be pre-counted, or the fit decision will drop children one char
+		// early when the budget is tight.
+		const fixedCost = joinedLineCost(["", labelLine, "Summary:", ...refLines, ...nestedLines]);
+		return { child, originalIndex, labelLine, refLines, nestedLines, fixedCost };
+	});
+
+	// Dynamic reduction: drop trailing displayed children when their scaffolding alone
+	// exceeds the ceiling. Each dropped child is counted in an explicit omission marker
+	// rather than being silently tail-cut.
+	const outerCost =
+		joinedLineCost(outerLines) + (priorityOmissionLine ? joinedLineCost(["", priorityOmissionLine]) : 0);
+	let effectiveCount = displayedChildren.length;
+	while (effectiveCount > 0) {
+		const partialFixedCost = childFixedData.slice(0, effectiveCount).reduce((s, c) => s + c.fixedCost, 0);
+		const budgetOmittedHere = displayedChildren.length - effectiveCount;
+		// The loop always tests whether effectiveCount >= 1 children fit, so paths ARE
+		// listed above whenever the omission line would appear. Use the with-paths wording.
+		const budgetOmissionCostHere =
+			budgetOmittedHere > 0
+				? joinedLineCost([
+						"",
+						`… [${budgetOmittedHere} additional child results omitted due to display size limit; see listed paths above]`,
+					])
+				: 0;
+		if (outerCost + partialFixedCost + budgetOmissionCostHere <= MAX_NATIVE_FOREGROUND_CHARS) break;
+		effectiveCount--;
 	}
 
-	return truncateWithMarker(lines.join("\n"), MAX_NATIVE_FOREGROUND_CHARS, NATIVE_FOREGROUND_TOTAL_TRUNCATION_MARKER);
+	const effectiveChildData = childFixedData.slice(0, effectiveCount);
+	const budgetOmittedCount = displayedChildren.length - effectiveCount;
+	// When every child is dropped (effectiveCount === 0) there are no paths above;
+	// state unavailability plainly instead of pointing at an empty list.
+	const budgetOmissionLine =
+		budgetOmittedCount > 0
+			? effectiveCount === 0
+				? `… [${budgetOmittedCount} child results omitted due to display size limit; full output is unavailable]`
+				: `… [${budgetOmittedCount} additional child results omitted due to display size limit; see listed paths above]`
+			: null;
+
+	// Compute total fixed cost and derive per-child summary budget from remaining space.
+	// +effectiveCount reserves one char per displayed child for the newline that joins("\n")
+	// emits between the summary text and the following ref lines. The loop's drop decision
+	// does NOT include this char (it checks bare scaffolding only), so it must be added
+	// here to keep the rendered total within the ceiling.
+	const totalFixedCost =
+		outerCost +
+		(budgetOmissionLine ? joinedLineCost(["", budgetOmissionLine]) : 0) +
+		effectiveChildData.reduce((s, c) => s + c.fixedCost, 0);
+
+	const perChildSummaryBudget = resolveNativeForegroundPerChildSummaryBudget(
+		effectiveCount,
+		totalFixedCost + effectiveCount,
+		MAX_NATIVE_FOREGROUND_CHARS,
+	);
+
+	// Render.
+	const lines: string[] = [...outerLines];
+	if (priorityOmissionLine) lines.push("", priorityOmissionLine);
+	if (budgetOmissionLine) lines.push("", budgetOmissionLine);
+
+	for (const { child, labelLine, refLines, nestedLines } of effectiveChildData) {
+		lines.push("", labelLine, "Summary:");
+		// Emit summary text with per-child budget. Suppress entirely when the budget
+		// cannot hold a well-formed truncation marker to prevent mangled fragments.
+		const summaryText = boundedNativeForegroundSummary(child, perChildSummaryBudget);
+		if (summaryText) lines.push(summaryText);
+		lines.push(...refLines, ...nestedLines);
+	}
+
+	return lines.join("\n");
 }
 
 interface GroupedNativeForegroundMessageInput {

--- a/extensions/subagents/src/runs/background/notify.js
+++ b/extensions/subagents/src/runs/background/notify.js
@@ -5,6 +5,7 @@ import { createCompletionBatcher, resolveCompletionBatchConfig, } from "./comple
 import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../shared/types.js";
 import { isProtectedPausedLifecycle } from "../shared/lifecycle-privacy.js";
 import { BACKGROUND_COMPLETION_NUDGE_TEXT } from "../shared/nudge-texts.js";
+import { sliceSafe, truncateWithMarker } from "../../shared/string-utils.js";
 export const MAX_COMPLETION_MESSAGE_CHARS = 32_000;
 const MAX_DISPLAYED_CHILDREN = 8;
 const MAX_GROUPED_ENTRIES = 8;
@@ -16,13 +17,6 @@ const MAX_NESTED_DEPTH = 2;
 const MAX_LABEL_CHARS = 160;
 const MAX_ASYNC_ID_CHARS = 200;
 const MAX_SESSION_PATH_CHARS = 4_096;
-function truncateWithMarker(value, maxChars, marker) {
-    if (value.length <= maxChars)
-        return value;
-    if (marker.length >= maxChars)
-        return marker.slice(0, maxChars);
-    return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
-}
 function boundedSummary(value, maxChars) {
     return truncateWithMarker(value, maxChars, "… [summary truncated]");
 }
@@ -38,11 +32,6 @@ function resolvePerChildSummaryBudget(displayedChildCount, nonSummaryCostWithinP
     const count = Math.max(displayedChildCount, 1);
     const availableForSummaries = Math.max(ceilingForPreview - nonSummaryCostWithinPreview, 0);
     return Math.min(MAX_SUMMARY_CHARS, Math.floor(availableForSummaries / count));
-}
-function sliceSafe(value, end) {
-    const sliced = value.slice(0, end);
-    const last = sliced.charCodeAt(sliced.length - 1);
-    return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
 }
 export function boundedReference(value) {
     if (value.length <= MAX_REFERENCE_CHARS)

--- a/extensions/subagents/src/runs/background/notify.ts
+++ b/extensions/subagents/src/runs/background/notify.ts
@@ -21,6 +21,7 @@ import {
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../shared/types.ts";
 import { isProtectedPausedLifecycle } from "../shared/lifecycle-privacy.ts";
 import { BACKGROUND_COMPLETION_NUDGE_TEXT } from "../shared/nudge-texts.ts";
+import { sliceSafe, truncateWithMarker } from "../../shared/string-utils.ts";
 
 // --- Injection / context bounds on child-controlled text ---
 // These constants limit text that originates from child subagents and enters
@@ -148,12 +149,6 @@ export interface RegisterSubagentNotifyOptions {
 	now?: () => number;
 }
 
-function truncateWithMarker(value: string, maxChars: number, marker: string): string {
-	if (value.length <= maxChars) return value;
-	if (marker.length >= maxChars) return marker.slice(0, maxChars);
-	return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
-}
-
 function boundedSummary(value: string, maxChars: number): string {
 	return truncateWithMarker(value, maxChars, "… [summary truncated]");
 }
@@ -218,18 +213,6 @@ function resolvePerChildSummaryBudget(
 	// this function previously had at count * MAX_SUMMARY_CHARS === MAX_COMPLETION_MESSAGE_CHARS.
 	const availableForSummaries = Math.max(ceilingForPreview - nonSummaryCostWithinPreview, 0);
 	return Math.min(MAX_SUMMARY_CHARS, Math.floor(availableForSummaries / count));
-}
-
-/**
- * Returns value.slice(0, end), backing up by one code unit when the last kept code
- * unit is a UTF-16 high surrogate (U+D800–U+DBFF). A high surrogate without its
- * paired low surrogate produces an ill-formed string; backing up one code unit keeps
- * the string well-formed at the cost of one fewer character of context.
- */
-function sliceSafe(value: string, end: number): string {
-	const sliced = value.slice(0, end);
-	const last = sliced.charCodeAt(sliced.length - 1);
-	return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
 }
 
 /**

--- a/extensions/subagents/src/runs/foreground/subagent-executor.js
+++ b/extensions/subagents/src/runs/foreground/subagent-executor.js
@@ -1936,7 +1936,7 @@ async function resumeAsyncRun(input) {
 }
 const MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS = 600;
 function boundedNativeForegroundSaveError(error) {
-    const marker = "… [save error truncated; inspect retained details for full diagnostic]";
+    const marker = "… [save error truncated; full diagnostic is unavailable]";
     if (error.length <= MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS)
         return error;
     return `${error.slice(0, MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS - marker.length)}${marker}`;
@@ -1995,7 +1995,16 @@ function resultNoticeForEarlierSuccessfulChainStep(result) {
     }
     if (result.modelFallbackNotice)
         lines.push(`Notice: ${result.modelFallbackNotice}`);
-    lines.push("Earlier successful chain step output omitted here; inspect retained details for the full step output.");
+    const hasArtifact = Boolean(result.artifactPaths?.outputPath);
+    const hasSession = Boolean(result.sessionFile);
+    const stepOutputNote = hasArtifact && hasSession
+        ? "Earlier successful chain step output omitted here; see the artifact and session paths below for reference."
+        : hasArtifact
+            ? "Earlier successful chain step output omitted here; see the artifact path below for reference."
+            : hasSession
+                ? "Earlier successful chain step output omitted here; see the session path below for reference."
+                : "Earlier successful chain step output omitted here; full step output is unavailable.";
+    lines.push(stepOutputNote);
     if (result.outputMode === "file-only" && result.savedOutputPath && result.outputReference) {
         lines.push(getSingleResultOutput(result) || result.outputReference.message);
     }

--- a/extensions/subagents/src/runs/foreground/subagent-executor.ts
+++ b/extensions/subagents/src/runs/foreground/subagent-executor.ts
@@ -2434,7 +2434,7 @@ async function resumeAsyncRun(input: {
 const MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS = 600;
 
 function boundedNativeForegroundSaveError(error: string): string {
-	const marker = "… [save error truncated; inspect retained details for full diagnostic]";
+	const marker = "… [save error truncated; full diagnostic is unavailable]";
 	if (error.length <= MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS) return error;
 	return `${error.slice(0, MAX_NATIVE_FOREGROUND_SAVE_ERROR_CHARS - marker.length)}${marker}`;
 }
@@ -2496,7 +2496,22 @@ function resultNoticeForEarlierSuccessfulChainStep(result: SingleResult): string
 		lines.push(`Output file error:\n${boundedNativeForegroundSaveError(result.outputSaveError)}`);
 	}
 	if (result.modelFallbackNotice) lines.push(`Notice: ${result.modelFallbackNotice}`);
-	lines.push("Earlier successful chain step output omitted here; inspect retained details for the full step output.");
+	// Derive wording from the same values that populate artifactPath/sessionPath in the
+	// enclosing child block (result.artifactPaths?.outputPath and result.sessionFile), so
+	// the note and the rendered paths cannot drift apart. Do NOT condition on outputMode
+	// alone — the previous wording did that and produced a false "unavailable" claim when
+	// an artifact or session path was about to be rendered directly below.
+	const hasArtifact = Boolean(result.artifactPaths?.outputPath);
+	const hasSession = Boolean(result.sessionFile);
+	const stepOutputNote =
+		hasArtifact && hasSession
+			? "Earlier successful chain step output omitted here; see the artifact and session paths below for reference."
+			: hasArtifact
+				? "Earlier successful chain step output omitted here; see the artifact path below for reference."
+				: hasSession
+					? "Earlier successful chain step output omitted here; see the session path below for reference."
+					: "Earlier successful chain step output omitted here; full step output is unavailable.";
+	lines.push(stepOutputNote);
 	if (result.outputMode === "file-only" && result.savedOutputPath && result.outputReference) {
 		lines.push(getSingleResultOutput(result) || result.outputReference.message);
 	}

--- a/extensions/subagents/src/shared/string-utils.js
+++ b/extensions/subagents/src/shared/string-utils.js
@@ -1,0 +1,12 @@
+export function sliceSafe(value, end) {
+    const sliced = value.slice(0, end);
+    const last = sliced.charCodeAt(sliced.length - 1);
+    return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+export function truncateWithMarker(value, maxChars, marker) {
+    if (value.length <= maxChars)
+        return value;
+    if (marker.length >= maxChars)
+        return sliceSafe(marker, maxChars);
+    return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
+}

--- a/extensions/subagents/src/shared/string-utils.ts
+++ b/extensions/subagents/src/shared/string-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared surrogate-safe string helpers used across the subagent extension.
+ *
+ * A single canonical copy is kept here so every call site shares one correct
+ * implementation; duplicating the logic on separate paths risks divergence.
+ */
+
+/**
+ * Slice a string to at most `end` UTF-16 code units, then back up by one unit
+ * when the last kept code unit is a UTF-16 high surrogate (U+D800–U+DBFF). A
+ * high surrogate without its paired low surrogate produces an ill-formed string;
+ * backing up one code unit keeps the string well-formed at the cost of one
+ * fewer character of context.
+ */
+export function sliceSafe(value: string, end: number): string {
+	const sliced = value.slice(0, end);
+	const last = sliced.charCodeAt(sliced.length - 1);
+	return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+
+/**
+ * Truncate `value` to at most `maxChars` UTF-16 code units, appending `marker`
+ * when truncation is necessary. If the budget cannot even hold the full marker,
+ * the marker itself is sliced to fit. The slice is surrogate-safe: the function
+ * will not produce an ill-formed string at the cut point for any input, including
+ * non-BMP markers.
+ */
+export function truncateWithMarker(value: string, maxChars: number, marker: string): string {
+	if (value.length <= maxChars) return value;
+	if (marker.length >= maxChars) return sliceSafe(marker, maxChars);
+	return `${sliceSafe(value, maxChars - marker.length)}${marker}`;
+}

--- a/extensions/subagents/test/unit/notify.test.ts
+++ b/extensions/subagents/test/unit/notify.test.ts
@@ -2646,11 +2646,11 @@ describe("boundedReference", () => {
 // ---------------------------------------------------------------------------
 // truncateWithMarker surrogate safety — all four call sites
 //
-// The root cause (tlhm-vxik) is a raw value.slice(0, maxChars - marker.length)
-// inside truncateWithMarker that can leave an unpaired UTF-16 high surrogate
-// (U+D800–U+DBFF) at the cut boundary when an emoji straddles that position.
-// The fix replaces it with sliceSafe, which backs up one code unit when the
-// last retained unit is a high surrogate.
+// truncateWithMarker cuts at maxChars - marker.length. When a surrogate pair
+// (U+D800–U+DBFF high + U+DC00–U+DFFF low) straddles that position, a raw
+// slice leaves an unpaired high surrogate at the boundary, producing an
+// ill-formed string. sliceSafe enforces the invariant by backing up one code
+// unit when the last retained unit is a high surrogate.
 //
 // CUT-POINT DERIVATION: each cut is maxChars - marker.length, derived directly
 // from the function arguments.  Tests measure this from the constants rather

--- a/extensions/subagents/test/unit/result-intercom.test.ts
+++ b/extensions/subagents/test/unit/result-intercom.test.ts
@@ -439,7 +439,7 @@ describe("formatForegroundNativeSubagentText ceiling-contract sweep", () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// F1 premature-drop regression: no child is dropped while its bare
+	// Premature-drop guard: no child is dropped while its bare
 	// scaffolding would fit.
 	//
 	// Before the fix the per-child fit decision included a 1-char summary-line
@@ -456,7 +456,7 @@ describe("formatForegroundNativeSubagentText ceiling-contract sweep", () => {
 	// At artifactPath=426 the new scaffold is 8002 > 8000, so the drop to 7 is
 	// legitimate and expected in both old and new code.
 	// -------------------------------------------------------------------------
-	it("no child dropped while bare scaffolding fits — F1 premature-drop boundary", () => {
+	it("no child dropped while bare scaffolding fits", () => {
 		const artPath = "a".repeat(425); // 425 chars — scaffold_new = 7994 ≤ 8000
 		const sessPath = "b".repeat(500); // 500 chars (at the reference cap)
 		const children = Array.from({ length: 8 }, (_, i) => ({
@@ -501,5 +501,130 @@ describe("formatForegroundNativeSubagentText ceiling-contract sweep", () => {
 		// 7 of 8 is expected here (scaffold exceeds ceiling), and output must still be within bound.
 		assert.equal(artCountPlus, 7, `expected 7 artifact pointers at boundary+1, got ${artCountPlus}`);
 		assert.ok(textPlus.length <= MAX_CHARS, `length ${textPlus.length} exceeds ceiling`);
+	});
+
+	// -------------------------------------------------------------------------
+	// Bare-heading guard: orphaned 'Summary:' heading when per-child summary budget is exhausted.
+	//
+	// When the per-child summary budget is smaller than any well-formed truncation
+	// marker, boundedNativeForegroundSummary returns "", and the caller must NOT
+	// emit the 'Summary:' heading at all — an orphaned heading is worse than none.
+	//
+	// Measured shape: 8 children, 7 with 500-char artifact and session paths
+	// (budget too tight for any marker), 1 with no references (budget fits the
+	// shorter no-references marker). Before the fix: 7 bare 'Summary:' headings.
+	// After the fix: 0 bare 'Summary:' headings.
+	//
+	// Detector note: the previous search for this defect only treated a heading as
+	// bare when the next line was a child header or end of input, missing the case
+	// where scaffolding lines (e.g. 'Output artifact:') follow. The correct detector
+	// below treats a 'Summary:' heading as bare when its next non-blank line is
+	// scaffolding, an omission marker, or end of input.
+	// -------------------------------------------------------------------------
+	it("no bare 'Summary:' heading emitted when per-child summary budget is exhausted", () => {
+		// 7 children carry 500-char paths that push the per-child budget below any
+		// well-formed marker length; 1 child has no references and receives the shorter
+		// (49-char) no-references marker which still fits.
+		const fatArtPath = "a".repeat(500);
+		const fatSessPath = "b".repeat(500);
+		const children = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: "completed" as const,
+			summary: "S".repeat(1_200),
+			// 7 children with 500-char paths; last child has no references.
+			...(i < 7 ? { artifactPath: fatArtPath, sessionPath: fatSessPath } : {}),
+			index: i,
+		}));
+
+		const { text } = formatForegroundNativeSubagentResult({
+			runId: "run-finding-a-regression",
+			mode: "parallel",
+			children,
+		});
+
+		// All 8 children must still be displayed and output must be within ceiling.
+		assert.ok(text.length <= MAX_CHARS, `length ${text.length} exceeds ceiling`);
+		assert.equal((text.match(/worker-/g) ?? []).length, 8, "all 8 children must appear");
+
+		// Count bare 'Summary:' headings using the correct detector:
+		// a heading is bare when its next non-blank line is scaffolding,
+		// an omission marker, or end of input — NOT only when a child header follows.
+		const lines = text.split("\n");
+		let bareSummaryCount = 0;
+		for (let i = 0; i < lines.length; i++) {
+			if (lines[i]?.trim() !== "Summary:") continue;
+			let j = i + 1;
+			while (j < lines.length && lines[j]?.trim() === "") j++;
+			const next = lines[j]?.trim() ?? "";
+			// Scaffolding lines that would directly follow an orphaned heading:
+			const isScaffolding =
+				next.startsWith("Output artifact:") || next.startsWith("Session:") || next.startsWith("Nested subagents:");
+			const isOmissionMarker = next.startsWith("…");
+			const isChildHeader = /^\d+\/\d+\./.test(next); // e.g. '2/8. worker'
+			const isEndOfInput = j >= lines.length;
+			if (isScaffolding || isOmissionMarker || isEndOfInput || isChildHeader) bareSummaryCount++;
+		}
+		// Before the fix: 7 bare headings. After the fix: 0.
+		assert.equal(bareSummaryCount, 0, `${bareSummaryCount} bare 'Summary:' heading(s) found; expected 0`);
+
+		// Additional gate checks from the contract sweep.
+		assert.doesNotThrow(() => assertNoMangledMarker("finding-a", text));
+		assert.doesNotThrow(() => assertNoOrphanedNestedHeading("finding-a", text));
+		assert.ok(text.isWellFormed());
+	});
+
+	// -------------------------------------------------------------------------
+	// Omission-marker guard: marker must not direct reader to paths of retained children.
+	//
+	// When some (not all) children are dropped for size, the omitted children's
+	// paths are never emitted. The marker must not imply those results are
+	// reachable through paths that belong to retained children.
+	//
+	// Measured shape: 8 children at 499-char paths; 7 display, 1 is dropped.
+	// Before the fix: marker said "see listed paths above" (misdirected).
+	// After the fix: marker states output is not reachable from this envelope.
+	// -------------------------------------------------------------------------
+	it("partial-drop omission marker does not point at retained children's paths", () => {
+		// 499-char paths push the fixed cost just over the ceiling at 8 children,
+		// causing exactly 1 child to be dropped.
+		const artPath = "a".repeat(499);
+		const sessPath = "b".repeat(499);
+		const children = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: "completed" as const,
+			summary: "S".repeat(1_200),
+			artifactPath: artPath,
+			sessionPath: sessPath,
+			index: i,
+		}));
+
+		const { text } = formatForegroundNativeSubagentResult({
+			runId: "run-finding-b-regression",
+			mode: "parallel",
+			children,
+		});
+
+		// 7 children retained, 1 dropped — confirm the partial-drop case fired.
+		const artCount = (text.match(/Output artifact:/g) ?? []).length;
+		assert.equal(artCount, 7, `expected 7 retained artifact pointers, got ${artCount}`);
+
+		// The omission marker must not claim the dropped child's output is reachable
+		// through the retained children's paths.
+		assert.doesNotMatch(
+			text,
+			/see listed paths above/,
+			"marker must not direct reader to paths belonging to retained children",
+		);
+		// The marker must include the count and state that output is not reachable.
+		assert.match(
+			text,
+			/… \[1 additional child results omitted; their output is not reachable from this envelope\]/,
+			"marker must state omitted output is not reachable from this envelope",
+		);
+
+		// Ceiling and well-formedness.
+		assert.ok(text.length <= MAX_CHARS, `length ${text.length} exceeds ceiling`);
+		assert.doesNotThrow(() => assertNoMangledMarker("finding-b", text));
+		assert.ok(text.isWellFormed());
 	});
 });

--- a/extensions/subagents/test/unit/result-intercom.test.ts
+++ b/extensions/subagents/test/unit/result-intercom.test.ts
@@ -92,7 +92,7 @@ describe("result intercom formatter", () => {
 		);
 		assert.match(
 			grouped.text,
-			/… \[1 child results omitted; highest-priority results shown first, inspect retained details for the full set\]/,
+			/… \[1 child results omitted; highest-priority results shown first; full set is unavailable\]/,
 		);
 		assert.match(grouped.text, /Output artifact: \/tmp\/a\.md/);
 		assert.match(grouped.text, /Session: \/tmp\/b\.jsonl/);
@@ -155,13 +155,44 @@ describe("result intercom formatter", () => {
 		assert.equal(grouped.summary, "1 failed");
 		assert.match(grouped.text, /Chain steps: 2/);
 		assert.match(grouped.text, /Error:\nCollected output validation failed:/);
-		assert.match(grouped.text, /\[error truncated; inspect retained details for full text\]/);
+		assert.match(grouped.text, /\[error truncated; full text is unavailable\]/);
 		assert.match(grouped.text, /Summary:\ns+[\s\S]*\[summary truncated; see references below for full output\]/);
 		assert.match(grouped.text, /Nested subagents:/);
-		assert.match(grouped.text, /… \[nested depth limit reached; inspect retained details for full tree\]/);
-		assert.match(grouped.text, /… \[additional nested entries omitted; inspect retained details for full tree\]/);
+		assert.match(grouped.text, /… \[nested depth limit reached; full tree is unavailable\]/);
+		assert.match(grouped.text, /… \[additional nested entries omitted; full tree is unavailable\]/);
 		assert.equal(grouped.text.match(/Collected output validation failed/g)?.length ?? 0, 1);
 		assert.ok(grouped.text.length <= 8_000);
+	});
+
+	it("summary truncation is surrogate-safe in formatForegroundNativeSubagentResult", () => {
+		// MEASURE the cut point by passing a long pure-ASCII summary and counting
+		// how many content characters survive. This avoids hard-coding an offset
+		// that might drift when constants or markers change.
+		const ascii = "A".repeat(5_000);
+		const measured = formatForegroundNativeSubagentResult({
+			runId: "run-surr-measure",
+			mode: "parallel",
+			children: [{ agent: "a", status: "completed", summary: ascii, index: 0 }],
+		});
+		// Count how many 'A' characters survived — that is the exact cut index.
+		const summarySection = measured.text.split("\nSummary:\n")[1] ?? "";
+		const cutPoint = (summarySection.match(/A/g) ?? []).length;
+		assert.ok(cutPoint > 0, "expected summary to be truncated with some content surviving");
+
+		// Build a summary where an emoji's high surrogate lands exactly on the
+		// final kept code-unit position (index cutPoint - 1, 0-indexed).
+		// 🌍 (U+1F30D) encodes as two UTF-16 code units: high surrogate at
+		// cutPoint-1 and low surrogate at cutPoint. A raw slice(0, cutPoint)
+		// keeps the high surrogate but drops the low surrogate → ill-formed.
+		const emoji = "\u{1F30D}"; // 🌍 — two UTF-16 code units
+		const surrogateAtCut = "B".repeat(cutPoint - 1) + emoji + "C".repeat(5_000);
+		const result = formatForegroundNativeSubagentResult({
+			runId: "run-surr-safe",
+			mode: "parallel",
+			children: [{ agent: "a", status: "completed", summary: surrogateAtCut, index: 0 }],
+		});
+		// The formatter must produce a well-formed string — no unpaired surrogates.
+		assert.ok(result.text.isWellFormed(), "summary truncation must not strand a UTF-16 high surrogate");
 	});
 
 	it("resolves paused and detached statuses", () => {
@@ -169,5 +200,306 @@ describe("result intercom formatter", () => {
 		assert.equal(resolveSubagentResultStatus({ detached: true }), "detached");
 		assert.equal(resolveSubagentResultStatus({ success: true }), "completed");
 		assert.equal(resolveSubagentResultStatus({ exitCode: 1 }), "failed");
+	});
+});
+
+// =========================================================================
+// formatForegroundNativeSubagentText ceiling-contract sweep.
+//
+// Derived from measured behaviour on this file. Do NOT import notify.ts
+// fixtures — the caps, scaffolding, and structure differ.
+//
+// Five properties are checked per combination:
+//   1. Output never exceeds MAX_NATIVE_FOREGROUND_CHARS (8 000).
+//   2. Every displayed child retains BOTH recovery pointers (artifact + session).
+//   3. A 'Nested subagents:' heading is never emitted without content beneath it.
+//   4. No mangled truncation-marker fragments (e.g. '… [su').
+//   5. Output is always well-formed UTF-16.
+// =========================================================================
+describe("formatForegroundNativeSubagentText ceiling-contract sweep", () => {
+	const ART_PATH = "/home/user/.the-last-harness/agent/runs/run-12345678-abcd-efgh-ijkl/artifacts/subagent-output.md";
+	const SESS_PATH = "/home/user/.the-last-harness/agent/runs/run-12345678-abcd-efgh-ijkl/run-0/session.jsonl";
+	const LONG_SUMMARY = "S".repeat(2_000); // well above MAX_NATIVE_FOREGROUND_SUMMARY_CHARS (1 200)
+	const MAX_CHARS = 8_000;
+
+	// Every marker this module emits has the shape '… [<text>]'. A bare '…' that is not
+	// followed by a complete bracketed marker is a sliced fragment.
+	const WELL_FORMED_MARKER = /^… \[[^\[\]]*\]/;
+	function assertNoMangledMarker(label: string, text: string): void {
+		for (let i = text.indexOf("…"); i !== -1; i = text.indexOf("…", i + 1)) {
+			assert.ok(
+				WELL_FORMED_MARKER.test(text.slice(i)),
+				`[${label}]: mangled marker at ${i}: ${JSON.stringify(text.slice(i, i + 40))}`,
+			);
+		}
+	}
+
+	// Structural well-formedness: a 'Nested subagents:' heading must never appear
+	// without content beneath it. A length check alone cannot catch this because an
+	// orphaned heading still fits within the ceiling while producing meaningless output.
+	function assertNoOrphanedNestedHeading(label: string, text: string): void {
+		const lines = text.split("\n");
+		for (let i = 0; i < lines.length; i++) {
+			if (lines[i]?.trim() !== "Nested subagents:") continue;
+			let j = i + 1;
+			while (j < lines.length && lines[j]?.trim() === "") j++;
+			const next = lines[j]?.trim() ?? "";
+			// The next non-empty line must be a nested entry (↳) or an omission marker (…).
+			const hasContent = next.startsWith("↳") || next.startsWith("…");
+			assert.ok(
+				hasContent,
+				`[${label}]: orphaned 'Nested subagents:' heading at line ${i} — next non-empty line: ${JSON.stringify(next)}`,
+			);
+		}
+	}
+
+	function makeNestedEntry(id: string) {
+		return {
+			id,
+			parentRunId: "root",
+			depth: 1 as const,
+			path: [{ runId: "root" }],
+			state: "complete",
+			agent: `nested-${id}`,
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// Detection check for the orphaned-heading guard.
+	//
+	// WHAT THIS ESTABLISHES: assertNoOrphanedNestedHeading actually fires when an
+	// orphaned heading is present, and does not fire on real formatter output. A
+	// guard that has never failed is not evidence of anything, so the detection
+	// half is exercised against a hand-built sample.
+	//
+	// WHAT THIS DOES NOT ESTABLISH: this formatter cannot produce an orphaned
+	// heading through its current code paths, so no live formatter run is used
+	// as the triggering input. The sample below is hand-built to exercise the
+	// assertNoOrphanedNestedHeading helper itself.
+	//
+	// The guard is FORWARD-LOOKING: nested lines are computed as a unit, and a
+	// future change that emits the heading and then omits the entries beneath it
+	// without a marker would produce exactly the defect this guard catches.
+	// -------------------------------------------------------------------------
+	it("orphaned-heading guard detects a bare heading and passes on real formatter output", () => {
+		// Construct text where 'Nested subagents:' is followed by a blank line and then
+		// an artifact line — NOT a nested entry (↳) or omission marker (…).
+		const orphanedText = [
+			"subagent results",
+			"",
+			"Run: run-x",
+			"Mode: parallel",
+			"Status: completed",
+			"Children: 1 completed",
+			"",
+			"1/1. worker — completed",
+			"Summary:",
+			"done",
+			"Nested subagents:",
+			// Blank line then non-nested-entry content: the defect.
+			"",
+			"Output artifact: /tmp/a.md",
+		].join("\n");
+
+		// The guard must detect the defect.
+		assert.throws(
+			() => assertNoOrphanedNestedHeading("hand-built-bare-heading-sample", orphanedText),
+			/orphaned/,
+			"assertNoOrphanedNestedHeading must fire on text with an orphaned 'Nested subagents:' heading",
+		);
+
+		// Real formatter output must pass the same guard.
+		const result = formatForegroundNativeSubagentResult({
+			runId: "run-x",
+			mode: "parallel",
+			children: [
+				{
+					agent: "worker",
+					status: "completed",
+					summary: "done",
+					index: 0,
+					children: [makeNestedEntry("n1")],
+				},
+			],
+		});
+		// Must not throw.
+		assert.doesNotThrow(
+			() => assertNoOrphanedNestedHeading("real-formatter-output", result.text),
+			"formatter must not produce an orphaned 'Nested subagents:' heading",
+		);
+		// Must also have the nested entry in the output.
+		assert.match(result.text, /Nested subagents:/, "nested section must appear");
+		assert.match(result.text, /↳ nested-n1/, "nested entry must appear beneath the heading");
+	});
+
+	// -------------------------------------------------------------------------
+	// Pointer survival sweep: 1 through 8 children.
+	//
+	// Every displayed child must keep both recovery pointers inside the ceiling.
+	// ART_PATH is 96 chars; SESS_PATH is 87 chars. Measured output lengths with
+	// 2 000-char summaries (runId="run-sweep-N"):
+	//   5 children → 7333 chars, 5/5 pointers
+	//   6 children → 7995 chars, 6/6 pointers
+	//   8 children → 7997 chars, 8/8 pointers
+	// -------------------------------------------------------------------------
+	for (let n = 1; n <= 8; n++) {
+		it(`${n} children: all displayed children retain both recovery pointers within the ceiling`, () => {
+			const children = Array.from({ length: n }, (_, i) => ({
+				agent: `worker-${i}`,
+				// Put one failed child first so priority ordering exercises the sort path.
+				status: (i === 0 && n > 1 ? "failed" : "completed") as "failed" | "completed",
+				summary: LONG_SUMMARY,
+				artifactPath: ART_PATH,
+				sessionPath: SESS_PATH,
+				index: i,
+			}));
+
+			const { text } = formatForegroundNativeSubagentResult({
+				runId: `run-sweep-${n}`,
+				mode: "parallel",
+				children,
+			});
+
+			const displayedN = Math.min(n, 8); // MAX_NATIVE_FOREGROUND_CHILDREN
+
+			// 1. Must not exceed the ceiling.
+			assert.ok(text.length <= MAX_CHARS, `n=${n}: length ${text.length} exceeds ceiling ${MAX_CHARS}`);
+
+			// 2. Every displayed child must retain BOTH recovery pointers.
+			const artifactCount = (text.match(/Output artifact:/g) ?? []).length;
+			const sessionCount = (text.match(/Session:/g) ?? []).length;
+			assert.equal(artifactCount, displayedN, `n=${n}: expected ${displayedN} artifact pointers, got ${artifactCount}`);
+			assert.equal(sessionCount, displayedN, `n=${n}: expected ${displayedN} session pointers, got ${sessionCount}`);
+
+			// 3. No orphaned 'Nested subagents:' headings.
+			assert.doesNotThrow(
+				() => assertNoOrphanedNestedHeading(`n=${n}`, text),
+				`n=${n}: orphaned 'Nested subagents:' heading in output`,
+			);
+
+			// 4. No mangled truncation markers.
+			assert.doesNotThrow(() => assertNoMangledMarker(`n=${n}`, text), `n=${n}: mangled truncation marker in output`);
+
+			// 5. Well-formed UTF-16.
+			assert.ok(text.isWellFormed(), `n=${n}: output contains ill-formed UTF-16`);
+		});
+	}
+
+	it("8 children with nested subagents: all displayed children retain pointers and no orphaned headings", () => {
+		const children = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: "completed" as const,
+			summary: "S".repeat(500),
+			artifactPath: ART_PATH,
+			sessionPath: SESS_PATH,
+			index: i,
+			// Every other child has a nested subagent to exercise the heading guard.
+			children: i % 2 === 0 ? [makeNestedEntry(`n${i}`)] : undefined,
+		}));
+
+		const { text } = formatForegroundNativeSubagentResult({
+			runId: "run-nested-sweep",
+			mode: "parallel",
+			children,
+		});
+
+		assert.ok(text.length <= MAX_CHARS, `length ${text.length} exceeds ceiling`);
+		assert.doesNotThrow(() => assertNoOrphanedNestedHeading("8-children-nested", text));
+		assert.doesNotThrow(() => assertNoMangledMarker("8-children-nested", text));
+		assert.ok(text.isWellFormed());
+		// All 8 children must retain both pointers.
+		assert.equal((text.match(/Output artifact:/g) ?? []).length, 8, "all 8 artifact pointers must survive");
+		assert.equal((text.match(/Session:/g) ?? []).length, 8, "all 8 session pointers must survive");
+	});
+
+	it("output stays within ceiling when children have very long reference paths", () => {
+		// Max-length paths push the per-child fixed cost near the reference cap (500 chars),
+		// stressing the budget computation in a way that short paths do not.
+		const longArt = "/artifacts/" + "a".repeat(480) + "/out.md";
+		const longSess = "/sessions/" + "b".repeat(480) + "/session.jsonl";
+		const children = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: "completed" as const,
+			summary: LONG_SUMMARY,
+			artifactPath: longArt,
+			sessionPath: longSess,
+			index: i,
+		}));
+
+		const { text } = formatForegroundNativeSubagentResult({
+			runId: "run-long-refs",
+			mode: "parallel",
+			children,
+		});
+
+		assert.ok(text.length <= MAX_CHARS, `length ${text.length} exceeds ceiling`);
+		assert.doesNotThrow(() => assertNoMangledMarker("long-refs", text));
+		assert.doesNotThrow(() => assertNoOrphanedNestedHeading("long-refs", text));
+		assert.ok(text.isWellFormed());
+	});
+
+	// -------------------------------------------------------------------------
+	// F1 premature-drop regression: no child is dropped while its bare
+	// scaffolding would fit.
+	//
+	// Before the fix the per-child fit decision included a 1-char summary-line
+	// placeholder in fixedCost, making the loop think each child cost 1 char more
+	// than its bare scaffolding actually does. With 8 children the overcount was
+	// 8 chars, causing a premature drop whenever the true scaffold total was in
+	// [7993, 8000] — a range the loop saw as [8001, 8008].
+	//
+	// Boundary measured with: runId="" (outerCost=85), artifactPath=425 chars,
+	// sessionPath=500 chars. Per-child fixedCost (new, 8-child sum): 7909.
+	// Scaffold_new = 85 + 7909 = 7994 ≤ 8000 → all 8 fit.
+	// Scaffold_old = 7994 + 8 = 8002 > 8000 → premature drop to 7.
+	//
+	// At artifactPath=426 the new scaffold is 8002 > 8000, so the drop to 7 is
+	// legitimate and expected in both old and new code.
+	// -------------------------------------------------------------------------
+	it("no child dropped while bare scaffolding fits — F1 premature-drop boundary", () => {
+		const artPath = "a".repeat(425); // 425 chars — scaffold_new = 7994 ≤ 8000
+		const sessPath = "b".repeat(500); // 500 chars (at the reference cap)
+		const children = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: (i === 0 ? "failed" : "completed") as "failed" | "completed",
+			summary: LONG_SUMMARY,
+			artifactPath: artPath,
+			sessionPath: sessPath,
+			index: i,
+		}));
+
+		const { text } = formatForegroundNativeSubagentResult({
+			runId: "", // empty runId gives outerCost=85
+			mode: "parallel",
+			children,
+		});
+		const artCount = (text.match(/Output artifact:/g) ?? []).length;
+		const sessCount = (text.match(/Session:/g) ?? []).length;
+
+		// All 8 children must render: their bare scaffolding (7994 chars) fits.
+		assert.equal(artCount, 8, `expected 8 artifact pointers, got ${artCount}`);
+		assert.equal(sessCount, 8, `expected 8 session pointers, got ${sessCount}`);
+		assert.ok(text.length <= MAX_CHARS, `length ${text.length} exceeds ceiling`);
+		assert.ok(text.isWellFormed());
+
+		// At +1 char (artifactPath=426), scaffold_new = 8002 > 8000: drop to 7 is legitimate.
+		const artPlus = "a".repeat(426);
+		const childrenPlus = Array.from({ length: 8 }, (_, i) => ({
+			agent: `worker-${i}`,
+			status: (i === 0 ? "failed" : "completed") as "failed" | "completed",
+			summary: LONG_SUMMARY,
+			artifactPath: artPlus,
+			sessionPath: sessPath,
+			index: i,
+		}));
+		const { text: textPlus } = formatForegroundNativeSubagentResult({
+			runId: "",
+			mode: "parallel",
+			children: childrenPlus,
+		});
+		const artCountPlus = (textPlus.match(/Output artifact:/g) ?? []).length;
+		// 7 of 8 is expected here (scaffold exceeds ceiling), and output must still be within bound.
+		assert.equal(artCountPlus, 7, `expected 7 artifact pointers at boundary+1, got ${artCountPlus}`);
+		assert.ok(textPlus.length <= MAX_CHARS, `length ${textPlus.length} exceeds ceiling`);
 	});
 });

--- a/tests/package-runtime-smoke.test.mjs
+++ b/tests/package-runtime-smoke.test.mjs
@@ -101,7 +101,7 @@ Return the deterministic faux child marker exactly.
 	]
 		.map((path) => path.replace(/\.ts$/, ".js"))
 		.sort();
-	assert.equal(generatedExtensionPaths.length, 165);
+	assert.equal(generatedExtensionPaths.length, 166);
 	for (const generatedPath of generatedExtensionPaths) {
 		assert.ok(packedPaths.has(generatedPath), `npm pack omitted generated extension module ${generatedPath}`);
 	}

--- a/tests/runtime-typescript-infra.test.mjs
+++ b/tests/runtime-typescript-infra.test.mjs
@@ -256,7 +256,7 @@ test("dedicated subagents runtime target compiles all production modules and rew
 	const sourcePaths = globSync("extensions/subagents/src/**/*.ts", { cwd: repoRoot }).filter(
 		(path) => !path.endsWith(".d.ts"),
 	);
-	assert.equal(sourcePaths.length, 92);
+	assert.equal(sourcePaths.length, 93);
 	for (const sourcePath of sourcePaths) {
 		const outputPath = sourcePath.replace(/\.ts$/, ".js");
 		assert.equal(existsSync(join(repoRoot, outputPath)), true, `${outputPath} should exist`);


### PR DESCRIPTION
## Summary

Foreground subagent result envelopes are capped at 8000 characters. The envelope was assembled from all child blocks and then end-truncated, but each block carries its own `Output artifact:` and `Session:` lines — so late children were deleted wholesale along with the only routes back to their output.

Measured with realistic paths: **5 children retained 4 of 5 pointer pairs, 6 retained 4 of 6, 8 retained 4 of 8.** Loss begins at five children.

Allocation is now budget-based. The fixed recovery scaffolding is reserved before the remainder is divided among summaries, so every displayed child keeps both pointers. A child that genuinely cannot fit is dropped with an explicit numeric omission marker rather than silently.

Two related problems are fixed in the same pass:

- **Eight truncation markers told the model to inspect retained details.** `AgentToolResult.details` is attached to the tool result message, but the Anthropic and OpenAI serializers both build model-visible content from `msg.content` alone and never read it. That route does not exist. Markers now name only reachable routes: an artifact path, a session path, or an explicit statement that output is unavailable. Marker length feeds truncation budgets, so every replacement was kept shorter than the text it replaced.
- **`truncateWithMarker` existed as two literal copies.** Only the `notify.ts` copy was surrogate-safe; the `result-intercom.ts` copy sliced raw and could strand an unpaired high surrogate. Both are replaced by one implementation in `src/shared/string-utils.ts`.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Exits **0**, zero failure indicators.

Behavioural verification was done by running the real formatter rather than reasoning from source:

| Property | Result |
|---|---|
| Recovery pointers, child counts 1–8 | **8/8 at every count** (was 4/5, 4/6, 4/8) |
| Output length vs 8000 ceiling | never exceeded across a 40-shape sweep |
| Orphaned `Nested subagents:` headings | 0 |
| Sliced or mangled markers | 0 |
| Well-formed UTF-16 output | 100% |
| Same shapes against the pre-change formatter | 64/90 pointers vs **90/90** now |

Two repo-level count assertions were updated because this branch adds one module: `generatedExtensionPaths.length` 165→166 and `sourcePaths.length` 92→93. The delta was verified to be exactly one new source module and one generated module before the numbers were changed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer surface touched)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Review notes

### Severity: this defect is latent, not active

I originally reported this as the change that "actually bites users" and that was wrong. Across 775 real session files there are 279 foreground envelopes; 69 postdate the 8000-char cap. Of those **69: zero exceeded the cap, zero were truncated, and the maximum child count ever observed is 3.** Every oversized envelope in the corpus predates the cap. The unsafe raw slice is likewise latent — summary truncation is common (38 of 69 envelopes) but no sampled envelope contained astral characters.

This is worth fixing because it is wrong and cheap to fix, not because it is firing today.

### Six defects found by review of this change, all fixed here

Review of the initial implementation returned six findings. All six were verified empirically before being acted on, and two severities were revised in the process.

The one that mattered was a regression introduced by this PR's own rewording: the chain-step note decided "full step output is unavailable" from output mode alone, while the enclosing block may render an artifact path directly beneath it. The previous text named an unreachable field, which is useless; the replacement made a positive false claim, which is worse, because it can stop the model reading a route sitting right there. Wording is now derived from the references the block actually emits.

The rest are boundary conditions that cannot fire with real data (longest observed path is 212 characters against a 500 cap): a child dropped while its bare scaffolding would have fit, summary suppression compared against the longer of two markers, an omission marker pointing at a path list that can be empty, and the shared helper's documented contract not holding for a non-BMP marker.

One finding was that test comments recorded fixture sizes and output lengths that did not match the fixtures they described. Those numbers are re-measured, and the fixture is now named in the comment so they can be re-derived rather than taken on trust.

### Deliberately out of scope

`boundedNativeForegroundReference` head-truncates at 500 characters, destroying the identifying tail of a path — unlike the equivalent helper in `notify.ts`, which preserves it. This is a real divergence and is left alone here: the longest path observed in the corpus is 212 characters, so it cannot fire, and folding it in would widen a change that is already broad. Worth its own low-priority follow-up.

Grapheme-cluster splitting is also out of scope. A split emoji is cosmetic; a lone surrogate is an ill-formed string, and only the latter is addressed.

### CI

All 10 checks pass on this branch.

I predicted in an earlier version of this description that the PR would inherit a failure from main, because `Tests (ubuntu-latest, shard 2/2)` is red on `09a2745` — this branch's merge-base and main's tip. That prediction was wrong, and the correction is worth recording rather than quietly deleting.

Main's failure is a flaky async test, not a broken build:

```
not ok 23 - resume action revives paused async acceptance with paused-ledger provenance and monotonic overrides
  error: 'Timed out waiting for file: /tmp/pi-subagents-test-root-wDWMy6/async-subagent-results/c76da338.json'
```

A timeout waiting on a result file in a randomly-named temp directory. It is tracked separately and is unrelated to this change. The same shard passes here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreground and background output truncation to stay within display limits while preserving available artifact and session recovery links.
  * Added clear notices when full diagnostics, child results, or nested output cannot be shown.
  * Prevented truncated text from splitting Unicode characters.
  * Improved prioritization of child results so important output remains visible under tight limits.

* **Tests**
  * Expanded coverage for output limits, omission notices, recovery references, nested results, and Unicode-safe truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->