### PR TITLE
Drop parallel count from subagent call header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ All notable changes to The Last Harness will be documented in this file.
 - Child-process JSON streams and quiet Glimpse no longer crash on valid non-object JSON; background and foreground runs retain those lines in raw output or transcripts where applicable.
 - When a foreground subagent run finishes with many children and the result summary has to be trimmed, every child that appears now keeps both of its recovery paths (artifact and session). Previously the summary was built in full and then cut at the end, which could silently delete whole child blocks — and the only pointers back to their output — from the tail. A child that genuinely cannot fit is now marked with an explicit omission notice instead of disappearing quietly.
 - Truncation notices in subagent output previously told the model to look at details it has no way of reading. They now point only at routes that actually exist: an artifact path, a session path, or a plain statement that the output is unavailable.
-### Changed
-
-- The subagent tool-call header no longer repeats `parallel (N)` for parallel dispatches; the result line's `parallel · x/y done` remains the single parallel indicator.
 
 ## [0.37.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to The Last Harness will be documented in this file.
 - When a foreground subagent run finishes with many children and the result summary has to be trimmed, every child that appears now keeps both of its recovery paths (artifact and session). Previously the summary was built in full and then cut at the end, which could silently delete whole child blocks — and the only pointers back to their output — from the tail. A child that genuinely cannot fit is now marked with an explicit omission notice instead of disappearing quietly.
 - Truncation notices in subagent output previously told the model to look at details it has no way of reading. They now point only at routes that actually exist: an artifact path, a session path, or a plain statement that the output is unavailable.
 
+### Changed
+
+- The subagent tool-call header no longer repeats `parallel (N)` for parallel dispatches; the result line's `parallel · x/y done` remains the single parallel indicator.
+
 ## [0.37.0] - 2026-08-11
 
 ### Model defaults

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to The Last Harness will be documented in this file.
 - Child-process JSON streams and quiet Glimpse no longer crash on valid non-object JSON; background and foreground runs retain those lines in raw output or transcripts where applicable.
 - When a foreground subagent run finishes with many children and the result summary has to be trimmed, every child that appears now keeps both of its recovery paths (artifact and session). Previously the summary was built in full and then cut at the end, which could silently delete whole child blocks — and the only pointers back to their output — from the tail. A child that genuinely cannot fit is now marked with an explicit omission notice instead of disappearing quietly.
 - Truncation notices in subagent output previously told the model to look at details it has no way of reading. They now point only at routes that actually exist: an artifact path, a session path, or a plain statement that the output is unavailable.
-
 ### Changed
 
 - The subagent tool-call header no longer repeats `parallel (N)` for parallel dispatches; the result line's `parallel · x/y done` remains the single parallel indicator.

--- a/extensions/subagents/src/extension/index.js
+++ b/extensions/subagents/src/extension/index.js
@@ -425,14 +425,6 @@ export default function registerSubagentExtension(pi) {
         getContext: () => state.lastUiContext,
         execute: (id, params, signal, onUpdate, ctx) => executeSubagent(id, params, signal, onUpdate, ctx),
     });
-    function effectiveParallelTaskCount(tasks) {
-        if (!tasks || tasks.length === 0)
-            return 0;
-        return tasks.reduce((total, task) => {
-            const count = typeof task.count === "number" && Number.isInteger(task.count) && task.count >= 1 ? task.count : 1;
-            return total + count;
-        }, 0);
-    }
     const parameters = SubagentParams;
     const tool = defineTool({
         name: "subagent",
@@ -451,10 +443,9 @@ export default function registerSubagentExtension(pi) {
                 return new Text(`${theme.fg("toolTitle", theme.bold("subagent "))}${args.action}${target ? ` ${theme.fg("accent", target)}` : ""}`, 0, 0);
             }
             const isParallel = (args.tasks?.length ?? 0) > 0;
-            const parallelCount = effectiveParallelTaskCount(args.tasks);
             const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
             if (isParallel)
-                return new Text(`${theme.fg("toolTitle", theme.bold("subagent "))}parallel (${parallelCount})${asyncLabel}`, 0, 0);
+                return new Text(`${theme.fg("toolTitle", theme.bold("subagent"))}${asyncLabel}`, 0, 0);
             return new Text(`${theme.fg("toolTitle", theme.bold("subagent "))}${theme.fg("accent", args.agent || "?")}${asyncLabel}`, 0, 0);
         },
         renderResult(result, options, theme, context) {

--- a/extensions/subagents/src/extension/index.ts
+++ b/extensions/subagents/src/extension/index.ts
@@ -591,14 +591,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		execute: (id, params, signal, onUpdate, ctx) => executeSubagent(id, params, signal, onUpdate, ctx),
 	});
 
-	function effectiveParallelTaskCount(tasks: Array<{ count?: unknown }> | undefined): number {
-		if (!tasks || tasks.length === 0) return 0;
-		return tasks.reduce((total, task) => {
-			const count = typeof task.count === "number" && Number.isInteger(task.count) && task.count >= 1 ? task.count : 1;
-			return total + count;
-		}, 0);
-	}
-
 	const parameters = SubagentParams;
 	const tool = defineTool<typeof parameters, Details>({
 		name: "subagent",
@@ -622,11 +614,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 				);
 			}
 			const isParallel = (args.tasks?.length ?? 0) > 0;
-			const parallelCount = effectiveParallelTaskCount(args.tasks as Array<{ count?: unknown }> | undefined);
 			const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
 			if (isParallel)
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}parallel (${parallelCount})${asyncLabel}`,
+					`${theme.fg("toolTitle", theme.bold("subagent"))}${asyncLabel}`,
 					0,
 					0,
 				);

--- a/extensions/subagents/src/extension/index.ts
+++ b/extensions/subagents/src/extension/index.ts
@@ -615,12 +615,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 			const isParallel = (args.tasks?.length ?? 0) > 0;
 			const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
-			if (isParallel)
-				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent"))}${asyncLabel}`,
-					0,
-					0,
-				);
+			if (isParallel) return new Text(`${theme.fg("toolTitle", theme.bold("subagent"))}${asyncLabel}`, 0, 0);
 			return new Text(
 				`${theme.fg("toolTitle", theme.bold("subagent "))}${theme.fg("accent", args.agent || "?")}${asyncLabel}`,
 				0,

--- a/extensions/subagents/test/unit/index-child-registration.test.ts
+++ b/extensions/subagents/test/unit/index-child-registration.test.ts
@@ -497,7 +497,7 @@ describe("subagent extension child mode", () => {
 			const asyncSingle = registeredTool.renderCall({ agent: "worker", async: true }, theme).text;
 			const asyncParallel = registeredTool.renderCall({ tasks: [{ agent: "worker" }, { agent: "reviewer", count: 2 }], async: true }, theme).text;
 			if (!asyncSingle.includes("[async]")) throw new Error("expected async single badge, got " + asyncSingle);
-			if (!asyncParallel.includes("parallel (3) [async]")) throw new Error("expected async parallel badge, got " + asyncParallel);
+			if (!asyncParallel.includes("[async]") || asyncParallel.includes("parallel")) throw new Error("expected async parallel badge without parallel count, got " + asyncParallel);
 		`;
 
 		execFileSync(


### PR DESCRIPTION
## Summary

Parallel subagent dispatches showed `parallel (N)` twice: once on the tool-call header line (`subagent parallel (2)`) and again on the result header (`parallel · 1/2 done`). The call header now renders just `subagent` (plus the `[async]` badge when applicable), leaving the result line as the single parallel indicator. Removed the now-unused `effectiveParallelTaskCount` helper and updated the affected unit test.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Targeted checks for the touched area:

```sh
TLH_RUNTIME_TYPESCRIPT_TARGETS=subagents node scripts/runtime-typescript.mjs build  # regenerated index.js, no errors
npm run test:subagents:unit  # 1008/1008 tests passed across 83 files
```

`tsc --noEmit` reports no new errors in changed files (2 pre-existing errors in unrelated `extensions/the-last-harness/model-visibility.ts`).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/drop-parallel-count-from-call-header/install.sh | bash -s -- --ref drop-parallel-count-from-call-header --track ref
```
