### PR TITLE
Await JSONL artifact flush before foreground run resolves

### DIFF
--- a/extensions/subagents/src/runs/foreground/execution.js
+++ b/extensions/subagents/src/runs/foreground/execution.js
@@ -935,139 +935,144 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
         proc.on("close", (code, signal) => {
             clearFinalDrainTimers();
             clearStdioGuard();
-            void jsonlWriter.close().catch(() => {
-            });
-            cleanupTempDir(tempDir);
             result.exitSignal = signal ?? undefined;
             if (buf.trim())
                 processLine(buf);
             if (stderrBuf.trim())
                 shared.transcriptWriter?.writeStderrText(stderrBuf);
-            if (!result.error && assistantError)
-                result.error = assistantError;
-            const forcedDrainAfterFinalSuccess = forcedTerminationSignal && cleanTerminalAssistantStopReceived && !result.error;
-            if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
-                result.error = stderrBuf.trim();
-            }
-            const finalCode = forcedDrainAfterFinalSuccess
-                ? 0
-                : forcedTerminationSignal || signal
-                    ? (code ?? 1)
-                    : (code ?? 0);
-            if (supervisorPauseRequested) {
-                void (async () => {
-                    const cleanup = await beginSupervisorPauseCleanup();
-                    result.processCleanup = cleanup;
-                    if (!cleanup.terminated) {
-                        supervisorPauseRequested = false;
-                        result.pause = undefined;
-                        result.interrupted = false;
-                        result.exitCode = 1;
-                        result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
-                        result.finalOutput = result.error;
+            processClosed = true;
+            void (async () => {
+                await jsonlWriter.close().catch(() => {
+                });
+                cleanupTempDir(tempDir);
+                if (!result.error && assistantError)
+                    result.error = assistantError;
+                const forcedDrainAfterFinalSuccess = forcedTerminationSignal && cleanTerminalAssistantStopReceived && !result.error;
+                if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
+                    result.error = stderrBuf.trim();
+                }
+                const finalCode = forcedDrainAfterFinalSuccess
+                    ? 0
+                    : forcedTerminationSignal || signal
+                        ? (code ?? 1)
+                        : (code ?? 0);
+                if (supervisorPauseRequested) {
+                    void (async () => {
+                        const cleanup = await beginSupervisorPauseCleanup();
+                        result.processCleanup = cleanup;
+                        if (!cleanup.terminated) {
+                            supervisorPauseRequested = false;
+                            result.pause = undefined;
+                            result.interrupted = false;
+                            result.exitCode = 1;
+                            result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
+                            result.finalOutput = result.error;
+                            result.exitSignal = undefined;
+                            progress.status = "failed";
+                            progress.error = result.error;
+                            finish(1);
+                            return;
+                        }
+                        result.exitCode = 0;
+                        result.interrupted = true;
+                        result.error = undefined;
                         result.exitSignal = undefined;
-                        progress.status = "failed";
-                        progress.error = result.error;
-                        finish(1);
-                        return;
-                    }
-                    result.exitCode = 0;
-                    result.interrupted = true;
-                    result.error = undefined;
-                    result.exitSignal = undefined;
-                    if (result.pause)
-                        result.pause = { ...result.pause, pausedAt: Date.now(), ownerPid: undefined };
+                        if (result.pause)
+                            result.pause = { ...result.pause, pausedAt: Date.now(), ownerPid: undefined };
+                        progress.durationMs = Date.now() - startTime;
+                        result.progressSummary = {
+                            toolCount: progress.toolCount,
+                            tokens: progress.tokens,
+                            durationMs: progress.durationMs,
+                        };
+                        resolveResultSessionFile(result, options, shared.sessionEnabled);
+                        try {
+                            options.onSupervisorPauseTransition?.({
+                                stage: "paused",
+                                result: snapshotResult(result, snapshotProgress(progress)),
+                            });
+                        }
+                        catch {
+                            supervisorPauseRequested = false;
+                            result.pause = undefined;
+                            result.interrupted = false;
+                            result.exitCode = 1;
+                            result.error = FOREGROUND_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+                            result.finalOutput = result.error;
+                            progress.status = "failed";
+                            progress.error = result.error;
+                            finish(1);
+                            return;
+                        }
+                        finish(0);
+                    })();
+                    return;
+                }
+                if (interruptedByControl) {
+                    void (async () => {
+                        const cleanup = await beginSupervisorPauseCleanup();
+                        result.processCleanup = cleanup;
+                        if (!cleanup.terminated) {
+                            interruptedByControl = false;
+                            result.interrupted = false;
+                            result.exitCode = 1;
+                            result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
+                            result.finalOutput = result.error;
+                            progress.status = "failed";
+                            progress.error = result.error;
+                            finish(1);
+                            return;
+                        }
+                        processClosed = true;
+                        finish(finalCode);
+                    })();
+                    return;
+                }
+                if (detached) {
+                    result.exitCode = result.error && finalCode === 0 ? 1 : finalCode;
+                    progress.status = result.exitCode === 0 ? "completed" : "failed";
                     progress.durationMs = Date.now() - startTime;
+                    if (result.error)
+                        progress.error = result.error;
                     result.progressSummary = {
                         toolCount: progress.toolCount,
                         tokens: progress.tokens,
                         durationMs: progress.durationMs,
                     };
-                    resolveResultSessionFile(result, options, shared.sessionEnabled);
-                    try {
-                        options.onSupervisorPauseTransition?.({
-                            stage: "paused",
-                            result: snapshotResult(result, snapshotProgress(progress)),
-                        });
+                    const finalOutput = getFinalOutput(result.messages ?? []);
+                    result.finalOutput =
+                        finalOutput.trim() || result.error || result.finalOutput || "Detached child exited without final output.";
+                    if (result.artifactPaths &&
+                        options.artifactConfig?.enabled !== false &&
+                        options.artifactConfig?.includeOutput !== false) {
+                        try {
+                            writeArtifact(result.artifactPaths.outputPath, result.finalOutput);
+                        }
+                        catch {
+                        }
                     }
-                    catch {
-                        supervisorPauseRequested = false;
-                        result.pause = undefined;
-                        result.interrupted = false;
-                        result.exitCode = 1;
-                        result.error = FOREGROUND_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-                        result.finalOutput = result.error;
-                        progress.status = "failed";
-                        progress.error = result.error;
-                        finish(1);
-                        return;
-                    }
-                    finish(0);
-                })();
-                return;
-            }
-            if (interruptedByControl) {
-                void (async () => {
-                    const cleanup = await beginSupervisorPauseCleanup();
-                    result.processCleanup = cleanup;
-                    if (!cleanup.terminated) {
-                        interruptedByControl = false;
-                        result.interrupted = false;
-                        result.exitCode = 1;
-                        result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
-                        result.finalOutput = result.error;
-                        progress.status = "failed";
-                        progress.error = result.error;
-                        finish(1);
-                        return;
-                    }
-                    processClosed = true;
-                    finish(finalCode);
-                })();
-                return;
-            }
-            if (detached) {
-                result.exitCode = result.error && finalCode === 0 ? 1 : finalCode;
-                progress.status = result.exitCode === 0 ? "completed" : "failed";
-                progress.durationMs = Date.now() - startTime;
-                if (result.error)
-                    progress.error = result.error;
-                result.progressSummary = {
-                    toolCount: progress.toolCount,
-                    tokens: progress.tokens,
-                    durationMs: progress.durationMs,
-                };
-                const finalOutput = getFinalOutput(result.messages ?? []);
-                result.finalOutput =
-                    finalOutput.trim() || result.error || result.finalOutput || "Detached child exited without final output.";
-                if (result.artifactPaths &&
-                    options.artifactConfig?.enabled !== false &&
-                    options.artifactConfig?.includeOutput !== false) {
-                    try {
-                        writeArtifact(result.artifactPaths.outputPath, result.finalOutput);
-                    }
-                    catch {
-                    }
+                    options.onDetachedExit?.(snapshotResult(result, snapshotProgress(progress)));
+                    finish(-2);
+                    return;
                 }
-                options.onDetachedExit?.(snapshotResult(result, snapshotProgress(progress)));
-                finish(-2);
-                return;
-            }
-            processClosed = true;
-            finish(finalCode);
+                finish(finalCode);
+            })();
         });
         proc.on("error", (error) => {
             clearFinalDrainTimers();
             clearStdioGuard();
-            void jsonlWriter.close().catch(() => {
-            });
-            cleanupTempDir(tempDir);
             if (stderrBuf.trim())
                 shared.transcriptWriter?.writeStderrText(stderrBuf);
             if (!result.error) {
                 result.error = error instanceof Error ? error.message : String(error);
             }
-            finish(1);
+            processClosed = true;
+            void (async () => {
+                await jsonlWriter.close().catch(() => {
+                });
+                cleanupTempDir(tempDir);
+                finish(1);
+            })();
         });
         if (options.signal) {
             const kill = () => {

--- a/extensions/subagents/src/runs/foreground/execution.ts
+++ b/extensions/subagents/src/runs/foreground/execution.ts
@@ -1115,139 +1115,155 @@ async function runSingleAttempt(
 			clearFinalDrainTimers();
 		});
 		proc.on("close", (code, signal) => {
+			// Synchronous prelude — runs before any await so guards cannot observe stale state.
 			clearFinalDrainTimers();
 			clearStdioGuard();
-			void jsonlWriter.close().catch(() => {
-				// JSONL artifact flush is best effort.
-			});
-			cleanupTempDir(tempDir);
 			result.exitSignal = signal ?? undefined;
+			// processLine must be called before processClosed = true: the onUpdate guards at line 874/890
+			// check processClosed and would suppress the trailing line's progress update if set earlier.
 			if (buf.trim()) processLine(buf);
 			if (stderrBuf.trim()) shared.transcriptWriter?.writeStderrText(stderrBuf);
-			if (!result.error && assistantError) result.error = assistantError;
-			const forcedDrainAfterFinalSuccess =
-				forcedTerminationSignal && cleanTerminalAssistantStopReceived && !result.error;
-			if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
-				result.error = stderrBuf.trim();
-			}
-			const finalCode = forcedDrainAfterFinalSuccess
-				? 0
-				: forcedTerminationSignal || signal
-					? (code ?? 1)
-					: (code ?? 0);
-			if (supervisorPauseRequested) {
-				void (async () => {
-					const cleanup = await beginSupervisorPauseCleanup();
-					result.processCleanup = cleanup;
-					if (!cleanup.terminated) {
-						supervisorPauseRequested = false;
-						result.pause = undefined;
-						result.interrupted = false;
-						result.exitCode = 1;
-						result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
-						result.finalOutput = result.error;
+			// processClosed must be set before the first await so timeout and kill guards cannot
+			// observe a stale false during the artifact flush window (see lines 1079-1080, 596-599, 823-828).
+			processClosed = true;
+			void (async () => {
+				// jsonlWriter.close() marks itself closed and drops its stream synchronously before
+				// its first await (jsonl-writer.ts), so processLine() must be called before close()
+				// to ensure any trailing partial line reaches the JSONL artifact.
+				await jsonlWriter.close().catch(() => {
+					// JSONL artifact flush is best effort.
+				});
+				cleanupTempDir(tempDir);
+				if (!result.error && assistantError) result.error = assistantError;
+				const forcedDrainAfterFinalSuccess =
+					forcedTerminationSignal && cleanTerminalAssistantStopReceived && !result.error;
+				if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
+					result.error = stderrBuf.trim();
+				}
+				const finalCode = forcedDrainAfterFinalSuccess
+					? 0
+					: forcedTerminationSignal || signal
+						? (code ?? 1)
+						: (code ?? 0);
+				if (supervisorPauseRequested) {
+					void (async () => {
+						const cleanup = await beginSupervisorPauseCleanup();
+						result.processCleanup = cleanup;
+						if (!cleanup.terminated) {
+							supervisorPauseRequested = false;
+							result.pause = undefined;
+							result.interrupted = false;
+							result.exitCode = 1;
+							result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
+							result.finalOutput = result.error;
+							result.exitSignal = undefined;
+							progress.status = "failed";
+							progress.error = result.error;
+							finish(1);
+							return;
+						}
+						result.exitCode = 0;
+						result.interrupted = true;
+						result.error = undefined;
 						result.exitSignal = undefined;
-						progress.status = "failed";
-						progress.error = result.error;
-						finish(1);
-						return;
-					}
-					result.exitCode = 0;
-					result.interrupted = true;
-					result.error = undefined;
-					result.exitSignal = undefined;
-					if (result.pause) result.pause = { ...result.pause, pausedAt: Date.now(), ownerPid: undefined };
+						if (result.pause) result.pause = { ...result.pause, pausedAt: Date.now(), ownerPid: undefined };
+						progress.durationMs = Date.now() - startTime;
+						result.progressSummary = {
+							toolCount: progress.toolCount,
+							tokens: progress.tokens,
+							durationMs: progress.durationMs,
+						};
+						resolveResultSessionFile(result, options, shared.sessionEnabled);
+						try {
+							options.onSupervisorPauseTransition?.({
+								stage: "paused",
+								result: snapshotResult(result, snapshotProgress(progress)),
+							});
+						} catch {
+							supervisorPauseRequested = false;
+							result.pause = undefined;
+							result.interrupted = false;
+							result.exitCode = 1;
+							result.error = FOREGROUND_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+							result.finalOutput = result.error;
+							progress.status = "failed";
+							progress.error = result.error;
+							finish(1);
+							return;
+						}
+						finish(0);
+					})();
+					return;
+				}
+				if (interruptedByControl) {
+					void (async () => {
+						const cleanup = await beginSupervisorPauseCleanup();
+						result.processCleanup = cleanup;
+						if (!cleanup.terminated) {
+							interruptedByControl = false;
+							result.interrupted = false;
+							result.exitCode = 1;
+							result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
+							result.finalOutput = result.error;
+							progress.status = "failed";
+							progress.error = result.error;
+							finish(1);
+							return;
+						}
+						processClosed = true;
+						finish(finalCode);
+					})();
+					return;
+				}
+				if (detached) {
+					result.exitCode = result.error && finalCode === 0 ? 1 : finalCode;
+					progress.status = result.exitCode === 0 ? "completed" : "failed";
 					progress.durationMs = Date.now() - startTime;
+					if (result.error) progress.error = result.error;
 					result.progressSummary = {
 						toolCount: progress.toolCount,
 						tokens: progress.tokens,
 						durationMs: progress.durationMs,
 					};
-					resolveResultSessionFile(result, options, shared.sessionEnabled);
-					try {
-						options.onSupervisorPauseTransition?.({
-							stage: "paused",
-							result: snapshotResult(result, snapshotProgress(progress)),
-						});
-					} catch {
-						supervisorPauseRequested = false;
-						result.pause = undefined;
-						result.interrupted = false;
-						result.exitCode = 1;
-						result.error = FOREGROUND_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-						result.finalOutput = result.error;
-						progress.status = "failed";
-						progress.error = result.error;
-						finish(1);
-						return;
+					const finalOutput = getFinalOutput(result.messages ?? []);
+					result.finalOutput =
+						finalOutput.trim() || result.error || result.finalOutput || "Detached child exited without final output.";
+					if (
+						result.artifactPaths &&
+						options.artifactConfig?.enabled !== false &&
+						options.artifactConfig?.includeOutput !== false
+					) {
+						try {
+							writeArtifact(result.artifactPaths.outputPath, result.finalOutput);
+						} catch {
+							// Detached children may outlive test/temp cleanup; recovered status is best-effort.
+						}
 					}
-					finish(0);
-				})();
-				return;
-			}
-			if (interruptedByControl) {
-				void (async () => {
-					const cleanup = await beginSupervisorPauseCleanup();
-					result.processCleanup = cleanup;
-					if (!cleanup.terminated) {
-						interruptedByControl = false;
-						result.interrupted = false;
-						result.exitCode = 1;
-						result.error = FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE;
-						result.finalOutput = result.error;
-						progress.status = "failed";
-						progress.error = result.error;
-						finish(1);
-						return;
-					}
-					processClosed = true;
-					finish(finalCode);
-				})();
-				return;
-			}
-			if (detached) {
-				result.exitCode = result.error && finalCode === 0 ? 1 : finalCode;
-				progress.status = result.exitCode === 0 ? "completed" : "failed";
-				progress.durationMs = Date.now() - startTime;
-				if (result.error) progress.error = result.error;
-				result.progressSummary = {
-					toolCount: progress.toolCount,
-					tokens: progress.tokens,
-					durationMs: progress.durationMs,
-				};
-				const finalOutput = getFinalOutput(result.messages ?? []);
-				result.finalOutput =
-					finalOutput.trim() || result.error || result.finalOutput || "Detached child exited without final output.";
-				if (
-					result.artifactPaths &&
-					options.artifactConfig?.enabled !== false &&
-					options.artifactConfig?.includeOutput !== false
-				) {
-					try {
-						writeArtifact(result.artifactPaths.outputPath, result.finalOutput);
-					} catch {
-						// Detached children may outlive test/temp cleanup; recovered status is best-effort.
-					}
+					options.onDetachedExit?.(snapshotResult(result, snapshotProgress(progress)));
+					finish(-2);
+					return;
 				}
-				options.onDetachedExit?.(snapshotResult(result, snapshotProgress(progress)));
-				finish(-2);
-				return;
-			}
-			processClosed = true;
-			finish(finalCode);
+				finish(finalCode);
+			})();
 		});
 		proc.on("error", (error) => {
+			// Synchronous prelude — keep guards safe before the artifact flush await.
 			clearFinalDrainTimers();
 			clearStdioGuard();
-			void jsonlWriter.close().catch(() => {
-				// JSONL artifact flush is best effort.
-			});
-			cleanupTempDir(tempDir);
 			if (stderrBuf.trim()) shared.transcriptWriter?.writeStderrText(stderrBuf);
 			if (!result.error) {
 				result.error = error instanceof Error ? error.message : String(error);
 			}
-			finish(1);
+			// processClosed must be set before the first await so timeout, abort, and interrupt
+			// paths cannot observe a stale false and reinterpret a real process error.
+			processClosed = true;
+			void (async () => {
+				await jsonlWriter.close().catch(() => {
+					// JSONL artifact flush is best effort.
+				});
+				cleanupTempDir(tempDir);
+				finish(1);
+			})();
 		});
 
 		if (options.signal) {

--- a/extensions/subagents/src/shared/jsonl-writer.js
+++ b/extensions/subagents/src/shared/jsonl-writer.js
@@ -1,10 +1,13 @@
 import * as fs from "node:fs";
+const NO_OP_CLOSE_PROMISE = Promise.resolve();
 const DEFAULT_MAX_JSONL_BYTES = 50 * 1024 * 1024;
 export function createJsonlWriter(filePath, source, deps = {}) {
     if (!filePath) {
         return {
             writeLine() { },
-            async close() { },
+            close() {
+                return NO_OP_CLOSE_PROMISE;
+            },
         };
     }
     const createWriteStream = deps.createWriteStream ?? ((targetPath) => fs.createWriteStream(targetPath, { flags: "a" }));
@@ -15,11 +18,14 @@ export function createJsonlWriter(filePath, source, deps = {}) {
     catch {
         return {
             writeLine() { },
-            async close() { },
+            close() {
+                return NO_OP_CLOSE_PROMISE;
+            },
         };
     }
     let backpressured = false;
     let closed = false;
+    let closePromise;
     let bytesWritten = 0;
     const maxBytes = deps.maxBytes ?? DEFAULT_MAX_JSONL_BYTES;
     return {
@@ -47,13 +53,18 @@ export function createJsonlWriter(filePath, source, deps = {}) {
                 void 0;
             }
         },
-        async close() {
-            if (!stream || closed)
-                return;
+        close() {
+            if (closePromise !== undefined)
+                return closePromise;
+            if (!stream) {
+                closePromise = Promise.resolve();
+                return closePromise;
+            }
             closed = true;
             const current = stream;
             stream = undefined;
-            await new Promise((resolve) => current.end(() => resolve()));
+            closePromise = new Promise((resolve) => current.end(() => resolve()));
+            return closePromise;
         },
     };
 }

--- a/extensions/subagents/src/shared/jsonl-writer.ts
+++ b/extensions/subagents/src/shared/jsonl-writer.ts
@@ -1,5 +1,9 @@
 import * as fs from "node:fs";
 
+// Stable resolved promise shared by all no-op writer variants so close() identity
+// is consistent (async close(){} would allocate a fresh promise per call).
+const NO_OP_CLOSE_PROMISE: Promise<void> = Promise.resolve();
+
 export interface DrainableSource {
 	pause(): void;
 	resume(): void;
@@ -31,7 +35,9 @@ export function createJsonlWriter(
 	if (!filePath) {
 		return {
 			writeLine() {},
-			async close() {},
+			close() {
+				return NO_OP_CLOSE_PROMISE;
+			},
 		};
 	}
 
@@ -43,12 +49,15 @@ export function createJsonlWriter(
 	} catch {
 		return {
 			writeLine() {},
-			async close() {},
+			close() {
+				return NO_OP_CLOSE_PROMISE;
+			},
 		};
 	}
 
 	let backpressured = false;
 	let closed = false;
+	let closePromise: Promise<void> | undefined;
 	let bytesWritten = 0;
 	const maxBytes = deps.maxBytes ?? DEFAULT_MAX_JSONL_BYTES;
 
@@ -73,12 +82,17 @@ export function createJsonlWriter(
 				void 0;
 			}
 		},
-		async close() {
-			if (!stream || closed) return;
+		close(): Promise<void> {
+			if (closePromise !== undefined) return closePromise;
+			if (!stream) {
+				closePromise = Promise.resolve();
+				return closePromise;
+			}
 			closed = true;
 			const current = stream;
 			stream = undefined;
-			await new Promise<void>((resolve) => current.end(() => resolve()));
+			closePromise = new Promise<void>((resolve) => current.end(() => resolve()));
+			return closePromise;
 		},
 	};
 }

--- a/extensions/subagents/test/integration/single-execution.test.ts
+++ b/extensions/subagents/test/integration/single-execution.test.ts
@@ -1449,8 +1449,31 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			.readFileSync(result.artifactPaths!.jsonlPath, "utf-8")
 			.trim()
 			.split("\n")
-			.map((line) => JSON.parse(line) as Record<string, unknown>);
+			.map((line) => JSON.parse(line) as unknown);
+		assert.equal(jsonlRecords.length, 6, "expected 6 JSONL records");
+		assert.deepEqual(jsonlRecords[0], null);
+		assert.deepEqual(jsonlRecords[1], [1, "two"]);
+		assert.deepEqual(jsonlRecords[2], "primitive");
+		assert.deepEqual(jsonlRecords[3], 42);
 		assert.deepEqual(jsonlRecords[4], unknownEvent);
+		// Record 5 is the assistant message_end event. The default acceptance level is "auto",
+		// so formatAcceptancePrompt emits a "## Acceptance Contract" section; the mock's
+		// taskRequestsAcceptance detects it and withAcceptanceReport appends an acceptance
+		// report to the assistant text. Assert structure and key fields, not exact text.
+		const r5 = jsonlRecords[5] as {
+			type?: string;
+			message?: {
+				role?: string;
+				model?: string;
+				stopReason?: string;
+				content?: Array<{ type?: string; text?: string }>;
+			};
+		};
+		assert.equal(r5.type, "message_end", "record 5 is message_end");
+		assert.equal(r5.message?.role, "assistant", "record 5 message role is assistant");
+		assert.equal(r5.message?.model, "mock/test-model", "record 5 message model is mock/test-model");
+		assert.equal(r5.message?.stopReason, "stop", "record 5 message stopReason is stop");
+		assert.ok(r5.message?.content?.[0]?.text?.startsWith("Done"), "record 5 text starts with 'Done'");
 
 		const transcriptRecords = fs
 			.readFileSync(result.transcriptPath!, "utf-8")

--- a/extensions/subagents/test/unit/jsonl-writer.test.ts
+++ b/extensions/subagents/test/unit/jsonl-writer.test.ts
@@ -116,4 +116,98 @@ describe("createJsonlWriter", () => {
 		writer.writeLine(line);
 		assert.equal(stream.writes.length, 2);
 	});
+
+	it("concurrent close() callers all await the same real completion", async () => {
+		const source = new MockSource();
+		let endCallCount = 0;
+		let releaseEnd!: () => void;
+		const stream = new (class extends MockStream {
+			override end(callback?: () => void): void {
+				endCallCount++;
+				this.ended = true;
+				// Store callback for manual release — deterministic handshake.
+				releaseEnd = callback ?? (() => {});
+			}
+		})();
+		const writer = createJsonlWriter("/tmp/out.jsonl", source, {
+			createWriteStream: () => stream,
+		});
+		writer.writeLine('{"type":"a"}');
+
+		// Three concurrent close() calls before the stream's end callback fires.
+		const p1 = writer.close();
+		const p2 = writer.close();
+		const p3 = writer.close();
+
+		// end() must be called exactly once, not three times.
+		assert.equal(endCallCount, 1, "end() called exactly once");
+		assert.equal(stream.ended, true);
+
+		// None of the promises should resolve until the end callback fires.
+		let settled = 0;
+		void p1.then(() => settled++);
+		void p2.then(() => settled++);
+		void p3.then(() => settled++);
+		await Promise.resolve(); // flush microtasks
+		assert.equal(settled, 0, "no caller resolves before end callback fires");
+
+		// Release the end callback and confirm all three callers resolve.
+		releaseEnd();
+		await Promise.all([p1, p2, p3]);
+		assert.equal(settled, 3, "all callers resolve after end callback fires");
+		assert.equal(endCallCount, 1, "end() still called exactly once");
+	});
+
+	it("repeated close() after completion is a no-op and returns the same resolved promise", async () => {
+		// --- stream-backed writer ---
+		{
+			const source = new MockSource();
+			let endCallCount = 0;
+			const stream = new (class extends MockStream {
+				override end(callback?: () => void): void {
+					endCallCount++;
+					this.ended = true;
+					callback?.();
+				}
+			})();
+			const writer = createJsonlWriter("/tmp/out.jsonl", source, {
+				createWriteStream: () => stream,
+			});
+			const p1 = writer.close();
+			const p2 = writer.close();
+			const p3 = writer.close();
+			await Promise.all([p1, p2, p3]);
+			assert.strictEqual(p1, p2, "stream-backed: p1 and p2 are the same promise");
+			assert.strictEqual(p2, p3, "stream-backed: p2 and p3 are the same promise");
+			assert.equal(endCallCount, 1, "end() called exactly once even after repeated close()");
+		}
+
+		// --- no-filePath (no-op) writer ---
+		{
+			const source = new MockSource();
+			const writer = createJsonlWriter(undefined, source);
+			const p1 = writer.close();
+			const p2 = writer.close();
+			const p3 = writer.close();
+			await Promise.all([p1, p2, p3]);
+			assert.strictEqual(p1, p2, "no-filePath: p1 and p2 are the same promise");
+			assert.strictEqual(p2, p3, "no-filePath: p2 and p3 are the same promise");
+		}
+
+		// --- createWriteStream-throws (no-op) writer ---
+		{
+			const source = new MockSource();
+			const writer = createJsonlWriter("/tmp/out.jsonl", source, {
+				createWriteStream: () => {
+					throw new Error("stream unavailable");
+				},
+			});
+			const p1 = writer.close();
+			const p2 = writer.close();
+			const p3 = writer.close();
+			await Promise.all([p1, p2, p3]);
+			assert.strictEqual(p1, p2, "createWriteStream-throws: p1 and p2 are the same promise");
+			assert.strictEqual(p2, p3, "createWriteStream-throws: p2 and p3 are the same promise");
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Fixes a runtime race where a foreground subagent run could resolve while its JSONL artifact was still flushing, so a caller reading `artifactPaths.jsonlPath` immediately could observe a truncated file.

Surfaced as a macOS CI flake in the non-object child JSON test added by #490 (that PR only *exposed* the bug — it did not introduce it; `jsonl-writer.ts` was untouched by it). The test reads the artifact as soon as `runSync` returns, so `finalOutput` passed from in-memory messages while the artifact was still short.

Two defects fixed:

- **Flush not awaited.** The child `close` handler started `jsonlWriter.close()` fire-and-forget and proceeded to `finish()`. Now awaited before `finish()` on both the `close` and `error` terminal paths.
- **Trailing line lost.** `close()` was started *before* the final unterminated buffer was processed, and the writer marks itself closed and drops its stream synchronously before its first await — so a trailing newline-less line was parsed into run state but could never reach the artifact. The trailing buffer is now processed first.

Writer `close()` is also memoized, so concurrent or repeated callers await the same real completion instead of returning early on the `closed` flag (including the no-filePath and stream-creation-failure paths).

**Reviewer attention — the subtle part.** Introducing an `await` into these long, stateful handlers opens a window where timers and listeners can observe intermediate state. Both handlers therefore assign `processClosed` before their first await. Without that, the timeout path (`execution.ts:1079-1080`) and the SIGTERM/SIGKILL escalation timers (`:596-599`, `:823-828`) could observe a stale `false` and spuriously time out or signal an already-exited child; in the `error` handler an interrupt landing in that window could reinterpret a real process error as a successful interruption. Two ordering invariants are pinned with comments, and both matter:

- `processLine(buf)` must stay **before** `processClosed = true` (the onUpdate guards at `:874`/`:890` would otherwise suppress the trailing line's progress update).
- `processClosed = true` must be set **before** the first await.

Reviewing `git diff -w` is much easier than the raw diff: the semantic change in `execution.ts` is ~34 lines, the rest is re-indentation from the async wrapper.

**Deliberately out of scope:** a narrow pre-existing path where a trailing newline-less *blocking-intercom* line can still reach `detachForIntercom()` → `finish(-2)` before the flush. Not a regression (the original never awaited the flush at all). Tracked in #494 with three candidate designs, since closing it requires a decision about the trailing line's progress update.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

- `npm run validate` — pass (exit 0); 443 published files, unchanged vs `main`
- `node scripts/run-subagents-tests.mjs unit` — 1010/1010
- `node scripts/run-subagents-tests.mjs integration` — 520/520
- `npm run lint` — clean (641 files)
- `npm run typecheck:runtime`, `npm run check:runtime` — pass; generated `.js` twins fresh (187 files across 3 targets)

New coverage in `extensions/subagents/test/unit/jsonl-writer.test.ts` is deterministic by construction: `end()` is overridden to capture its callback and release it manually, so concurrent callers are proven not to resolve early without any timer or wall-clock threshold. The pre-existing "repeated close" test was strengthened to assert promise *identity* across all three writer variants — as originally written it would have passed against the old non-memoized implementation.

The trailing-partial-line defect has no dedicated regression test: the mock harness always appends a newline (`writeJsonlLine`) and exposes no raw/partial-output option, so covering it means extending the harness. That is folded into #494 rather than skipped silently; the invariant is pinned with a code comment in the meantime.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer, wrapper, or settings-merge surface touched)
- [x] Relevant tests or smoke checks pass
- [x] Docs reviewed. No `CHANGELOG.md` entry added, per maintainer decision — the Unreleased entries were intentionally consolidated into a single terse line in 99ff0bc.
- [x] Diff contains no secrets, local paths, or unintended generated files
