### PR TITLE
Hide claude-opus-4-7 and gpt-5.6-luna from the model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to The Last Harness will be documented in this file.
 ### Changed
 
 - Various improvements to how subagents look in the TUI, and how they report issues to the primary agents.
+- `anthropic/claude-opus-4-7` and `openai-codex/gpt-5.6-luna` are now hidden from the model picker and `tlh --list-models` by default.
 
 ## [0.37.0] - 2026-08-11
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -36,7 +36,7 @@ For review independence, `code-reviewer` and `oracle` intentionally prefer an av
 
 ## Hidden model defaults in the TLH profile
 
-TLH also ships with a bundled hidden-model filter for a selected set of older Anthropic and OpenAI Codex models. Those bundled defaults are built into TLH itself (currently in `extensions/the-last-harness/model-visibility.ts`); they are not written into `settings.json` as default JSON. Any `tlh.modelVisibility` entries you add under the TLH isolated profile at `~/.the-last-harness/agent/settings.json` are user overrides/additional customization only. TLH does not modify your normal `~/.pi/agent/settings.json` for this, and it does not delete auth or model definitions.
+TLH also ships with a bundled hidden-model filter for a selected set of Anthropic and OpenAI Codex models. Those bundled defaults are built into TLH itself (currently in `extensions/the-last-harness/model-visibility.ts`); they are not written into `settings.json` as default JSON. Any `tlh.modelVisibility` entries you add under the TLH isolated profile at `~/.the-last-harness/agent/settings.json` are user overrides/additional customization only. TLH does not modify your normal `~/.pi/agent/settings.json` for this, and it does not delete auth or model definitions.
 
 For example, you can add an extra hidden pattern of your own and explicitly unhide one model that TLH normally hides by default:
 

--- a/extensions/the-last-harness/model-visibility.js
+++ b/extensions/the-last-harness/model-visibility.js
@@ -26,6 +26,7 @@ export const TLH_HIDDEN_MODEL_DEFAULTS = Object.freeze([
     "anthropic/claude-opus-4-5",
     "anthropic/claude-opus-4-5-20251101",
     "anthropic/claude-opus-4-6",
+    "anthropic/claude-opus-4-7",
     "anthropic/claude-sonnet-4-0",
     "anthropic/claude-sonnet-4-20250514",
     "anthropic/claude-sonnet-4-5",
@@ -35,6 +36,7 @@ export const TLH_HIDDEN_MODEL_DEFAULTS = Object.freeze([
     "openai-codex/gpt-5.3-codex-spark",
     "openai-codex/gpt-5.4",
     "openai-codex/gpt-5.4-mini",
+    "openai-codex/gpt-5.6-luna",
 ]);
 function normalizePatternList(value) {
     if (!Array.isArray(value)) {

--- a/extensions/the-last-harness/model-visibility.ts
+++ b/extensions/the-last-harness/model-visibility.ts
@@ -81,6 +81,7 @@ export const TLH_HIDDEN_MODEL_DEFAULTS = Object.freeze([
 	"anthropic/claude-opus-4-5",
 	"anthropic/claude-opus-4-5-20251101",
 	"anthropic/claude-opus-4-6",
+	"anthropic/claude-opus-4-7",
 	"anthropic/claude-sonnet-4-0",
 	"anthropic/claude-sonnet-4-20250514",
 	"anthropic/claude-sonnet-4-5",
@@ -90,6 +91,7 @@ export const TLH_HIDDEN_MODEL_DEFAULTS = Object.freeze([
 	"openai-codex/gpt-5.3-codex-spark",
 	"openai-codex/gpt-5.4",
 	"openai-codex/gpt-5.4-mini",
+	"openai-codex/gpt-5.6-luna",
 ]);
 
 function normalizePatternList(value: unknown): string[] {

--- a/tests/the-last-harness-model-visibility.test.mjs
+++ b/tests/the-last-harness-model-visibility.test.mjs
@@ -114,6 +114,7 @@ test("hidden model defaults stay pinned to the approved ordered list", () => {
 		"anthropic/claude-opus-4-5",
 		"anthropic/claude-opus-4-5-20251101",
 		"anthropic/claude-opus-4-6",
+		"anthropic/claude-opus-4-7",
 		"anthropic/claude-sonnet-4-0",
 		"anthropic/claude-sonnet-4-20250514",
 		"anthropic/claude-sonnet-4-5",
@@ -123,6 +124,7 @@ test("hidden model defaults stay pinned to the approved ordered list", () => {
 		"openai-codex/gpt-5.3-codex-spark",
 		"openai-codex/gpt-5.4",
 		"openai-codex/gpt-5.4-mini",
+		"openai-codex/gpt-5.6-luna",
 	]);
 });
 


### PR DESCRIPTION
## Summary

Hide `anthropic/claude-opus-4-7` and `openai-codex/gpt-5.6-luna` from the `/model` picker and `tlh --list-models` by adding both canonical IDs to the bundled `TLH_HIDDEN_MODEL_DEFAULTS`.

`openai-codex/gpt-5.6-luna` intentionally remains the packaged OpenAI default for the `developer`, `repo-scout`, `web-scout`, `librarian`, and `diff-summarizer` subagents and the `rush` primary. That stays working because every default-resolution path (`primary-agent-runtime.ts`, `launch-telemetry.ts`, `subagent-settings.ts`) reads `getUnfilteredAvailableModels(...)`, and exact canonical selection (`/model openai-codex/gpt-5.6-luna`) still resolves hidden models. Precedent: `anthropic/claude-opus-4-6` is already hidden while remaining `product`'s packaged model.

Users can opt out per model with `tlh.modelVisibility.visible`, or disable the filter entirely with `tlh.modelVisibility.disabled: true`.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

Targeted checks for the touched paths (8 insertions, 1 deletion, data-only):

```sh
node --test tests/the-last-harness-model-visibility.test.mjs   # pinned-list test passes
npm run lint                                                   # clean (649 files)
```

Full `npm run validate` was not usable locally: this checkout's `node_modules` has `@earendil-works/pi-coding-agent` **0.83.0** while `package.json`/`package-lock.json` pin **0.84.1**, so `npm run typecheck` / `npm run check:runtime` fail with 2 pre-existing errors in `model-visibility.ts` (0.83.0's `ModelRuntime.getAvailable` takes one parameter, the pinned 0.84.1 signature takes two) and 3 tests in `tests/the-last-harness-model-visibility.test.mjs` fail. All 5 failures reproduce identically at unmodified `HEAD` in a throwaway git worktree, so they are unrelated to this change and CI's fresh install is the authoritative signal here.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer, wrapper, or settings-write paths touched; no `~/.pi/agent` interaction)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

`extensions/the-last-harness/model-visibility.js` is the generated counterpart of the `.ts` change and contains only the same two added entries.
