### PR TITLE
Fix ext4 inode-reuse flake in job tracker replacement fixture

### DIFF
--- a/extensions/subagents/test/integration/async-job-tracker.test.ts
+++ b/extensions/subagents/test/integration/async-job-tracker.test.ts
@@ -1485,8 +1485,12 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				"oversized discard state before replacement",
 			);
 
-			fs.unlinkSync(eventPath);
-			await new Promise((resolve) => setTimeout(resolve, 30));
+			// Create the replacement file BEFORE unlinking the original so that both
+			// files are live at the same time. POSIX guarantees distinct inodes when
+			// two names exist simultaneously. Unlink-then-create lets ext4 hand the
+			// freed inode straight back to the new file; APFS never reuses inodes,
+			// which is why macOS shards pass while ubuntu fails. This ordering is
+			// load-bearing and must not be simplified back to unlink-then-create.
 			const control = JSON.stringify({
 				type: "subagent.control",
 				channels: ["event"],
@@ -1507,6 +1511,8 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				"utf-8",
 			);
 			assert.equal(fs.statSync(replacementPath).size, originalContents.length);
+			fs.unlinkSync(eventPath);
+			await new Promise((resolve) => setTimeout(resolve, 30));
 			fs.renameSync(replacementPath, eventPath);
 			const replacementStat = fs.statSync(eventPath);
 			const replacementIdentity = `${replacementStat.dev}:${replacementStat.ino}`;


### PR DESCRIPTION
## Summary

`resets skip state when a disappeared log is replaced at the same path and size` (`extensions/subagents/test/integration/async-job-tracker.test.ts`, added by #502) fails intermittently on ubuntu CI — on its own fixture precondition, before any product behaviour is exercised:

```
not ok 25 - resets skip state when a disappeared log is replaced at the same path and size
  error: 'replacement fixture must change dev/ino identity'
```

**Cause.** The fixture unlinked `events.jsonl` and only *then* created the same-size replacement. The original inode was already back on the free list when the replacement was allocated, so ext4 can hand it straight back and `dev:ino` is unchanged. APFS assigns monotonically and never reuses — which is precisely why both macOS shards passed while ubuntu failed.

Seen in 1 of the 3 CI runs that have contained this test since #502 (`b71d02c` pass, `295604e` fail, `9faa9b0` pass).

**Fix.** Create the replacement while the original is still linked, so two names are live at once and POSIX guarantees distinct inodes. The `unlink` then 30ms window then `rename` sequence is unchanged, so the tracker still observes the log disappear and reappear at the same path and size.

This removes the dependency on allocator behaviour rather than narrowing the race.

The `assert.notEqual` precondition is **deliberately kept**. It is no longer a coin flip, and it still guards against a future refactor that truncates in place instead of swapping files.

### No production change, on purpose

Inode reuse combined with an identical size would defeat both of the tracker replacement signals (`async-job-tracker.ts:203-205`, `dev:ino` plus size-shrink). That path is unreachable: `events.jsonl` is append-only via `appendJsonlBestEffort`, and no production code unlinks, truncates, or recreates it. Reaching it needs an external actor deleting the file and recreating it at byte-identical size.

Adding an mtime/birthtime signal to the poll loop was considered and rejected as speculative work on an unreachable path.

## Change type

- [x] Extension / skill / prompt / theme

## Validation

```sh
npm run validate
```

Exit 0, zero failures.

| check | result |
|---|---|
| Standalone probe, new ordering, temp dir outside the repo | 10000 iterations, **0** identity collisions |
| Control probe, old ordering, on APFS | 0 collisions, confirming APFS never reuses, consistent with macOS CI always being green |
| Target test, 5 consecutive local runs | `33 pass / 0 fail` each |

The red state is not locally reproducible on macOS/APFS by construction; the CI failure on `295604e` is the reproduction.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (no installer surface touched)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — n/a, test-only, no user-visible behaviour change
- [x] Diff contains no secrets, local paths, or unintended generated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous job tracking test reliability by ensuring replacement files are fully created before the original files are removed.
  * Prevented file identity conflicts across different filesystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->