### PR TITLE
Hide harmless npm-root installer notice

### DIFF
--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -1712,7 +1712,7 @@ function preInstallNpmDefaultExtensions(config) {
     const npmRoot = join(config.agentDir, "npm");
     try {
         if (npmDestinationExists(npmRoot)) {
-            log(config, `Skipping pinned npm default-extension pre-install because the npm root already exists (left untouched): ${npmRoot}`);
+            verboseLog(config, `Skipping pinned npm default-extension pre-install because the npm root already exists (left untouched): ${npmRoot}`);
             return;
         }
     }

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -2212,7 +2212,7 @@ function preInstallNpmDefaultExtensions(config: InstallConfig): void {
   const npmRoot = join(config.agentDir, "npm");
   try {
     if (npmDestinationExists(npmRoot)) {
-      log(
+      verboseLog(
         config,
         `Skipping pinned npm default-extension pre-install because the npm root already exists (left untouched): ${npmRoot}`,
       );

--- a/tests/install-stage1-default-extensions.test.mjs
+++ b/tests/install-stage1-default-extensions.test.mjs
@@ -262,7 +262,7 @@ test("stage-1 batches only enabled pinned npm defaults from matching string and 
   }
 });
 
-test("stage-1 leaves an existing final npm root untouched without reading inside it", (t) => {
+test("stage-1 hides the existing final npm root notice unless verbose", (t) => {
   const defaults = [{ id: "pkg-a", source: "npm:@scope/pkg-a@1.0.0" }];
   const { config, agentDir } = makeDefaultExtensionInstallConfig(t, {
     defaultExtensions: defaults,
@@ -272,9 +272,22 @@ test("stage-1 leaves an existing final npm root untouched without reading inside
   const npmRoot = join(agentDir, "npm");
   mkdirSync(npmRoot, { recursive: true });
   writeFileSync(join(npmRoot, "sentinel"), "preserve me");
+  config.quiet = false;
 
-  preInstallNpmDefaultExtensions(config);
+  const normalStdout = captureConsole("log", () => preInstallNpmDefaultExtensions(config));
 
+  assert.doesNotMatch(
+    normalStdout,
+    /Skipping pinned npm default-extension pre-install because the npm root already exists/,
+  );
+
+  config.verbose = true;
+  const verboseStdout = captureConsole("log", () => preInstallNpmDefaultExtensions(config));
+
+  assert.match(
+    verboseStdout,
+    /Skipping pinned npm default-extension pre-install because the npm root already exists \(left untouched\):/,
+  );
   assert.equal(readFileSync(join(npmRoot, "sentinel"), "utf8"), "preserve me");
   assert.equal(existsSync(join(agentDir, "npm-called.log")), false);
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Demote the expected existing npm-root notice to verbose-only installer output. The installer still leaves the existing isolated npm root untouched, and focused coverage verifies both normal and verbose output.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed, including installer smoke checks, runtime generation checks, tests, typechecking, lint, formatting, shellcheck, settings dry-run, and package dry-run.

Focused validation also passed:

```sh
node --test tests/install-stage1-default-extensions.test.mjs
npm run check:runtime
npm run typecheck:runtime
```

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/chore/hide-existing-npm-root-notice/install.sh | bash -s -- --ref chore/hide-existing-npm-root-notice --track ref
```
