### PR TITLE
Move subagent override, reconcile, and auth-health docs out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,56 +77,6 @@ All bundled subagents:
 - `oracle` for a deeper second opinion
 - `contrarian` as a bundled default minor subagent for sparing adversarial stress-tests
 
-### Minor-agent model and effort overrides
-
-Use `/subagent-settings` to persist model or effort choices for the bundled TLH minor-agent roles: `code-reviewer`, `contrarian`, `developer`, `diff-summarizer`, `librarian`, `oracle`, `repo-scout`, and `web-scout`.
-
-- `/subagent-settings` opens a picker in the interactive TLH TUI; outside the TUI it reports status.
-- `/subagent-settings status [role]` shows all roles or one role.
-- `/subagent-settings set <role> [model <provider/id>] [effort <off|minimal|low|medium|high|xhigh|max>]` sets one or both fields; the `model` and `effort` pairs may be given in either order.
-- `/subagent-settings reset <role> [model|effort]` clears one field or both, and `/subagent-settings reset-all` clears the saved model/effort fields for bundled roles only.
-
-Values are stored under `subagents.agentOverrides` in the active isolated profile's `settings.json` (normally `~/.the-last-harness/agent/settings.json`, or the profile selected by `PI_CODING_AGENT_DIR`). A caller-supplied dispatch model takes precedence; otherwise stored role overrides are resolved before bundled provider-aware defaults. A fixed model can reduce provider independence for `code-reviewer`, `oracle`, and `contrarian`, so TLH warns and requires confirmation in UI sessions and refuses those writes in headless mode.
-
-The valid effort values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Stored effort is applied when the resolved model advertises support (`max` requires `thinkingLevelMap` support); if a saved value is no longer supported, TLH warns and neutralizes it with the bundled effort or explicit `off` when possible. If neither is supported, the subagents runtime drops the unsupported value for a known model; unknown or unresolvable models fail open and still receive the suffix. `max` is also a live bundled default where configured, not a hypothetical value.
-
-When existing settings content is replaced, TLH creates a `settings.json.bak-*` backup and shows its path. To undo a change, use the matching `reset` command, use `reset-all` for bundled roles, or restore the desired `settings.json.bak-*` backup over the active profile's `settings.json`.
-
-See [`docs/commands.md`](docs/commands.md) for the complete grammar, precedence details, warnings, and recovery steps.
-
-### Reconciling overrides with TLH packaged defaults
-
-When TLH ships an update that changes the packaged model or effort default for a role you have overridden, it shows a one-line startup notice: `TLH default model/effort changed for <role> — run /reconcile to review`. The notice is non-blocking and reappears each launch until you act.
-
-Run `/reconcile` to review and resolve the drift:
-
-- **Keep** — acknowledges the new TLH default and preserves your override unchanged. Non-destructive: your setting is untouched.
-- **Reset** — clears your override so the role falls back to TLH packaged defaults. For primary agents, the packaged default is also applied to the active session immediately (subject to your `tlh.primaryAgent.applyModel` setting). Undoable: restore the value through the native `/model` picker and choose `All sessions` (the default `This session only — default` option is session-only); for subagents, use `/subagent-settings set <role> ...`. Settings writes always create a `settings.json.bak-*` backup shown in the notification.
-
-The **only trigger** is TLH changing a packaged default for a role you have overridden. There is no periodic or scheduled reminder.
-
-Acknowledgments are per-provider. A Keep or Reset under one provider does not suppress the notice if you later switch providers and that provider's packaged default has since changed.
-
-When the session provider is unknown, TLH defers all comparison — no notice appears and Keep is unavailable until a provider is active. Overrides that pre-date this release are silently backfilled on your first startup with a known provider; the notice then fires on the next packaged-default change after that point, not for any changes that occurred before the backfill.
-
-The reported value is the canonical packaged default for the active provider, resolved from TLH's own bundled catalog. It may name a model your current environment cannot reach, and it may differ from the model Reset produces in a live session (for example, roles that prefer an opposite-provider model will show a same-provider fallback here). That does not block the decision; Keep and Reset work regardless.
-
-Outside the TUI, `/reconcile` prints a read-only drift summary. See [`docs/commands.md`](docs/commands.md) for full details.
-
-### Provider auth-health warning
-
-When TLH dispatches a subagent and the provider's credential fails, a sticky footer warning appears:
-
-```text
-⚠ reauth: anthropic
-```
-
-The warning is per-provider (both providers are shown in one line when both fail: `⚠ reauth: anthropic, openai-codex`) and **outlives the run that revealed it** — it does not disappear when the failing run finishes. It clears automatically once the credential works again, checked at each dispatch and turn boundary, so no restart is needed. A new session starts clean and re-flags on the next failed dispatch. A toast notification pointing at `/login` appears the first time a provider is flagged within a session.
-
-Credential failures are detected at dispatch time and also from completed runs, including async ones — so a silently degraded `code-reviewer`, `oracle`, or `contrarian` is surfaced even when the failure happened after the tool call returned.
-
-Only unambiguous credential rejections (revoked/expired OAuth grants, 401/403 during token refresh) surface this warning. Transient network failures, rate limits, and server errors are silent — they are retried automatically on the next dispatch.
-
 ### Customisation
 
 You can add your own skills, prompts, extensions, and packages to TLH.
@@ -151,6 +101,7 @@ After adding files, installing a package, or saving project trust, run `/reload`
 
 - Slash commands reference: [`docs/commands.md`](docs/commands.md)
 - First-party subagent dispatch, supervision, migration, and undo steps: [`docs/subagents.md`](docs/subagents.md)
+- User-owned trusted embedded subagents: [`docs/embedded-subagents.md`](docs/embedded-subagents.md)
 - TLH model defaults, thinking levels, and provider selection: [`docs/models.md`](docs/models.md)
 - Install, update, uninstall, paths, and undo steps: [`docs/install.md`](docs/install.md)
 - Common failure recovery and conservative troubleshooting: [`docs/troubleshooting.md`](docs/troubleshooting.md)

--- a/docs/models.md
+++ b/docs/models.md
@@ -28,11 +28,43 @@ To undo a persistent choice, choose the desired model again through the native p
 
 ### Staying in sync when TLH updates its defaults
 
-When TLH ships an update that changes a bundled model or effort default for a role you have overridden, it shows a startup notice and prompts you to run `/reconcile`. Use `/reconcile` to keep your override as-is (acknowledging the new default) or reset it to restore the TLH packaged default. See [`docs/commands.md § /reconcile`](commands.md#reconcile) for the full grammar, trigger model, and undo steps.
+When TLH ships an update that changes the packaged model or effort default for a role you have overridden, it shows a one-line startup notice: `TLH default model/effort changed for <role> — run /reconcile to review`. The notice is non-blocking and reappears each launch until you act.
+
+Run `/reconcile` to review and resolve the drift:
+
+- **Keep** — acknowledges the new TLH default and preserves your override unchanged. Non-destructive: your setting is untouched.
+- **Reset** — clears your override so the role falls back to TLH packaged defaults. For primary agents, the packaged default is also applied to the active session immediately (subject to your `tlh.primaryAgent.applyModel` setting). Undoable: restore the value through the native `/model` picker and choose `All sessions` (the default `This session only — default` option is session-only); for subagents, use `/subagent-settings set <role> ...`. Settings writes always create a `settings.json.bak-*` backup shown in the notification.
+
+The **only trigger** is TLH changing a packaged default for a role you have overridden. There is no periodic or scheduled reminder.
+
+Acknowledgments are per-provider. A Keep or Reset under one provider does not suppress the notice if you later switch providers and that provider's packaged default has since changed.
+
+When the session provider is unknown, TLH defers all comparison — no notice appears and Keep is unavailable until a provider is active. Overrides that pre-date this release are silently backfilled on your first startup with a known provider; the notice then fires on the next packaged-default change after that point, not for any changes that occurred before the backfill.
+
+The reported value is the canonical packaged default for the active provider, resolved from TLH's own bundled catalog. It may name a model your current environment cannot reach, and it may differ from the model Reset produces in a live session (for example, roles that prefer an opposite-provider model will show a same-provider fallback here). That does not block the decision; Keep and Reset work regardless.
+
+Outside the TUI, `/reconcile` prints a read-only drift summary. See [`commands.md § /reconcile`](commands.md#reconcile) for the full grammar, trigger model, and undo steps.
 
 ### Review independence for code-reviewer, oracle, and contrarian
 
 For review independence, `code-reviewer` and `oracle` intentionally prefer an available opposite provider. `contrarian` uses that same opposite-provider pattern for adversarial challenge passes. Anthropic sessions try to use the OpenAI Codex subscription provider for these subagents when it is available, while OpenAI/OpenAI-Codex sessions try Anthropic. When TLH injects one of those opposite-provider subagent models, it also supplies a same/current-provider fallback candidate for retryable model failures; if that fallback is used, the subagent output includes a notice that review independence is reduced. If you only have regular OpenAI API access and not the Codex subscription provider, TLH does not force `code-reviewer`, `oracle`, or `contrarian` onto unavailable Codex-only defaults. All other bundled subagents — including `developer`, `web-scout`, `repo-scout`, and `librarian` — follow the active primary session provider when TLH injects model defaults.
+
+## Minor-agent model and effort overrides
+
+Use `/subagent-settings` to persist model or effort choices for the bundled TLH minor-agent roles: `code-reviewer`, `contrarian`, `developer`, `diff-summarizer`, `librarian`, `oracle`, `repo-scout`, and `web-scout`.
+
+- `/subagent-settings` opens a picker in the interactive TLH TUI; outside the TUI it reports status.
+- `/subagent-settings status [role]` shows all roles or one role.
+- `/subagent-settings set <role> [model <provider/id>] [effort <off|minimal|low|medium|high|xhigh|max>]` sets one or both fields; the `model` and `effort` pairs may be given in either order.
+- `/subagent-settings reset <role> [model|effort]` clears one field or both, and `/subagent-settings reset-all` clears the saved model/effort fields for bundled roles only.
+
+Values are stored under `subagents.agentOverrides` in the active isolated profile's `settings.json` (normally `~/.the-last-harness/agent/settings.json`, or the profile selected by `PI_CODING_AGENT_DIR`). A caller-supplied dispatch model takes precedence; otherwise stored role overrides are resolved before bundled provider-aware defaults. A fixed model can reduce provider independence for `code-reviewer`, `oracle`, and `contrarian`, so TLH warns and requires confirmation in UI sessions and refuses those writes in headless mode.
+
+The valid effort values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Stored effort is applied when the resolved model advertises support (`max` requires `thinkingLevelMap` support); if a saved value is no longer supported, TLH warns and neutralizes it with the bundled effort or explicit `off` when possible. If neither is supported, the subagents runtime drops the unsupported value for a known model; unknown or unresolvable models fail open and still receive the suffix. `max` is also a live bundled default where configured, not a hypothetical value.
+
+When existing settings content is replaced, TLH creates a `settings.json.bak-*` backup and shows its path. To undo a change, use the matching `reset` command, use `reset-all` for bundled roles, or restore the desired `settings.json.bak-*` backup over the active profile's `settings.json`.
+
+See [`commands.md`](commands.md) for the complete grammar, precedence details, warnings, and recovery steps.
 
 ## Thinking selection scope
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -221,6 +221,20 @@ Useful diagnostics:
 
 See [commands.md](commands.md) for command visibility and [install.md](install.md) for the exact install/update migration and uninstall behavior.
 
+## Provider auth-health warning
+
+When TLH dispatches a subagent and the provider's credential fails, a sticky footer warning appears:
+
+```text
+⚠ reauth: anthropic
+```
+
+The warning is per-provider (both providers are shown in one line when both fail: `⚠ reauth: anthropic, openai-codex`) and **outlives the run that revealed it** — it does not disappear when the failing run finishes. It clears automatically once the credential works again, checked at each dispatch and turn boundary, so no restart is needed. A new session starts clean and re-flags on the next failed dispatch. A toast notification pointing at `/login` appears the first time a provider is flagged within a session.
+
+Credential failures are detected at dispatch time and also from completed runs, including async ones — so a silently degraded `code-reviewer`, `oracle`, or `contrarian` is surfaced even when the failure happened after the tool call returned.
+
+Only unambiguous credential rejections (revoked/expired OAuth grants, 401/403 during token refresh) surface this warning. Transient network failures, rate limits, and server errors are silent — they are retried automatically on the next dispatch.
+
 ## Updating, migrating, and removing
 
 `tlh update` updates the first-party runtime together with the rest of TLH. It does not download or publish a standalone subagent package. On legacy profiles, install/update removes a retired external subagent package only when TLH can establish that it managed that package. Profiles with provenance preserve a matching manually owned entry; pre-provenance profiles treat the old default identities as TLH-managed for the one-time migration.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -425,4 +425,5 @@ Use `--dry-run` first if you are unsure which uninstall plan you want.
 
 - [Install, update, and uninstall](install.md)
 - [Slash commands and bundled command surface](commands.md)
+- [Provider auth-health warning (⚠ reauth)](subagents.md#provider-auth-health-warning)
 - [Project overview](../README.md)


### PR DESCRIPTION
## Summary

Relocates three reference sections out of `README.md` into the docs that own their topic, so the README stays overview-level. Docs-only; no behavior, code, or test changes.

| Moved from `README.md` | New home |
| --- | --- |
| `### Minor-agent model and effort overrides` | `docs/models.md` -> new `## Minor-agent model and effort overrides` |
| `### Reconciling overrides with TLH packaged defaults` | `docs/models.md` -> folded into the existing `### Staying in sync when TLH updates its defaults` subsection (no duplicate section) |
| `### Provider auth-health warning` | `docs/subagents.md` -> new `## Provider auth-health warning`, cross-referenced from `docs/troubleshooting.md` "Related docs" |

The auth-health content was the only material documented nowhere else under `docs/`, so it moves verbatim. Also adds the missing `docs/embedded-subagents.md` entry to the README "Docs dump" index.

Note on placement: the minor-agent override section covers the **bundled** minor-agent roles (`/subagent-settings`), so it lands in `docs/models.md` alongside the other per-role model/thinking defaults — not in `docs/embedded-subagents.md`, which documents only the default-off user-owned embedded-agent flag.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed: package-versions, package-contents, lazy-import-boundaries, typecheck, typecheck:runtime, check:runtime, installer smoke, tests (unit/integration/e2e), lint, format:check, lint:sh, merge-settings dry-run, npm pack dry-run.

Docs-specific checks:

- Content-loss diff review across all four files — every fact from the removed README prose is present in its new home.
- Dangling-reference grep for the three removed headings and for old README anchors (excluding `node_modules` and `docs/subagents-history`) — no external references.
- Anchor-slug verification: `docs/troubleshooting.md` -> `subagents.md#provider-auth-health-warning` matches the real heading; relative links rewritten for the new location (`docs/commands.md` -> `commands.md`).
- Heading hierarchy and section ordering reviewed in both destination files.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — no `CHANGELOG.md` entry: this only relocates existing documentation, with no user-visible behavior change
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/docs/relocate-readme-sections-to-docs/install.sh | bash -s -- --ref docs/relocate-readme-sections-to-docs --track ref
```
