### PR TITLE
Deduplicate subagent live-detail hint

### DIFF
--- a/extensions/subagents/src/tui/render.js
+++ b/extensions/subagents/src/tui/render.js
@@ -52,25 +52,41 @@ function collapsedForegroundSummaryLines(hiddenCount, theme, width, maxLines) {
     }
     return firstLines;
 }
-function fitCollapsedForegroundLines(lines, theme, width) {
+function fitCollapsedForegroundLines(contentLines, theme, width, footerLines = []) {
     const budget = collapsedForegroundLineBudget();
-    if (lines.length <= budget)
-        return lines;
-    for (let visibleCount = Math.min(lines.length, budget - 1); visibleCount >= 0; visibleCount--) {
-        const hiddenCount = lines.length - visibleCount;
+    if (footerLines.length > budget) {
+        const summaryLines = collapsedForegroundSummaryLines(contentLines.length, theme, width, budget);
+        return summaryLines.slice(0, budget);
+    }
+    if (contentLines.length + footerLines.length <= budget) {
+        return [...contentLines, ...footerLines];
+    }
+    const contentBudget = budget - footerLines.length;
+    for (let visibleCount = Math.min(contentLines.length, contentBudget - 1); visibleCount >= 0; visibleCount--) {
+        const hiddenCount = contentLines.length - visibleCount;
         const summaryLines = wrapDisplayLine(theme.fg("dim", `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`), width);
-        if (visibleCount + summaryLines.length <= budget) {
-            return [...lines.slice(0, visibleCount), ...summaryLines];
+        if (visibleCount + summaryLines.length <= contentBudget) {
+            return [...contentLines.slice(0, visibleCount), ...summaryLines, ...footerLines];
         }
     }
-    return collapsedForegroundSummaryLines(lines.length, theme, width, budget);
+    const summaryLines = contentBudget > 0
+        ? collapsedForegroundSummaryLines(contentLines.length, theme, width, contentBudget)
+        : [];
+    return [...summaryLines.slice(0, contentBudget), ...footerLines];
 }
 function collapsedForegroundComponent(logicalLines, theme) {
     return {
         render(width) {
             const contentWidth = Math.max(1, width);
-            const physicalLines = wrapDisplayLines(logicalLines, contentWidth);
-            return fitCollapsedForegroundLines(physicalLines, theme, contentWidth);
+            const trailingLiveDetailFooter = logicalLines.at(-1);
+            const hasLiveDetailFooter = trailingLiveDetailFooter !== undefined &&
+                stripTerminalSequences(trailingLiveDetailFooter).trim() === liveDetailHintText();
+            const contentLogicalLines = hasLiveDetailFooter ? logicalLines.slice(0, -1) : logicalLines;
+            const contentLines = wrapDisplayLines(contentLogicalLines, contentWidth);
+            const footerLines = hasLiveDetailFooter
+                ? wrapDisplayLine(trailingLiveDetailFooter, contentWidth)
+                : [];
+            return fitCollapsedForegroundLines(contentLines, theme, contentWidth, footerLines);
         },
         invalidate() { },
     };
@@ -1955,6 +1971,7 @@ function renderMultiCompact(d, theme, frame) {
                 agentName: r?.agent || `${fallbackLabel}-${rowNumber}`,
             };
         });
+    let hasRunningResult = false;
     for (const entry of renderEntries) {
         if (entry.kind === "placeholder") {
             const glyph = widgetStepGlyph(entry.status, theme);
@@ -1995,11 +2012,11 @@ function renderMultiCompact(d, theme, frame) {
         if (ticketLine)
             lines.push(ticketLine);
         if (rRunning && liveProgress) {
+            hasRunningResult = true;
             for (const [activityIndex, activity] of compactProgressActivityLines(liveProgress, width, WIDGET_ACTIVITY_PREFIX, WIDGET_ACTIVITY_CONTINUATION_PREFIX).entries()) {
                 const prefix = activityIndex === 0 ? WIDGET_ACTIVITY_PREFIX : WIDGET_ACTIVITY_CONTINUATION_PREFIX;
                 lines.push(theme.fg("dim", `${prefix}${activity}`));
             }
-            lines.push(theme.fg("dim", `    ${liveDetailHintText()}`));
         }
         else if (!rPending &&
             (r.exitCode !== 0 ||
@@ -2011,6 +2028,8 @@ function renderMultiCompact(d, theme, frame) {
     }
     if (d.artifacts)
         lines.push(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`));
+    if (hasRunningResult)
+        lines.push(theme.fg("dim", `    ${liveDetailHintText()}`));
     return collapsedForegroundComponent(lines, theme);
 }
 export function renderSubagentResult(result, options, theme, frame) {

--- a/extensions/subagents/src/tui/render.ts
+++ b/extensions/subagents/src/tui/render.ts
@@ -106,30 +106,58 @@ function collapsedForegroundSummaryLines(
   return firstLines;
 }
 
-function fitCollapsedForegroundLines(lines: string[], theme: Theme, width: number): string[] {
+function fitCollapsedForegroundLines(
+  contentLines: string[],
+  theme: Theme,
+  width: number,
+  footerLines: readonly string[] = [],
+): string[] {
   const budget = collapsedForegroundLineBudget();
-  if (lines.length <= budget) return lines;
+  if (footerLines.length > budget) {
+    const summaryLines = collapsedForegroundSummaryLines(contentLines.length, theme, width, budget);
+    return summaryLines.slice(0, budget);
+  }
+  if (contentLines.length + footerLines.length <= budget) {
+    return [...contentLines, ...footerLines];
+  }
 
-  for (let visibleCount = Math.min(lines.length, budget - 1); visibleCount >= 0; visibleCount--) {
-    const hiddenCount = lines.length - visibleCount;
+  const contentBudget = budget - footerLines.length;
+  for (
+    let visibleCount = Math.min(contentLines.length, contentBudget - 1);
+    visibleCount >= 0;
+    visibleCount--
+  ) {
+    const hiddenCount = contentLines.length - visibleCount;
     const summaryLines = wrapDisplayLine(
       theme.fg("dim", `… ${hiddenCount} lines hidden · ${liveDetailKeyText()} expands`),
       width,
     );
-    if (visibleCount + summaryLines.length <= budget) {
-      return [...lines.slice(0, visibleCount), ...summaryLines];
+    if (visibleCount + summaryLines.length <= contentBudget) {
+      return [...contentLines.slice(0, visibleCount), ...summaryLines, ...footerLines];
     }
   }
 
-  return collapsedForegroundSummaryLines(lines.length, theme, width, budget);
+  const summaryLines =
+    contentBudget > 0
+      ? collapsedForegroundSummaryLines(contentLines.length, theme, width, contentBudget)
+      : [];
+  return [...summaryLines.slice(0, contentBudget), ...footerLines];
 }
 
 function collapsedForegroundComponent(logicalLines: readonly string[], theme: Theme): Component {
   return {
     render(width: number): string[] {
       const contentWidth = Math.max(1, width);
-      const physicalLines = wrapDisplayLines(logicalLines, contentWidth);
-      return fitCollapsedForegroundLines(physicalLines, theme, contentWidth);
+      const trailingLiveDetailFooter = logicalLines.at(-1);
+      const hasLiveDetailFooter =
+        trailingLiveDetailFooter !== undefined &&
+        stripTerminalSequences(trailingLiveDetailFooter).trim() === liveDetailHintText();
+      const contentLogicalLines = hasLiveDetailFooter ? logicalLines.slice(0, -1) : logicalLines;
+      const contentLines = wrapDisplayLines(contentLogicalLines, contentWidth);
+      const footerLines = hasLiveDetailFooter
+        ? wrapDisplayLine(trailingLiveDetailFooter!, contentWidth)
+        : [];
+      return fitCollapsedForegroundLines(contentLines, theme, contentWidth, footerLines);
     },
     invalidate(): void {},
   };
@@ -2732,6 +2760,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
         agentName: r?.agent || `${fallbackLabel}-${rowNumber}`,
       };
     });
+  let hasRunningResult = false;
   for (const entry of renderEntries) {
     if (entry.kind === "placeholder") {
       const glyph = widgetStepGlyph(entry.status as AsyncJobStep["status"], theme);
@@ -2773,6 +2802,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
     const ticketLine = foregroundTkTicketLine(r, theme, rRunning, "    ");
     if (ticketLine) lines.push(ticketLine);
     if (rRunning && liveProgress) {
+      hasRunningResult = true;
       for (const [activityIndex, activity] of compactProgressActivityLines(
         liveProgress,
         width,
@@ -2783,7 +2813,6 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
           activityIndex === 0 ? WIDGET_ACTIVITY_PREFIX : WIDGET_ACTIVITY_CONTINUATION_PREFIX;
         lines.push(theme.fg("dim", `${prefix}${activity}`));
       }
-      lines.push(theme.fg("dim", `    ${liveDetailHintText()}`));
     } else if (
       !rPending &&
       (r.exitCode !== 0 ||
@@ -2797,6 +2826,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
     }
   }
   if (d.artifacts) lines.push(theme.fg("dim", `  artifacts: ${shortenPath(d.artifacts.dir)}`));
+  if (hasRunningResult) lines.push(theme.fg("dim", `    ${liveDetailHintText()}`));
   return collapsedForegroundComponent(lines, theme);
 }
 

--- a/extensions/subagents/test/integration/render-fork-badge.test.ts
+++ b/extensions/subagents/test/integration/render-fork-badge.test.ts
@@ -42,6 +42,22 @@ function withTerminalWidth<T>(columns: number, fn: () => T): T {
   }
 }
 
+function withTerminalRows<T>(rows: number, fn: () => T): T {
+  const original = process.stdout.rows;
+  Object.defineProperty(process.stdout, "rows", {
+    value: rows,
+    configurable: true,
+  });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process.stdout, "rows", {
+      value: original,
+      configurable: true,
+    });
+  }
+}
+
 describe("renderSubagentResult fork indicator", () => {
   it("shows a resolved foreground tk ticket once while active in compact and expanded cards", () => {
     const result = {
@@ -144,6 +160,286 @@ describe("renderSubagentResult fork indicator", () => {
       .render(140)
       .join("\n");
     assert.equal(text.match(/ticket: Show active tk title/g)?.length, 1);
+  });
+
+  it("renders one live-detail hint after all running foreground result rows", () => {
+    const text = withTerminalWidth(140, () =>
+      renderSubagentResult!(
+        {
+          content: [{ type: "text", text: "running" }],
+          details: {
+            mode: "parallel",
+            totalSteps: 2,
+            results: [
+              {
+                agent: "reviewer",
+                task: "Review the change.",
+                exitCode: 0,
+                usage: emptyUsage,
+                tkTicket: { id: "tlhf-first", title: "First ticket" },
+                progress: {
+                  index: 0,
+                  agent: "reviewer",
+                  status: "running",
+                  task: "Review the change.",
+                  currentTool: "read",
+                  currentToolArgs: "reviewer.ts",
+                  recentTools: [],
+                  recentOutput: [],
+                  toolCount: 1,
+                  tokens: 0,
+                  durationMs: 10,
+                },
+              },
+              {
+                agent: "writer",
+                task: "Write the change.",
+                exitCode: 0,
+                usage: emptyUsage,
+                progress: {
+                  index: 1,
+                  agent: "writer",
+                  status: "running",
+                  task: "Write the change.",
+                  currentTool: "write",
+                  currentToolArgs: "writer.ts",
+                  recentTools: [],
+                  recentOutput: [],
+                  toolCount: 1,
+                  tokens: 0,
+                  durationMs: 10,
+                },
+              },
+            ],
+            artifacts: { dir: "/tmp/foreground-artifacts", files: [] },
+          },
+        },
+        { expanded: false },
+        theme,
+      )
+        .render(140)
+        .join("\n"),
+    );
+
+    const lines = text.split("\n");
+    const hintLines = lines.filter((line) => line.includes(liveDetailHint));
+    assert.equal(hintLines.length, 1, "concurrent running rows should share one live-detail hint");
+    assert.match(text, /artifacts: \/tmp\/foreground-artifacts/);
+
+    const reviewerRowIndex = lines.findIndex((line) => line.includes("reviewer"));
+    const reviewerTicketIndex = lines.findIndex((line) => line.includes("ticket: First ticket"));
+    const reviewerActivityIndex = lines.findIndex((line) => line.includes("read: reviewer.ts"));
+    const writerRowIndex = lines.findIndex((line) => line.includes("writer"));
+    const writerActivityIndex = lines.findIndex((line) => line.includes("write: writer.ts"));
+    const artifactsIndex = lines.findIndex((line) =>
+      line.includes("artifacts: /tmp/foreground-artifacts"),
+    );
+    const hintIndex = lines.findIndex((line) => line.includes(liveDetailHint));
+
+    assert.ok(reviewerRowIndex !== -1, "first agent row should be present");
+    assert.ok(reviewerTicketIndex > reviewerRowIndex, "ticket should remain under its agent row");
+    assert.ok(
+      reviewerActivityIndex > reviewerTicketIndex,
+      "first agent activity should remain after its ticket",
+    );
+    assert.ok(writerRowIndex !== -1, "second agent row should be present");
+    assert.ok(
+      writerActivityIndex > writerRowIndex,
+      "second agent activity should remain in its row",
+    );
+    assert.ok(hintIndex > writerActivityIndex, "shared hint should follow all agent activity");
+    assert.equal(
+      artifactsIndex,
+      hintIndex - 1,
+      "artifacts should remain immediately before the shared hint",
+    );
+    assert.equal(hintIndex, lines.length - 1, "shared hint should be the final rendered card line");
+  });
+
+  it("keeps the shared live-detail footer after collapsed multi-agent truncation", () => {
+    const text = withTerminalWidth(140, () =>
+      withTerminalRows(10, () =>
+        renderSubagentResult!(
+          {
+            content: [{ type: "text", text: "running" }],
+            details: {
+              mode: "parallel",
+              totalSteps: 2,
+              results: [
+                {
+                  agent: "reviewer",
+                  task: "Review the change.",
+                  exitCode: 0,
+                  usage: emptyUsage,
+                  progress: {
+                    index: 0,
+                    agent: "reviewer",
+                    status: "running",
+                    task: "Review the change.",
+                    currentTool: "read",
+                    currentToolArgs: "reviewer.ts",
+                    recentTools: [],
+                    recentOutput: [],
+                    toolCount: 1,
+                    tokens: 0,
+                    durationMs: 10,
+                  },
+                },
+                {
+                  agent: "writer",
+                  task: "Write the change.",
+                  exitCode: 0,
+                  usage: emptyUsage,
+                  progress: {
+                    index: 1,
+                    agent: "writer",
+                    status: "running",
+                    task: "Write the change.",
+                    currentTool: "write",
+                    currentToolArgs: "writer.ts",
+                    recentTools: [],
+                    recentOutput: [],
+                    toolCount: 1,
+                    tokens: 0,
+                    durationMs: 10,
+                  },
+                },
+              ],
+              artifacts: { dir: "/tmp/foreground-artifacts", files: [] },
+            },
+          },
+          { expanded: false },
+          theme,
+        )
+          .render(140)
+          .join("\n"),
+      ),
+    );
+
+    const lines = text.split("\n");
+    assert.match(text, new RegExp(`lines hidden · ${escapeRegExp(expandKey)} expands`));
+    assert.equal(
+      lines.filter((line) => line.includes(liveDetailHint)).length,
+      1,
+      "truncation should retain one shared live-detail footer",
+    );
+    assert.match(lines.at(-1) ?? "", new RegExp(escapeRegExp(liveDetailHint)));
+    assert.ok(lines.length <= 5, "collapsed output should respect the constrained line budget");
+  });
+
+  it("keeps the wrapped live-detail footer within a narrow collapsed height budget", () => {
+    const text = withTerminalWidth(37, () =>
+      withTerminalRows(10, () =>
+        renderSubagentResult!(
+          {
+            content: [{ type: "text", text: "running" }],
+            details: {
+              mode: "parallel",
+              totalSteps: 2,
+              results: [
+                {
+                  agent: "reviewer",
+                  task: "Review the change.",
+                  exitCode: 0,
+                  usage: emptyUsage,
+                  progress: {
+                    index: 0,
+                    agent: "reviewer",
+                    status: "running",
+                    task: "Review the change.",
+                    currentTool: "read",
+                    currentToolArgs: "reviewer.ts",
+                    recentTools: [],
+                    recentOutput: [],
+                    toolCount: 1,
+                    tokens: 0,
+                    durationMs: 10,
+                  },
+                },
+                {
+                  agent: "writer",
+                  task: "Write the change.",
+                  exitCode: 0,
+                  usage: emptyUsage,
+                  progress: {
+                    index: 1,
+                    agent: "writer",
+                    status: "running",
+                    task: "Write the change.",
+                    currentTool: "write",
+                    currentToolArgs: "writer.ts",
+                    recentTools: [],
+                    recentOutput: [],
+                    toolCount: 1,
+                    tokens: 0,
+                    durationMs: 10,
+                  },
+                },
+              ],
+              artifacts: { dir: "/tmp/foreground-artifacts", files: [] },
+            },
+          },
+          { expanded: false },
+          theme,
+        )
+          .render(37)
+          .join("\n"),
+      ),
+    );
+
+    const lines = text.split("\n");
+    const normalized = lines.join(" ").replace(/\s+/g, " ").trim();
+    assert.equal(
+      normalized.match(new RegExp(escapeRegExp(liveDetailHint), "g"))?.length,
+      1,
+      "narrow wrapping should retain exactly one live-detail hint",
+    );
+    const footerStart = lines.findIndex((line) => line.includes(`Press ${expandKey}`));
+    assert.ok(footerStart !== -1, "wrapped live-detail footer should be present");
+    assert.equal(
+      lines.slice(footerStart).join(" ").replace(/\s+/g, " ").trim(),
+      liveDetailHint,
+      "wrapped live-detail footer should remain final",
+    );
+    assert.ok(lines.length <= 5, "narrow collapsed output should respect the line budget");
+  });
+
+  it("falls back to a bounded key summary when the footer cannot fit", () => {
+    const tinyResult = {
+      content: [{ type: "text" as const, text: "running" }],
+      details: {
+        mode: "parallel" as const,
+        totalSteps: 2,
+        results: ["reviewer", "writer"].map((agent, index) => ({
+          agent,
+          task: "Run the assigned task.",
+          exitCode: 0,
+          usage: emptyUsage,
+          progress: {
+            index,
+            agent,
+            status: "running" as const,
+            task: "Run the assigned task.",
+            currentTool: "read",
+            currentToolArgs: `${agent}.ts`,
+            recentTools: [],
+            recentOutput: [],
+            toolCount: 1,
+            tokens: 0,
+            durationMs: 10,
+          },
+        })),
+      },
+    };
+    const text = withTerminalWidth(8, () =>
+      withTerminalRows(10, () =>
+        renderSubagentResult!(tinyResult, { expanded: false }, theme).render(8).join("\n"),
+      ),
+    );
+
+    const lines = text.split("\n");
+    assert.ok(lines.length <= 5, "tiny collapsed output should respect the line budget");
+    assert.doesNotMatch(text, /Press|live detail|for live/);
   });
 
   it("indents the ticket line deeper than its agent row in multi-agent compact output", () => {


### PR DESCRIPTION
## Summary

Show the foreground subagent live-detail hint once at the bottom of a multi-agent card instead of repeating it for every running agent. Preserve the footer through collapsed-height truncation and narrow wrapping while keeping tiny-terminal output bounded.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed completely. Targeted rendering regressions also pass, including normal, constrained-height, narrow-width, and tiny-width cases.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants (installer behavior is untouched)
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` reviewed; no update needed for this focused rendering fix
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/single-live-detail-hint/install.sh | bash -s -- --ref fix/single-live-detail-hint --track ref
```