### PR TITLE
Harden slash subagent request boundary

### DIFF
--- a/extensions/subagents/src/slash/slash-bridge.js
+++ b/extensions/subagents/src/slash/slash-bridge.js
@@ -1,4 +1,46 @@
 import { SLASH_SUBAGENT_CANCEL_EVENT, SLASH_SUBAGENT_REQUEST_EVENT, SLASH_SUBAGENT_RESPONSE_EVENT, SLASH_SUBAGENT_STARTED_EVENT, SLASH_SUBAGENT_UPDATE_EVENT, } from "../shared/types.js";
+const INVALID_SLASH_REQUEST_TEXT = "Unsupported slash subagent request.";
+function resolveAllowedSlashSubagentParams(value) {
+    try {
+        if (!value || typeof value !== "object" || Array.isArray(value))
+            return undefined;
+        if (Object.getPrototypeOf(value) !== Object.prototype)
+            return undefined;
+        const keys = Reflect.ownKeys(value);
+        if (keys.length === 1 && keys[0] === "action") {
+            const action = Object.getOwnPropertyDescriptor(value, "action");
+            return action?.enumerable && "value" in action && action.value === "doctor"
+                ? { action: "doctor" }
+                : undefined;
+        }
+        if (keys.length !== 2 || !keys.includes("action") || !keys.includes("view"))
+            return undefined;
+        const action = Object.getOwnPropertyDescriptor(value, "action");
+        const view = Object.getOwnPropertyDescriptor(value, "view");
+        return action?.enumerable &&
+            "value" in action &&
+            action.value === "status" &&
+            view?.enumerable &&
+            "value" in view &&
+            view.value === "fleet"
+            ? { action: "status", view: "fleet" }
+            : undefined;
+    }
+    catch {
+        return undefined;
+    }
+}
+function invalidSlashSubagentResponse(requestId) {
+    return {
+        requestId,
+        result: {
+            content: [{ type: "text", text: INVALID_SLASH_REQUEST_TEXT }],
+            details: { mode: "single", results: [] },
+        },
+        isError: true,
+        errorText: INVALID_SLASH_REQUEST_TEXT,
+    };
+}
 export function registerSlashSubagentBridge(options) {
     const controllers = new Map();
     const pendingCancels = new Set();
@@ -7,6 +49,10 @@ export function registerSlashSubagentBridge(options) {
         const unsubscribe = options.events.on(event, handler);
         if (typeof unsubscribe === "function")
             subscriptions.push(unsubscribe);
+    };
+    const rejectRequest = (requestId) => {
+        pendingCancels.delete(requestId);
+        options.events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, invalidSlashSubagentResponse(requestId));
     };
     subscribe(SLASH_SUBAGENT_CANCEL_EVENT, (data) => {
         if (!data || typeof data !== "object")
@@ -24,12 +70,44 @@ export function registerSlashSubagentBridge(options) {
     subscribe(SLASH_SUBAGENT_REQUEST_EVENT, async (data) => {
         if (!data || typeof data !== "object")
             return;
-        const request = data;
-        if (typeof request.requestId !== "string" || !request.params)
+        let requestId;
+        try {
+            requestId = data.requestId;
+        }
+        catch {
             return;
-        const { requestId, params } = request;
-        const ctx = request.ctx ?? options.getContext();
+        }
+        if (typeof requestId !== "string" || requestId.length === 0)
+            return;
+        if (Array.isArray(data)) {
+            rejectRequest(requestId);
+            return;
+        }
+        let params;
+        try {
+            params = data.params;
+        }
+        catch {
+            rejectRequest(requestId);
+            return;
+        }
+        const allowedParams = resolveAllowedSlashSubagentParams(params);
+        if (!allowedParams) {
+            rejectRequest(requestId);
+            return;
+        }
+        const request = data;
+        let requesterContext;
+        try {
+            requesterContext = request.ctx;
+        }
+        catch {
+            rejectRequest(requestId);
+            return;
+        }
+        const ctx = requesterContext ?? options.getContext();
         if (!ctx) {
+            pendingCancels.delete(requestId);
             const response = {
                 requestId,
                 result: {
@@ -63,7 +141,7 @@ export function registerSlashSubagentBridge(options) {
         }
         options.events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId });
         try {
-            const result = await options.execute(requestId, params, controller.signal, (update) => {
+            const result = await options.execute(requestId, allowedParams, controller.signal, (update) => {
                 const progress = update.details?.progress;
                 const first = progress?.[0];
                 const payload = {

--- a/extensions/subagents/src/slash/slash-bridge.ts
+++ b/extensions/subagents/src/slash/slash-bridge.ts
@@ -10,11 +10,59 @@ import {
   type SubagentToolResult,
 } from "../shared/types.ts";
 
+export type AllowedSlashSubagentParams = { action: "doctor" } | { action: "status"; view: "fleet" };
+
 interface SlashSubagentRequest {
   requestId: string;
-  params: SubagentParamsLike;
+  params: AllowedSlashSubagentParams;
   /** Optional requester context for in-process extension bridge calls. */
   ctx?: ExtensionContext;
+}
+
+const INVALID_SLASH_REQUEST_TEXT = "Unsupported slash subagent request.";
+
+/**
+ * Private first-party boundary: retained slash commands emit only these exact
+ * read-only parameter shapes before reaching the executor.
+ */
+function resolveAllowedSlashSubagentParams(value: unknown): AllowedSlashSubagentParams | undefined {
+  try {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+    if (Object.getPrototypeOf(value) !== Object.prototype) return undefined;
+
+    const keys = Reflect.ownKeys(value);
+    if (keys.length === 1 && keys[0] === "action") {
+      const action = Object.getOwnPropertyDescriptor(value, "action");
+      return action?.enumerable && "value" in action && action.value === "doctor"
+        ? { action: "doctor" }
+        : undefined;
+    }
+    if (keys.length !== 2 || !keys.includes("action") || !keys.includes("view")) return undefined;
+    const action = Object.getOwnPropertyDescriptor(value, "action");
+    const view = Object.getOwnPropertyDescriptor(value, "view");
+    return action?.enumerable &&
+      "value" in action &&
+      action.value === "status" &&
+      view?.enumerable &&
+      "value" in view &&
+      view.value === "fleet"
+      ? { action: "status", view: "fleet" }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function invalidSlashSubagentResponse(requestId: string): SlashSubagentResponse {
+  return {
+    requestId,
+    result: {
+      content: [{ type: "text", text: INVALID_SLASH_REQUEST_TEXT }],
+      details: { mode: "single" as const, results: [] },
+    },
+    isError: true,
+    errorText: INVALID_SLASH_REQUEST_TEXT,
+  };
 }
 
 export interface SlashSubagentResponse {
@@ -61,6 +109,11 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
     if (typeof unsubscribe === "function") subscriptions.push(unsubscribe);
   };
 
+  const rejectRequest = (requestId: string): void => {
+    pendingCancels.delete(requestId);
+    options.events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, invalidSlashSubagentResponse(requestId));
+  };
+
   subscribe(SLASH_SUBAGENT_CANCEL_EVENT, (data) => {
     if (!data || typeof data !== "object") return;
     const requestId = (data as { requestId?: unknown }).requestId;
@@ -75,12 +128,46 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 
   subscribe(SLASH_SUBAGENT_REQUEST_EVENT, async (data) => {
     if (!data || typeof data !== "object") return;
-    const request = data as Partial<SlashSubagentRequest>;
-    if (typeof request.requestId !== "string" || !request.params) return;
-    const { requestId, params } = request as SlashSubagentRequest;
 
-    const ctx = request.ctx ?? options.getContext();
+    let requestId: unknown;
+    try {
+      requestId = (data as { requestId?: unknown }).requestId;
+    } catch {
+      return;
+    }
+    if (typeof requestId !== "string" || requestId.length === 0) return;
+    if (Array.isArray(data)) {
+      rejectRequest(requestId);
+      return;
+    }
+
+    let params: unknown;
+    try {
+      params = (data as { params?: unknown }).params;
+    } catch {
+      rejectRequest(requestId);
+      return;
+    }
+    const allowedParams = resolveAllowedSlashSubagentParams(params);
+    if (!allowedParams) {
+      rejectRequest(requestId);
+      return;
+    }
+
+    const request = data as Partial<SlashSubagentRequest>;
+    // Trust the request-time context: this event bus is private first-party
+    // in-process plumbing, and retaining it avoids stale cached lastUiContext.
+    // Only read-only params cross the allowlist above; ctx provenance belongs elsewhere.
+    let requesterContext: ExtensionContext | undefined;
+    try {
+      requesterContext = request.ctx;
+    } catch {
+      rejectRequest(requestId);
+      return;
+    }
+    const ctx = requesterContext ?? options.getContext();
     if (!ctx) {
+      pendingCancels.delete(requestId);
       const response: SlashSubagentResponse = {
         requestId,
         result: {
@@ -120,7 +207,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
     try {
       const result = await options.execute(
         requestId,
-        params,
+        allowedParams,
         controller.signal,
         (update) => {
           const progress = update.details?.progress;

--- a/extensions/subagents/src/slash/slash-commands.ts
+++ b/extensions/subagents/src/slash/slash-commands.ts
@@ -3,10 +3,13 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey } from "@earendil-works/pi-tui";
-import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { formatTokens } from "../shared/formatters.ts";
 import { liveDetailShortcutDisplay } from "../shared/subagent-shortcuts.ts";
-import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
+import type {
+  AllowedSlashSubagentParams,
+  SlashSubagentResponse,
+  SlashSubagentUpdate,
+} from "./slash-bridge.ts";
 import {
   applySlashUpdate,
   buildSlashInitialResult,
@@ -156,7 +159,7 @@ async function requestSlashRun(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   requestId: string,
-  params: SubagentParamsLike,
+  params: AllowedSlashSubagentParams,
 ): Promise<SlashSubagentResponse> {
   return new Promise((resolve, reject) => {
     let done = false;
@@ -308,7 +311,7 @@ function persistSlashSessionSnapshot(ctx: ExtensionContext): void {
 async function runSlashSubagent(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
-  params: SubagentParamsLike,
+  params: AllowedSlashSubagentParams,
 ): Promise<void> {
   const requestId = randomUUID();
   const initialDetails = buildSlashInitialResult(requestId, params);

--- a/extensions/subagents/test/unit/slash-bridge.test.ts
+++ b/extensions/subagents/test/unit/slash-bridge.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { registerSlashSubagentBridge } from "../../src/slash/slash-bridge.ts";
 
 const REQUEST = "subagent:slash:request";
+const CANCEL = "subagent:slash:cancel";
 const RESPONSE = "subagent:slash:response";
 
 function eventBus() {
@@ -24,7 +25,173 @@ function eventBus() {
   };
 }
 
-describe("slash subagent bridge requester context", () => {
+function nextResponse(events: ReturnType<typeof eventBus>, requestId: string): Promise<any> {
+  return new Promise((resolve) => {
+    const unsubscribe = events.on(RESPONSE, (data: any) => {
+      if (data?.requestId !== requestId) return;
+      unsubscribe();
+      resolve(data);
+    });
+  });
+}
+
+describe("slash subagent bridge request boundary", () => {
+  it("executes only the exact retained diagnostic request shapes", async () => {
+    const events = eventBus();
+    const executed: unknown[] = [];
+    const fallbackCtx = { cwd: "/fallback" } as any;
+    const callerParams = [{ action: "doctor" }, { action: "status", view: "fleet" }];
+
+    registerSlashSubagentBridge({
+      events,
+      getContext: () => fallbackCtx,
+      execute: async (_id, params) => {
+        executed.push(params);
+        return {
+          content: [{ type: "text", text: "ok" }],
+          details: { mode: "single", results: [] },
+        } as any;
+      },
+    });
+
+    for (const [index, params] of callerParams.entries()) {
+      const requestId = `allowed-${index}`;
+      const response = nextResponse(events, requestId);
+      events.emit(REQUEST, { requestId, params });
+      assert.equal((await response).isError, false);
+      assert.notStrictEqual(executed[index], params);
+    }
+
+    assert.deepEqual(executed, [{ action: "doctor" }, { action: "status", view: "fleet" }]);
+  });
+
+  it("rejects unsupported, execution-bearing, extra-field, and malformed params", async () => {
+    const events = eventBus();
+    let executeCalls = 0;
+
+    registerSlashSubagentBridge({
+      events,
+      getContext: () => ({ cwd: "/fallback" }) as any,
+      execute: async () => {
+        executeCalls++;
+        return {
+          content: [{ type: "text", text: "unexpected" }],
+          details: { mode: "single", results: [] },
+        } as any;
+      },
+    });
+
+    const accessorParams = {};
+    Object.defineProperty(accessorParams, "action", {
+      enumerable: true,
+      get: () => "doctor",
+    });
+    const symbolParams = { action: "doctor" };
+    Object.defineProperty(symbolParams, Symbol("extra"), { enumerable: true, value: true });
+    const proxyParams = new Proxy(
+      { action: "doctor" },
+      {
+        ownKeys: () => {
+          throw new Error("hostile proxy");
+        },
+      },
+    );
+    const rejected: unknown[] = [
+      undefined,
+      null,
+      [],
+      {},
+      { action: "list" },
+      { agent: "worker", task: "run" },
+      { action: "doctor", agent: "worker" },
+      { action: "status" },
+      { action: "status", view: "fleet", id: "run-1" },
+      accessorParams,
+      symbolParams,
+      proxyParams,
+    ];
+
+    for (const [index, params] of rejected.entries()) {
+      const requestId = `rejected-${index}`;
+      const response = nextResponse(events, requestId);
+      events.emit(REQUEST, { requestId, params });
+      const result = await response;
+      assert.equal(result.isError, true);
+      assert.equal(result.errorText, "Unsupported slash subagent request.");
+      assert.deepEqual(result.result.content, [
+        { type: "text", text: "Unsupported slash subagent request." },
+      ]);
+      assert.deepEqual(result.result.details, { mode: "single", results: [] });
+    }
+
+    const missingParamsResponse = nextResponse(events, "missing-params");
+    events.emit(REQUEST, { requestId: "missing-params" });
+    assert.equal((await missingParamsResponse).isError, true);
+
+    const malformedEnvelope = Object.assign([], {
+      requestId: "array-envelope",
+      params: { action: "doctor" },
+    });
+    const malformedEnvelopeResponse = nextResponse(events, malformedEnvelope.requestId);
+    events.emit(REQUEST, malformedEnvelope);
+    assert.equal((await malformedEnvelopeResponse).isError, true);
+
+    const throwingContextRequest = { requestId: "throwing-context", params: { action: "doctor" } };
+    Object.defineProperty(throwingContextRequest, "ctx", {
+      enumerable: true,
+      get: () => {
+        throw new Error("hostile context getter");
+      },
+    });
+    const throwingContextResponse = nextResponse(events, throwingContextRequest.requestId);
+    events.emit(REQUEST, throwingContextRequest);
+    assert.equal((await throwingContextResponse).isError, true);
+    assert.equal(executeCalls, 0);
+  });
+
+  it("clears pending cancellation after rejected and no-context requests", async () => {
+    const events = eventBus();
+    const fallbackContext = { cwd: "/fallback" } as any;
+    let activeContext: any = fallbackContext;
+    let executeCalls = 0;
+
+    registerSlashSubagentBridge({
+      events,
+      getContext: () => activeContext,
+      execute: async () => {
+        executeCalls++;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          details: { mode: "single", results: [] },
+        } as any;
+      },
+    });
+
+    const rejectedId = "rejected-then-valid";
+    events.emit(CANCEL, { requestId: rejectedId });
+    const rejectedResponse = nextResponse(events, rejectedId);
+    events.emit(REQUEST, { requestId: rejectedId, params: { action: "list" } });
+    assert.equal((await rejectedResponse).isError, true);
+
+    const validAfterRejectedResponse = nextResponse(events, rejectedId);
+    events.emit(REQUEST, { requestId: rejectedId, params: { action: "doctor" } });
+    assert.equal((await validAfterRejectedResponse).isError, false);
+    assert.equal(executeCalls, 1);
+
+    const noContextId = "no-context-then-valid";
+    activeContext = null;
+    events.emit(CANCEL, { requestId: noContextId });
+    const noContextResponse = nextResponse(events, noContextId);
+    events.emit(REQUEST, { requestId: noContextId, params: { action: "doctor" } });
+    assert.equal((await noContextResponse).isError, true);
+
+    activeContext = fallbackContext;
+    const validAfterNoContextResponse = nextResponse(events, noContextId);
+    events.emit(REQUEST, { requestId: noContextId, params: { action: "doctor" } });
+    assert.equal((await validAfterNoContextResponse).isError, false);
+    assert.equal(executeCalls, 2);
+  });
+
   it("uses request ctx instead of stale fallback context when provided", async () => {
     const events = eventBus();
     const fallbackCtx = { cwd: "/fallback" } as any;
@@ -55,7 +222,7 @@ describe("slash subagent bridge requester context", () => {
       });
     });
 
-    events.emit(REQUEST, { requestId: "ctx-test", params: { action: "list" }, ctx: requestCtx });
+    events.emit(REQUEST, { requestId: "ctx-test", params: { action: "doctor" }, ctx: requestCtx });
     await done;
   });
 });


### PR DESCRIPTION
## Summary

- Restrict the private slash subagent event bridge to the exact retained `doctor` and `status`/fleet request shapes.
- Reject malformed, extra-field, or execution-bearing payloads before they reach the executor, passing only sanitized literals.
- Couple retained slash emitters to the allowlist at compile time and clear pending cancellation state on rejected requests.
- Add focused boundary, hostile-input, context, and cancellation regression coverage.

Part of #550.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed all checks, including:

- subagent unit tests: 1076/1076
- subagent integration tests: 592/592
- subagent e2e tests: 1/1
- generated runtime freshness: 195 files

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (no user-visible documentation change required)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/slash-subagent-boundary/install.sh | bash -s -- --ref fix/slash-subagent-boundary --track ref
```
