### PR TITLE
Remove dead exports found in dead-code audit

### DIFF
--- a/extensions/subagents/src/runs/shared/nested-events.js
+++ b/extensions/subagents/src/runs/shared/nested-events.js
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ASYNC_DIR, RESULTS_DIR, TEMP_ROOT_DIR, } from "../../shared/types.js";
+import { RESULTS_DIR, TEMP_ROOT_DIR, } from "../../shared/types.js";
 import { isSafeNestedPathId, parseNestedPathEnv, sanitizeNestedPath, } from "./nested-path.js";
 import { SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV, SUBAGENT_PARENT_CHILD_INDEX_ENV, SUBAGENT_PARENT_CONTROL_INBOX_ENV, SUBAGENT_PARENT_DEPTH_ENV, SUBAGENT_PARENT_EVENT_SINK_ENV, SUBAGENT_PARENT_PATH_ENV, SUBAGENT_PARENT_ROOT_RUN_ID_ENV, SUBAGENT_PARENT_RUN_ID_ENV, } from "./pi-args.js";
 import { writeAtomicJson } from "../../shared/atomic-json.js";
@@ -702,10 +702,6 @@ export function findNestedRunMatchesById(id, options = {}) {
     }
     return matches;
 }
-export function findNestedRunById(id) {
-    const match = findNestedRunMatchesById(id)[0];
-    return match ? { rootRunId: match.rootRunId, run: match.run } : undefined;
-}
 export function readNestedRegistry(route) {
     validateNestedRoute(route);
     try {
@@ -934,28 +930,6 @@ export function readNestedControlRequests(route) {
     }
     return requests;
 }
-export function nestedControlRequestOwnedBy(request, owner) {
-    return (request.ownerParentRunId === owner.parentRunId &&
-        request.ownerParentStepIndex === owner.parentStepIndex);
-}
-export function claimNestedControlRequest(route, request, claimantId) {
-    validateNestedRoute(route);
-    assertSafeId("claimantId", claimantId);
-    if (!containedPath(route.controlInbox, request.filePath))
-        return undefined;
-    const claimDir = path.join(route.controlInbox, ".claims", claimantId);
-    fs.mkdirSync(claimDir, { recursive: true, mode: 0o700 });
-    const claimPath = path.join(claimDir, path.basename(request.filePath));
-    try {
-        fs.renameSync(request.filePath, claimPath);
-        return claimPath;
-    }
-    catch (error) {
-        if (error.code === "ENOENT")
-            return undefined;
-        throw error;
-    }
-}
 export function writeNestedControlResult(route, result) {
     validateNestedRoute(route);
     assertSafeId("requestId", result.requestId);
@@ -1008,14 +982,6 @@ export function readNestedControlResults(route) {
         }
     }
     return results;
-}
-export function nestedRouteEnv(route) {
-    return {
-        [SUBAGENT_PARENT_EVENT_SINK_ENV]: route.eventSink,
-        [SUBAGENT_PARENT_CONTROL_INBOX_ENV]: route.controlInbox,
-        [SUBAGENT_PARENT_ROOT_RUN_ID_ENV]: route.rootRunId,
-        [SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]: route.capabilityToken,
-    };
 }
 export function attachRootChildrenToSteps(rootRunId, steps, children) {
     if (!steps?.length)
@@ -1145,17 +1111,6 @@ export function nestedSummaryFromAsyncStatus(status, asyncDir, fallback) {
             }
             : {}),
     };
-}
-export function nestedArtifactEnv(rootRunId, parentRunId) {
-    return {
-        PI_SUBAGENT_NESTED_ROOT_RUN_ID: rootRunId,
-        PI_SUBAGENT_NESTED_PARENT_RUN_ID: parentRunId,
-    };
-}
-export function isTopLevelAsyncDir(asyncDir) {
-    const resolved = path.resolve(asyncDir);
-    return (containedPath(ASYNC_DIR, resolved) &&
-        !containedPath(path.join(TEMP_ROOT_DIR, "nested-subagent-runs"), resolved));
 }
 export function nestedResultsPath(rootRunId, id) {
     assertSafeId("rootRunId", rootRunId);

--- a/extensions/subagents/src/runs/shared/nested-events.ts
+++ b/extensions/subagents/src/runs/shared/nested-events.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
-  ASYNC_DIR,
   RESULTS_DIR,
   TEMP_ROOT_DIR,
   type AsyncJobState,
@@ -896,13 +895,6 @@ export function findNestedRunMatchesById(
   return matches;
 }
 
-export function findNestedRunById(
-  id: string,
-): { rootRunId: string; run: NestedRunSummary } | undefined {
-  const match = findNestedRunMatchesById(id)[0];
-  return match ? { rootRunId: match.rootRunId, run: match.run } : undefined;
-}
-
 export function readNestedRegistry(route: NestedRoute): NestedRegistry {
   validateNestedRoute(route);
   try {
@@ -1132,36 +1124,6 @@ export function readNestedControlRequests(
   return requests;
 }
 
-export function nestedControlRequestOwnedBy(
-  request: NestedControlRequestRecord,
-  owner: { parentRunId: string; parentStepIndex?: number },
-): boolean {
-  return (
-    request.ownerParentRunId === owner.parentRunId &&
-    request.ownerParentStepIndex === owner.parentStepIndex
-  );
-}
-
-export function claimNestedControlRequest(
-  route: NestedRoute,
-  request: NestedControlRequestRecord & { filePath: string },
-  claimantId: string,
-): string | undefined {
-  validateNestedRoute(route);
-  assertSafeId("claimantId", claimantId);
-  if (!containedPath(route.controlInbox, request.filePath)) return undefined;
-  const claimDir = path.join(route.controlInbox, ".claims", claimantId);
-  fs.mkdirSync(claimDir, { recursive: true, mode: 0o700 });
-  const claimPath = path.join(claimDir, path.basename(request.filePath));
-  try {
-    fs.renameSync(request.filePath, claimPath);
-    return claimPath;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw error;
-  }
-}
-
 export function writeNestedControlResult(
   route: NestedRoute,
   result: Omit<NestedControlResultRecord, "type" | "rootRunId" | "capabilityToken">,
@@ -1211,15 +1173,6 @@ export function readNestedControlResults(route: NestedRoute): NestedControlResul
     }
   }
   return results;
-}
-
-export function nestedRouteEnv(route: NestedRoute): Record<string, string> {
-  return {
-    [SUBAGENT_PARENT_EVENT_SINK_ENV]: route.eventSink,
-    [SUBAGENT_PARENT_CONTROL_INBOX_ENV]: route.controlInbox,
-    [SUBAGENT_PARENT_ROOT_RUN_ID_ENV]: route.rootRunId,
-    [SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]: route.capabilityToken,
-  };
 }
 
 export function attachRootChildrenToSteps<
@@ -1365,21 +1318,6 @@ export function nestedSummaryFromAsyncStatus(
         }
       : {}),
   };
-}
-
-export function nestedArtifactEnv(rootRunId: string, parentRunId: string): Record<string, string> {
-  return {
-    PI_SUBAGENT_NESTED_ROOT_RUN_ID: rootRunId,
-    PI_SUBAGENT_NESTED_PARENT_RUN_ID: parentRunId,
-  };
-}
-
-export function isTopLevelAsyncDir(asyncDir: string): boolean {
-  const resolved = path.resolve(asyncDir);
-  return (
-    containedPath(ASYNC_DIR, resolved) &&
-    !containedPath(path.join(TEMP_ROOT_DIR, "nested-subagent-runs"), resolved)
-  );
 }
 
 export function nestedResultsPath(rootRunId: string, id: string): string {

--- a/extensions/subagents/src/shared/subagent-shortcuts.js
+++ b/extensions/subagents/src/shared/subagent-shortcuts.js
@@ -117,6 +117,3 @@ export function formatShortcutDisplay(key) {
 export function liveDetailShortcutDisplay() {
     return formatShortcutDisplay(SUBAGENT_LIVE_DETAIL_SHORTCUT);
 }
-export function pauseAllShortcutDisplay() {
-    return formatShortcutDisplay(SUBAGENT_PAUSE_ALL_SHORTCUT);
-}

--- a/extensions/subagents/src/shared/subagent-shortcuts.ts
+++ b/extensions/subagents/src/shared/subagent-shortcuts.ts
@@ -163,7 +163,3 @@ export function formatShortcutDisplay(key: string): string {
 export function liveDetailShortcutDisplay(): string {
   return formatShortcutDisplay(SUBAGENT_LIVE_DETAIL_SHORTCUT);
 }
-
-export function pauseAllShortcutDisplay(): string {
-  return formatShortcutDisplay(SUBAGENT_PAUSE_ALL_SHORTCUT);
-}

--- a/extensions/subagents/src/shared/utils.js
+++ b/extensions/subagents/src/shared/utils.js
@@ -88,22 +88,6 @@ export function readStatus(asyncDir) {
     }
     return status;
 }
-export function getLastActivity(outputFile) {
-    if (!outputFile)
-        return "";
-    try {
-        const stat = fs.statSync(outputFile);
-        const ago = Date.now() - stat.mtimeMs;
-        if (ago < 1000)
-            return "active now";
-        if (ago < 60000)
-            return `active ${Math.floor(ago / 1000)}s ago`;
-        return `active ${Math.floor(ago / 60000)}m ago`;
-    }
-    catch {
-        return "";
-    }
-}
 export function findLatestSessionFile(sessionDir) {
     if (!fs.existsSync(sessionDir))
         return null;

--- a/extensions/subagents/src/shared/utils.ts
+++ b/extensions/subagents/src/shared/utils.ts
@@ -140,23 +140,6 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 }
 
 /**
- * Get human-readable last activity time for a file
- */
-export function getLastActivity(outputFile: string | undefined): string {
-  if (!outputFile) return "";
-  try {
-    const stat = fs.statSync(outputFile);
-    const ago = Date.now() - stat.mtimeMs;
-    if (ago < 1000) return "active now";
-    if (ago < 60000) return `active ${Math.floor(ago / 1000)}s ago`;
-    return `active ${Math.floor(ago / 60000)}m ago`;
-  } catch {
-    // Last-activity text is best effort; missing files should simply omit the hint.
-    return "";
-  }
-}
-
-/**
  * Find the latest session file in a directory
  */
 export function findLatestSessionFile(sessionDir: string): string | null {

--- a/extensions/the-last-harness/attribution.js
+++ b/extensions/the-last-harness/attribution.js
@@ -1,5 +1,4 @@
-import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
-import { isRecord } from "./common.js";
+import {} from "@earendil-works/pi-coding-agent";
 import { commandBasename, extractHereDocBodies, getEnvLeadingOptionParseResult, getProcessSubstitutionOutput, getWrappedShellCommand, getWrappedShellCommandFromTokens, isSupportedEnvCommand, MAX_WRAPPED_SHELL_GIT_COMMIT_RECURSION_DEPTH, normalizeShellCommandTokens, normalizeShellCommandTokensFromTokens, normalizeTrailingLineEnding, splitShellCommandSegments, stripLeadingOptionTerminator, stripLeadingShellCommandPrefixes, tokenizeShellWords, } from "./shell-parser.js";
 export const TLH_DEFAULT_COMMIT_ATTRIBUTION = `Co-authored-by: The Last Harness <hi@thelastharness.com>`;
 const TLH_GIT_COMMIT_ATTRIBUTION_PROMPT_HEADING = "## TLH Git Commit Attribution";
@@ -13,25 +12,6 @@ const GIT_GLOBAL_OPTIONS_WITH_VALUES = new Set([
     "--super-prefix",
     "--work-tree",
 ]);
-function normalizeTlhAttributionConfig(config) {
-    if (!isRecord(config)) {
-        return undefined;
-    }
-    const commit = config.commit;
-    if (commit === undefined) {
-        return {};
-    }
-    return typeof commit === "boolean" ? { commit } : undefined;
-}
-export function getTlhAttributionConfig(cwd) {
-    try {
-        const settings = SettingsManager.create(cwd, getAgentDir()).getGlobalSettings();
-        return normalizeTlhAttributionConfig(settings.tlh?.attribution);
-    }
-    catch {
-        return undefined;
-    }
-}
 export function resolveTlhCommitAttribution(config) {
     if (config?.commit === false) {
         return { enabled: false };

--- a/extensions/the-last-harness/attribution.ts
+++ b/extensions/the-last-harness/attribution.ts
@@ -1,5 +1,4 @@
-import { SettingsManager, getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { isRecord } from "./common.js";
+import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   commandBasename,
   extractHereDocBodies,
@@ -17,7 +16,7 @@ import {
   stripLeadingShellCommandPrefixes,
   tokenizeShellWords,
 } from "./shell-parser.js";
-import type { TlhAttributionConfig, TlhCommitAttributionState, TlhSettings } from "./types.js";
+import type { TlhAttributionConfig, TlhCommitAttributionState } from "./types.js";
 
 export const TLH_DEFAULT_COMMIT_ATTRIBUTION = `Co-authored-by: The Last Harness <hi@thelastharness.com>`;
 
@@ -33,26 +32,6 @@ const GIT_GLOBAL_OPTIONS_WITH_VALUES = new Set([
   "--super-prefix",
   "--work-tree",
 ]);
-
-function normalizeTlhAttributionConfig(config: unknown): TlhAttributionConfig | undefined {
-  if (!isRecord(config)) {
-    return undefined;
-  }
-  const commit = config.commit;
-  if (commit === undefined) {
-    return {};
-  }
-  return typeof commit === "boolean" ? { commit } : undefined;
-}
-
-export function getTlhAttributionConfig(cwd: string): TlhAttributionConfig | undefined {
-  try {
-    const settings = SettingsManager.create(cwd, getAgentDir()).getGlobalSettings() as TlhSettings;
-    return normalizeTlhAttributionConfig(settings.tlh?.attribution);
-  } catch {
-    return undefined;
-  }
-}
 
 export function resolveTlhCommitAttribution(
   config: TlhAttributionConfig | undefined,

--- a/extensions/the-last-harness/changelog.js
+++ b/extensions/the-last-harness/changelog.js
@@ -56,9 +56,3 @@ export async function handleTlhChangelogCommand(pi, _args, ctx) {
         details: { title: TLH_RELEASE_NOTES_TITLE },
     });
 }
-export function registerTlhChangelogCommand(pi) {
-    pi.registerCommand("tlh-changelog", {
-        description: TLH_CHANGELOG_COMMAND_DESCRIPTION,
-        handler: async (args, ctx) => handleTlhChangelogCommand(pi, args, ctx),
-    });
-}

--- a/extensions/the-last-harness/changelog.ts
+++ b/extensions/the-last-harness/changelog.ts
@@ -82,10 +82,3 @@ export async function handleTlhChangelogCommand(
     details: { title: TLH_RELEASE_NOTES_TITLE },
   });
 }
-
-export function registerTlhChangelogCommand(pi: ExtensionAPI): void {
-  pi.registerCommand("tlh-changelog", {
-    description: TLH_CHANGELOG_COMMAND_DESCRIPTION,
-    handler: async (args, ctx) => handleTlhChangelogCommand(pi, args, ctx),
-  });
-}

--- a/extensions/the-last-harness/experimental-command.js
+++ b/extensions/the-last-harness/experimental-command.js
@@ -1,5 +1,5 @@
 import { formatHomePath, isRecord } from "./common.js";
-import { availableExperimentalFeatureList, EXPERIMENTAL_COMMAND_COMPLETIONS, EXPERIMENTAL_COMMAND_HELP, getExperimentalFeature, getTlhExperimentalConfig, hasRegisteredExperimentalFeatures, isTlhExperimentalFeatureEnabled, noExperimentalFeaturesMessage, normalizeEnabledFeatures, parseExperimentalSlashAction, TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT, TLH_EXPERIMENTAL_FEATURES, unknownExperimentalFeatureMessage, } from "./experimental.js";
+import { availableExperimentalFeatureList, EXPERIMENTAL_COMMAND_HELP, getExperimentalFeature, getTlhExperimentalConfig, hasRegisteredExperimentalFeatures, isTlhExperimentalFeatureEnabled, noExperimentalFeaturesMessage, normalizeEnabledFeatures, parseExperimentalSlashAction, TLH_EXPERIMENTAL_FEATURE_CHANGED_EVENT, TLH_EXPERIMENTAL_FEATURES, unknownExperimentalFeatureMessage, } from "./experimental.js";
 import { withLockedTlhSettingsWrite } from "./profile-state.js";
 function validateTlhExperimentalSettings(settings) {
     if (!isRecord(settings)) {
@@ -149,15 +149,6 @@ function writeExperimentalFeaturePreference(cwd, featureId, action) {
             nextContent: `${JSON.stringify(settings, null, 2)}\n`,
         };
     });
-}
-export function getExperimentalCommandCompletions(prefix) {
-    const normalizedPrefix = prefix.trim().toLowerCase();
-    const completions = EXPERIMENTAL_COMMAND_COMPLETIONS.filter((option) => option.value.startsWith(normalizedPrefix)).map((option) => ({
-        value: option.value,
-        label: option.value,
-        description: option.description,
-    }));
-    return completions.length > 0 ? completions : null;
 }
 export async function handleExperimentalCommand(pi, args, ctx) {
     const command = parseExperimentalSlashAction(args);

--- a/extensions/the-last-harness/experimental-command.ts
+++ b/extensions/the-last-harness/experimental-command.ts
@@ -3,7 +3,6 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { formatHomePath, isRecord } from "./common.js";
 import {
   availableExperimentalFeatureList,
-  EXPERIMENTAL_COMMAND_COMPLETIONS,
   EXPERIMENTAL_COMMAND_HELP,
   getExperimentalFeature,
   getTlhExperimentalConfig,
@@ -248,18 +247,6 @@ function writeExperimentalFeaturePreference(
       };
     },
   );
-}
-
-export function getExperimentalCommandCompletions(prefix: string) {
-  const normalizedPrefix = prefix.trim().toLowerCase();
-  const completions = EXPERIMENTAL_COMMAND_COMPLETIONS.filter((option) =>
-    option.value.startsWith(normalizedPrefix),
-  ).map((option) => ({
-    value: option.value,
-    label: option.value,
-    description: option.description,
-  }));
-  return completions.length > 0 ? completions : null;
 }
 
 export async function handleExperimentalCommand(

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -464,19 +464,6 @@ function classifyAliasBroadTarget(
 	);
 }
 
-export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
-	let current = expression;
-	while (
-		current.type === "ParenthesizedExpression" ||
-		current.type === "TSAsExpression" ||
-		current.type === "TSTypeAssertion" ||
-		current.type === "TSNonNullExpression"
-	) {
-		current = current.expression;
-	}
-	return current.type === "ObjectExpression" && current.properties.length > 0;
-}
-
 export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
 	let current = expression;
 	while (


### PR DESCRIPTION
## Summary

Removes the 12 genuinely-dead exported symbols identified in the dead-code audit (#557), plus their generated `.js` twins and directly orphaned private helpers/imports. Pure deletion — no behavior change. Compat tombstones called out in #557 (`scripts/tlh-install-query.mjs`, `scripts/lib/tlh-profile-writes.mjs`, `config/librarian.defaults.json`) are intentionally untouched.

Removed symbols:

- `extensions/subagents/src/runs/shared/nested-events.ts`: `claimNestedControlRequest`, `findNestedRunById`, `isTopLevelAsyncDir`, `nestedArtifactEnv`, `nestedControlRequestOwnedBy`, `nestedRouteEnv`
- `extensions/subagents/src/shared/subagent-shortcuts.ts`: `pauseAllShortcutDisplay`
- `extensions/subagents/src/shared/utils.ts`: `getLastActivity`
- `extensions/the-last-harness/attribution.ts`: `getTlhAttributionConfig`
- `extensions/the-last-harness/changelog.ts`: `registerTlhChangelogCommand`
- `extensions/the-last-harness/experimental-command.ts`: `getExperimentalCommandCompletions`
- `tools/oxlint/anti-slop/shared/dictionary-types.ts`: `isPopulatedObjectExpression`

## Change type

- [x] Extension / skill / prompt / theme
- [ ] Installer / wrapper
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

_Paste the relevant output or a summary here:_

- `npm run validate` exit 0 (after a first-run lint catch of a now-unused import in `experimental-command`, fixed and re-validated)
- subagents unit tests 1071/1071 passed, integration 588/588 passed, e2e 1/1 passed
- `git grep` for each removed symbol returns zero hits across all tracked files
- Generated `.js` twins regenerated via `node scripts/runtime-typescript.mjs build`

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (no user-visible change; internal dead code only)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/dead-code-audit-cleanup/install.sh | bash -s -- --ref dead-code-audit-cleanup --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed Features**
  - Removed the TLH changelog command and experimental command-completion suggestions.
  - Removed settings-based TLH attribution loading; attribution now relies on existing configuration.
  - Removed pause-all shortcut display and activity-label reporting.
  - Retired unused nested-run controls and environment helpers while preserving nested result handling.

- **Maintenance**
  - Updated expression analysis to recognize a broader set of evidence expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->