### PR TITLE
Fix async runner startup interrupt race

### DIFF
--- a/extensions/subagents/src/runs/background/subagent-runner.js
+++ b/extensions/subagents/src/runs/background/subagent-runner.js
@@ -1430,6 +1430,11 @@ async function runSubagent(config) {
     const overallStartTime = Date.now();
     const shareEnabled = config.share === true;
     const asyncDir = config.asyncDir;
+    let interruptRunner;
+    const interruptSignalTrampoline = () => {
+        interruptRunner?.();
+    };
+    process.on(ASYNC_INTERRUPT_SIGNAL, interruptSignalTrampoline);
     const statusPath = path.join(asyncDir, "status.json");
     const eventsPath = path.join(asyncDir, "events.jsonl");
     const logPath = path.join(asyncDir, `subagent-log-${id}.md`);
@@ -2603,7 +2608,7 @@ async function runSubagent(config) {
         }, 1000);
         activityTimer.unref?.();
     }
-    const interruptRunner = () => {
+    interruptRunner = () => {
         consumeInterruptRequest(asyncDir);
         if (interrupted || statusPayload.state !== "running")
             return;
@@ -2675,7 +2680,6 @@ async function runSubagent(config) {
         timeoutNestedAsyncDescendants();
         timeoutActiveChildren();
     };
-    process.on(ASYNC_INTERRUPT_SIGNAL, interruptRunner);
     const disposeControlInbox = watchAsyncControlInbox(asyncDir, {
         onInterrupt: interruptRunner,
         onTimeout: timeoutRunner,

--- a/extensions/subagents/src/runs/background/subagent-runner.ts
+++ b/extensions/subagents/src/runs/background/subagent-runner.ts
@@ -2014,6 +2014,15 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
   const overallStartTime = Date.now();
   const shareEnabled = config.share === true;
   const asyncDir = config.asyncDir;
+  // Install this route before publishing the running PID. The control inbox is
+  // authoritative, so the early trampoline deliberately does not act on the
+  // signal until the graceful handler below is initialized; it only prevents
+  // the platform default from terminating the runner in that startup window.
+  let interruptRunner: (() => void) | undefined;
+  const interruptSignalTrampoline = (): void => {
+    interruptRunner?.();
+  };
+  process.on(ASYNC_INTERRUPT_SIGNAL, interruptSignalTrampoline);
   const statusPath = path.join(asyncDir, "status.json");
   const eventsPath = path.join(asyncDir, "events.jsonl");
   const logPath = path.join(asyncDir, `subagent-log-${id}.md`);
@@ -3417,7 +3426,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
     activityTimer.unref?.();
   }
 
-  const interruptRunner = () => {
+  interruptRunner = () => {
     consumeInterruptRequest(asyncDir);
     if (interrupted || statusPayload.state !== "running") return;
     interrupted = true;
@@ -3501,7 +3510,6 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
     timeoutNestedAsyncDescendants();
     timeoutActiveChildren();
   };
-  process.on(ASYNC_INTERRUPT_SIGNAL, interruptRunner);
   // Portable control inbox: the parent drops control request files here when
   // it cannot deliver OS signals (e.g. ENOSYS on Windows) or when steering a
   // live child. Interrupts still route into the same graceful interruptRunner().


### PR DESCRIPTION
## Summary

Prevent an async runner from being terminated when an interrupt arrives after its running PID is published but before the graceful interrupt handler is initialized. The early signal trampoline preserves the file-based control inbox as the authoritative request path.

Fixes the failure observed in [GitHub Actions job 97556563377](https://github.com/diegopetrucci/the-last-harness/actions/runs/32766348680/job/97556563377).

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed. Additional focused validation:

- Supervisor-first/external-interrupt race test: 10/10 repeated passes
- Subagent integration suite: 592/592 passed
- Generated runtime outputs verified fresh

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this internal race fix)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/async-startup-interrupt-race/install.sh | bash -s -- --ref fix/async-startup-interrupt-race --track ref
```
