### PR TITLE
Define canonical validation check inventory

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:subagents-test": "tsc --noEmit --project tsconfig.subagents-test.json",
     "typecheck:runtime": "node scripts/runtime-typescript.mjs typecheck",
-    "validate": "npm run check:package-versions && npm run check:package-contents && npm run check:lazy-import-boundaries && npm run typecheck && npm run typecheck:runtime && npm run check:runtime && bash scripts/check-installer-smoke.sh && npm test && npm run lint && npm run format:check && npm run lint:sh && node scripts/merge-settings.mjs --dry-run && npm pack --dry-run"
+    "validate": "node scripts/run-validation.mjs"
   },
   "files": [
     "agents",

--- a/scripts/.npmignore
+++ b/scripts/.npmignore
@@ -17,4 +17,6 @@ run-subagents-tests.mjs
 run-lane.mjs
 run-ci-test-shard.mjs
 run-ci-validation.mjs
+run-validation.mjs
 runtime-typescript.mjs
+validation-checks.mjs

--- a/scripts/run-ci-validation.mjs
+++ b/scripts/run-ci-validation.mjs
@@ -12,86 +12,29 @@
  *   --exclude=<a,b,...>  comma-separated list of lanes to skip
  *   Both flags also accept the space form: --lanes lint,pkg or --exclude smoke
  *
- * Runs all 11 non-test validation checks in concurrent lanes.
- * This is the CI-only parallel runner; 'npm run validate' stays sequential for contributors.
+ * Runs all non-test validation checks in concurrent lanes projected from the canonical
+ * manifest. Commands within each selected lane remain sequential; lanes run concurrently.
+ * Contributor `npm run validate` remains sequential and fail-fast.
  *
- * Lane grouping:
- *   - smoke:        bash scripts/check-installer-smoke.sh (~15s)
- *   - typecheck-rt: npm run typecheck:runtime (~10s)
- *   - check-rt:     npm run check:runtime (~10s)
- *   - typecheck:    npm run typecheck (~8s)
- *   - lint:         npm run lint → npm run format:check → npm run lint:sh (~6.5s)
- *   - pkg:          npm run check:package-versions → npm run check:package-contents →
- *                   node scripts/merge-settings.mjs --dry-run → npm pack --dry-run (~5s)
- *
- * Sequential within "lint": lint:sh downloads the shellcheck binary into node_modules/;
- * keeping the Oxlint, Oxfmt, and ShellCheck checks sequential prevents that write from
- * overlapping either tool run.
- *
- * Sequential within "pkg": check:package-contents and npm pack --dry-run both inspect
- * packaging metadata; sequential ordering avoids any shared-state hazard between them.
- *
- * typecheck:runtime and check:runtime run in separate lanes (each compiles to its own
- * mkdtempSync directory and never writes into the repo), as noted in the design.
- *
- * Lane split usage in CI: pass --lanes or --exclude to a job so that only the relevant
- * subset of checks runs in that job, while LANES stays the single source of truth.
+ * CI selects the lint lane for the lint job and excludes it for the non-lint validation job;
+ * the latter therefore includes the lazy-import-boundary check from the manifest.
  */
 
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { projectConcurrentLanes } from "./validation-checks.mjs";
 import { runLanes } from "./run-lane.mjs";
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(scriptPath), "..");
 
-const mergeSettingsScript = join(repoRoot, "scripts", "merge-settings.mjs");
-
 /**
- * All validation checks, organized as concurrent lanes.
+ * Concurrent CI projection of the canonical validation manifest.
  * Commands within a lane run sequentially; lanes run concurrently.
  *
  * @type {import("./run-lane.mjs").Lane[]}
  */
-export const LANES = [
-  {
-    name: "smoke",
-    commands: [["bash", "scripts/check-installer-smoke.sh"]],
-  },
-  {
-    name: "typecheck-rt",
-    commands: [["npm", "run", "typecheck:runtime"]],
-  },
-  {
-    name: "check-rt",
-    commands: [["npm", "run", "check:runtime"]],
-  },
-  {
-    name: "typecheck",
-    commands: [["npm", "run", "typecheck"]],
-  },
-  {
-    name: "lint",
-    commands: [
-      // lint:sh downloads shellcheck into node_modules/; keep sequential with lint to
-      // avoid concurrent writes to node_modules while the Oxlint/Oxfmt checks are running.
-      ["npm", "run", "lint"],
-      ["npm", "run", "format:check"],
-      ["npm", "run", "lint:sh"],
-    ],
-  },
-  {
-    name: "pkg",
-    commands: [
-      ["npm", "run", "check:package-versions"],
-      // check:package-contents and npm pack --dry-run both inspect packaging metadata;
-      // run them sequentially to avoid any shared-state hazard.
-      ["npm", "run", "check:package-contents"],
-      [process.execPath, mergeSettingsScript, "--dry-run"],
-      ["npm", "pack", "--dry-run"],
-    ],
-  },
-];
+export const LANES = projectConcurrentLanes();
 
 /**
  * Parse argv for --lanes and --exclude flags and return the selected subset of lanes.

--- a/scripts/run-validation.mjs
+++ b/scripts/run-validation.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Contributor validation entrypoint.
+ *
+ * The non-test commands come from validation-checks.mjs. npm test remains an
+ * explicit contributor-only step between installer smoke and lint, matching the
+ * historical `npm run validate` placement. Commands stop at the first failure.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { projectSequentialChecks, VALIDATION_CHECKS } from "./validation-checks.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+
+export const TEST_AFTER_CHECK_ID = "check-installer-smoke";
+export const TEST_COMMAND = Object.freeze(["npm", "test"]);
+
+/**
+ * Project the manifest into the complete contributor sequence, including the
+ * non-manifest test step at its established position.
+ *
+ * @returns {Array<{ kind: "validation" | "test"; id: string; argv: string[] }>}
+ */
+export function projectContributorCommands(checks = VALIDATION_CHECKS) {
+  const commands = [];
+  let insertedTest = false;
+
+  for (const check of projectSequentialChecks(checks)) {
+    commands.push({ kind: "validation", id: check.id, argv: [...check.argv] });
+    if (check.id === TEST_AFTER_CHECK_ID) {
+      commands.push({ kind: "test", id: "npm-test", argv: [...TEST_COMMAND] });
+      insertedTest = true;
+    }
+  }
+
+  if (!insertedTest) {
+    throw new Error(
+      `Contributor validation manifest must include ${TEST_AFTER_CHECK_ID} to place npm test.`,
+    );
+  }
+
+  return commands;
+}
+
+/**
+ * Run one command with the contributor's normal environment and working tree.
+ *
+ * @param {string[]} argv
+ * @returns {number}
+ */
+function runCommand(argv) {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    process.stderr.write(`Failed to run ${argv.join(" ")}: ${result.error.message}\n`);
+    return 1;
+  }
+  return result.status ?? 1;
+}
+
+/**
+ * Run contributor validation sequentially and fail fast.
+ *
+ * @param {{
+ *   checks?: ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>;
+ *   run?: (argv: string[], command: { kind: "validation" | "test"; id: string; argv: string[] }) => number;
+ * }} [options]
+ * @returns {number}
+ */
+export function runContributorValidation({ checks = VALIDATION_CHECKS, run = runCommand } = {}) {
+  for (const command of projectContributorCommands(checks)) {
+    const status = run(command.argv, command);
+    if (status !== 0) return typeof status === "number" ? status : 1;
+  }
+  return 0;
+}
+
+export async function main() {
+  return runContributorValidation();
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  main()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `Fatal error: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      process.exitCode = 1;
+    });
+}

--- a/scripts/validation-checks.mjs
+++ b/scripts/validation-checks.mjs
@@ -1,0 +1,204 @@
+/**
+ * Canonical inventory of production validation checks.
+ *
+ * Keep the manifest declaration grouped by the existing CI lane order so CI's
+ * lane selection remains stable. `order` is the contributor-facing sequential
+ * order and is deliberately independent of that declaration order.
+ */
+
+const CHECK_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Every command that validates the production package without running tests.
+ *
+ * @type {ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>}
+ */
+export const VALIDATION_CHECKS = Object.freeze(
+  [
+    {
+      id: "check-installer-smoke",
+      argv: ["bash", "scripts/check-installer-smoke.sh"],
+      lane: "smoke",
+      order: 7,
+    },
+    {
+      id: "typecheck-runtime",
+      argv: ["npm", "run", "typecheck:runtime"],
+      lane: "typecheck-rt",
+      order: 5,
+    },
+    {
+      id: "check-runtime",
+      argv: ["npm", "run", "check:runtime"],
+      lane: "check-rt",
+      order: 6,
+    },
+    {
+      id: "typecheck",
+      argv: ["npm", "run", "typecheck"],
+      lane: "typecheck",
+      order: 4,
+    },
+    // Keep lint, format, and ShellCheck in one lane and in this order. lint:sh can
+    // download the ShellCheck binary into node_modules; this prevents that write from
+    // overlapping the other checks.
+    {
+      id: "lint",
+      argv: ["npm", "run", "lint"],
+      lane: "lint",
+      order: 8,
+    },
+    {
+      id: "format-check",
+      argv: ["npm", "run", "format:check"],
+      lane: "lint",
+      order: 9,
+    },
+    {
+      id: "lint-sh",
+      argv: ["npm", "run", "lint:sh"],
+      lane: "lint",
+      order: 10,
+    },
+    // Keep package checks in one lane and preserve their order. The package
+    // contents and npm pack checks inspect shared packaging metadata; the lazy
+    // import check is included here for the non-lint CI projection independently.
+    {
+      id: "check-package-versions",
+      argv: ["npm", "run", "check:package-versions"],
+      lane: "pkg",
+      order: 1,
+    },
+    {
+      id: "check-package-contents",
+      argv: ["npm", "run", "check:package-contents"],
+      lane: "pkg",
+      order: 2,
+    },
+    {
+      id: "check-lazy-import-boundaries",
+      argv: ["npm", "run", "check:lazy-import-boundaries"],
+      lane: "pkg",
+      order: 3,
+    },
+    {
+      id: "merge-settings",
+      argv: ["node", "scripts/merge-settings.mjs", "--dry-run"],
+      lane: "pkg",
+      order: 11,
+    },
+    {
+      id: "npm-pack",
+      argv: ["npm", "pack", "--dry-run"],
+      lane: "pkg",
+      order: 12,
+    },
+  ].map((check) => Object.freeze({ ...check, argv: Object.freeze([...check.argv]) })),
+);
+
+/**
+ * Validate a manifest before projecting it into either execution form.
+ *
+ * @param {unknown} checks
+ * @returns {ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>}
+ */
+export function assertValidValidationChecks(checks) {
+  if (!Array.isArray(checks) || checks.length === 0) {
+    throw new Error("Validation check manifest must be a non-empty array.");
+  }
+
+  const ids = new Set();
+  const argvOwners = new Map();
+  const orders = new Set();
+  for (const [index, check] of checks.entries()) {
+    if (check === null || typeof check !== "object" || Array.isArray(check)) {
+      throw new Error(`Validation check ${index + 1} must be an object.`);
+    }
+
+    const { id, argv, lane, order } = check;
+    if (typeof id !== "string" || !CHECK_ID_PATTERN.test(id)) {
+      throw new Error(`Validation check ${index + 1} has an invalid id; use lowercase kebab-case.`);
+    }
+    if (ids.has(id)) {
+      throw new Error(`Validation check id is duplicated: ${id}`);
+    }
+    ids.add(id);
+
+    if (
+      !Array.isArray(argv) ||
+      argv.length === 0 ||
+      argv.some((argument) => typeof argument !== "string" || argument.length === 0)
+    ) {
+      throw new Error(`Validation check ${id} must define a non-empty argv of non-empty strings.`);
+    }
+    const argvKey = JSON.stringify(argv);
+    const existingArgvOwner = argvOwners.get(argvKey);
+    if (existingArgvOwner !== undefined) {
+      throw new Error(
+        `Validation check argv is duplicated between ${existingArgvOwner} and ${id}.`,
+      );
+    }
+    argvOwners.set(argvKey, id);
+
+    if (typeof lane !== "string" || lane.length === 0) {
+      throw new Error(`Validation check ${id} must define a non-empty CI lane.`);
+    }
+
+    if (!Number.isSafeInteger(order) || order < 1) {
+      throw new Error(`Validation check ${id} must define a positive integer order.`);
+    }
+    if (orders.has(order)) {
+      throw new Error(`Validation check order is duplicated: ${order}`);
+    }
+    orders.add(order);
+  }
+
+  return checks;
+}
+
+/**
+ * @param {ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>} checks
+ */
+function orderedChecks(checks) {
+  assertValidValidationChecks(checks);
+  return [...checks].sort((left, right) => left.order - right.order);
+}
+
+/**
+ * Project the manifest into the contributor's sequential check list.
+ *
+ * @param {ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>} [checks]
+ * @returns {Array<{ id: string; argv: string[]; lane: string; order: number }>}
+ */
+export function projectSequentialChecks(checks = VALIDATION_CHECKS) {
+  return orderedChecks(checks).map((check) => ({ ...check, argv: [...check.argv] }));
+}
+
+/**
+ * Project the manifest into the concurrent CI lane shape consumed by run-lane.
+ * Commands within each lane retain the manifest's sequential ordering.
+ *
+ * @param {ReadonlyArray<Readonly<{ id: string; argv: readonly string[]; lane: string; order: number }>>} [checks]
+ * @returns {Array<{ name: string; commands: string[][] }>}
+ */
+export function projectConcurrentLanes(checks = VALIDATION_CHECKS) {
+  assertValidValidationChecks(checks);
+  const lanes = new Map();
+  for (const check of checks) {
+    let laneChecks = lanes.get(check.lane);
+    if (laneChecks === undefined) {
+      laneChecks = [];
+      lanes.set(check.lane, laneChecks);
+    }
+    laneChecks.push(check);
+  }
+
+  return [...lanes].map(([name, laneChecks]) => ({
+    name,
+    commands: [...laneChecks]
+      .sort((left, right) => left.order - right.order)
+      .map((check) => [...check.argv]),
+  }));
+}
+
+assertValidValidationChecks(VALIDATION_CHECKS);

--- a/tests/run-validation.test.mjs
+++ b/tests/run-validation.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  projectContributorCommands,
+  runContributorValidation,
+  TEST_AFTER_CHECK_ID,
+  TEST_COMMAND,
+} from "../scripts/run-validation.mjs";
+import { projectSequentialChecks } from "../scripts/validation-checks.mjs";
+
+test("contributor projection inserts npm test after installer smoke", () => {
+  const commands = projectContributorCommands();
+  const checks = projectSequentialChecks();
+  const validationCommands = commands.filter((command) => command.kind === "validation");
+  const testCommands = commands.filter((command) => command.kind === "test");
+
+  assert.deepEqual(
+    validationCommands.map((command) => command.id),
+    checks.map((check) => check.id),
+  );
+  assert.equal(testCommands.length, 1);
+  assert.deepEqual(testCommands[0].argv, TEST_COMMAND);
+
+  const smokeIndex = commands.findIndex((command) => command.id === TEST_AFTER_CHECK_ID);
+  const testIndex = commands.findIndex((command) => command.kind === "test");
+  const lintIndex = commands.findIndex((command) => command.id === "lint");
+  assert.equal(testIndex, smokeIndex + 1);
+  assert.ok(testIndex < lintIndex);
+});
+
+test("contributor runner fails fast at the first failed command", () => {
+  const commands = projectContributorCommands();
+  const failedId = commands[2].id;
+  const invoked = [];
+
+  const status = runContributorValidation({
+    run(_argv, command) {
+      invoked.push(command.id);
+      return command.id === failedId ? 17 : 0;
+    },
+  });
+
+  assert.equal(status, 17);
+  assert.deepEqual(
+    invoked,
+    commands.slice(0, 3).map((command) => command.id),
+    "commands after the first failure must not run",
+  );
+});
+
+test("contributor runner returns zero after every projected command succeeds", () => {
+  const invoked = [];
+  const status = runContributorValidation({
+    run(_argv, command) {
+      invoked.push(command.id);
+      return 0;
+    },
+  });
+
+  assert.equal(status, 0);
+  assert.deepEqual(
+    invoked,
+    projectContributorCommands().map((command) => command.id),
+  );
+});

--- a/tests/validation-checks.test.mjs
+++ b/tests/validation-checks.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LANES, selectLanes } from "../scripts/run-ci-validation.mjs";
+import {
+  assertValidValidationChecks,
+  projectConcurrentLanes,
+  projectSequentialChecks,
+  VALIDATION_CHECKS,
+} from "../scripts/validation-checks.mjs";
+
+function commandKey(argv) {
+  return JSON.stringify(argv);
+}
+
+test("validation manifest has unique IDs, orders, and valid argv", () => {
+  assert.doesNotThrow(() => assertValidValidationChecks(VALIDATION_CHECKS));
+  assert.equal(new Set(VALIDATION_CHECKS.map((check) => check.id)).size, VALIDATION_CHECKS.length);
+  assert.equal(
+    new Set(VALIDATION_CHECKS.map((check) => check.order)).size,
+    VALIDATION_CHECKS.length,
+  );
+  for (const check of VALIDATION_CHECKS) {
+    assert.ok(check.id.length > 0);
+    assert.ok(check.lane.length > 0);
+    assert.ok(check.argv.length > 0);
+    assert.ok(check.argv.every((argument) => typeof argument === "string" && argument.length > 0));
+  }
+});
+
+test("validation projections include every manifest command exactly once", () => {
+  const expected = VALIDATION_CHECKS.map((check) => commandKey(check.argv)).sort();
+  const sequential = projectSequentialChecks();
+  const concurrent = projectConcurrentLanes().flatMap((lane) => lane.commands);
+
+  assert.deepEqual(
+    sequential.map((check) => commandKey(check.argv)).sort(),
+    expected,
+    "sequential projection must contain every manifest command once",
+  );
+  assert.deepEqual(
+    concurrent.map(commandKey).sort(),
+    expected,
+    "concurrent projection must contain every manifest command once",
+  );
+  assert.equal(new Set(sequential.map((check) => check.id)).size, VALIDATION_CHECKS.length);
+});
+
+test("sequential projection starts with the dependency version check", () => {
+  const [firstCheck] = projectSequentialChecks();
+  assert.equal(
+    firstCheck.id,
+    "check-package-versions",
+    "package-version validation must precede all other contributor checks",
+  );
+});
+
+test("sequential projection preserves package and lint ordering invariants", () => {
+  const sequential = projectSequentialChecks();
+  const indexOf = (id) => sequential.findIndex((check) => check.id === id);
+  const before = (left, right) =>
+    assert.ok(indexOf(left) < indexOf(right), `${left} must precede ${right}`);
+
+  before("check-package-versions", "check-package-contents");
+  before("check-package-contents", "check-lazy-import-boundaries");
+  before("check-lazy-import-boundaries", "merge-settings");
+  before("merge-settings", "npm-pack");
+  before("lint", "format-check");
+  before("format-check", "lint-sh");
+  before("check-runtime", "check-installer-smoke");
+  before("check-installer-smoke", "lint");
+});
+
+test("lazy-import-boundaries is projected into the non-lint CI invocation", () => {
+  const lazyCheck = VALIDATION_CHECKS.find((check) => check.id === "check-lazy-import-boundaries");
+  assert.ok(lazyCheck);
+
+  const nonLintCommands = projectConcurrentLanes()
+    .filter((lane) => lane.name !== "lint")
+    .flatMap((lane) => lane.commands)
+    .map(commandKey);
+  assert.ok(nonLintCommands.includes(commandKey(lazyCheck.argv)));
+});
+
+test("production lane selection retains the existing lint and non-lint splits", () => {
+  const allLanes = selectLanes(LANES, []);
+  assert.deepEqual(
+    allLanes.map((lane) => lane.name),
+    [...new Set(VALIDATION_CHECKS.map((check) => check.lane))],
+  );
+
+  const lintLanes = selectLanes(LANES, ["--lanes=lint"]);
+  assert.deepEqual(
+    lintLanes.map((lane) => lane.name),
+    ["lint"],
+  );
+
+  const nonLintLanes = selectLanes(LANES, ["--exclude=lint"]);
+  assert.ok(!nonLintLanes.some((lane) => lane.name === "lint"));
+  assert.ok(
+    nonLintLanes.some((lane) =>
+      lane.commands.some(
+        (argv) => commandKey(argv) === commandKey(["npm", "run", "check:lazy-import-boundaries"]),
+      ),
+    ),
+  );
+});
+
+test("invalid or duplicate manifest entries are rejected", () => {
+  const duplicateId = VALIDATION_CHECKS.map((check) => ({ ...check, argv: [...check.argv] }));
+  duplicateId[1].id = duplicateId[0].id;
+  assert.throws(() => assertValidValidationChecks(duplicateId), /id is duplicated/);
+
+  const duplicateArgv = VALIDATION_CHECKS.map((check) => ({ ...check, argv: [...check.argv] }));
+  duplicateArgv[1].id = `${duplicateArgv[1].id}-duplicate`;
+  duplicateArgv[1].argv = [...duplicateArgv[0].argv];
+  assert.throws(() => assertValidValidationChecks(duplicateArgv), /argv is duplicated/);
+
+  const invalidArgv = VALIDATION_CHECKS.map((check) => ({ ...check, argv: [...check.argv] }));
+  invalidArgv[0].argv = [];
+  assert.throws(() => assertValidValidationChecks(invalidArgv), /non-empty argv/);
+});


### PR DESCRIPTION
## Summary

Define one canonical non-test validation-check inventory for contributor and CI execution, closing the S24 drift identified in #574. `npm run validate` now projects the manifest sequentially while CI derives concurrent lanes from the same source, including lazy-import-boundary validation in the non-lint Linux/macOS path.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed completely. Highlights:

- Focused validation projection/runner tests: 26 passed
- Subagent suites: unit 1110/1110, integration 592/592, e2e 1/1
- Runtime generated outputs: 193 fresh
- Package contents: 450 files; contributor-only validation scripts excluded
- Final review found no blockers or unintended generated, packed, staged, or ticket artifacts

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it — no user-visible packaged behavior changed
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/feat/canonical-validation-inventory/install.sh | bash -s -- --ref feat/canonical-validation-inventory --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized validation checks and execution order across contributor and CI workflows.
  * Validation commands now fail fast and report errors clearly.
  * CI validation lanes continue running concurrently while preserving sequential checks within each lane.
* **Bug Fixes**
  * Ensured all configured validation checks run exactly once.
  * Preserved required test, lint, packaging, and boundary-check ordering.
* **Tests**
  * Added coverage for validation ordering, lane projections, failure handling, and manifest integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->