### PR TITLE
Require release tags to belong to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Check out tag
         uses: actions/checkout@v7
         with:
+          # The ancestry gate needs the full history to verify reachability from origin/main.
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -28,6 +29,11 @@ jobs:
         with:
           node-version: '22.19.0'
           cache: 'npm'
+
+      - name: Verify release commit ancestry
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: node scripts/check-release-tag-ancestry.mjs
 
       - name: Verify release tag
         run: |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,11 +2,12 @@
 
 Releases are GitHub tag based. Pushing a semver tag such as `v0.1.0` runs `.github/workflows/release.yml`, which:
 
-1. verifies the tag matches `package.json`;
-2. runs the release checks;
-3. builds an npm-style package tarball;
-4. generates a pinned stage-0 `install.sh` asset with the tag baked in for support-file fetches and the `latest-release` update track baked in for future updates;
-5. creates a GitHub Release whose body is the matching `CHANGELOG.md` section, plus release assets.
+1. verifies the tag commit is reachable from `origin/main`;
+2. verifies the tag matches `package.json`;
+3. runs the release checks;
+4. builds an npm-style package tarball;
+5. generates a pinned stage-0 `install.sh` asset with the tag baked in for support-file fetches and the `latest-release` update track baked in for future updates;
+6. creates a GitHub Release whose body is the matching `CHANGELOG.md` section, plus release assets.
 
 There is no `stable` branch. A release is the immutable Git tag plus its GitHub Release assets. The stage-1 installer (`scripts/tlh-install.mjs`) and `scripts/lib/` helpers must be present in both the tag and package tarball.
 
@@ -69,6 +70,8 @@ git commit -m "Release v$version"
 ```
 
 ## Tag and publish
+
+Push `main` before pushing the tag: the release gate requires the tag commit to be reachable from `origin/main`.
 
 ```sh
 git tag -a "v$version" -m "v$version"

--- a/scripts/.npmignore
+++ b/scripts/.npmignore
@@ -11,6 +11,7 @@ installer-smoke/uninstall-runtime.sh
 check-lazy-import-boundaries.mjs
 check-package-contents.mjs
 check-package-versions.mjs
+check-release-tag-ancestry.mjs
 check-startup-performance.mjs
 release-notes.mjs
 run-subagents-tests.mjs

--- a/scripts/check-release-tag-ancestry.mjs
+++ b/scripts/check-release-tag-ancestry.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const RELEASE_MAIN_REF = "origin/main";
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function readReleaseCommit() {
+  const commit = process.env.GITHUB_SHA?.trim();
+  if (!commit) {
+    throw new Error("GITHUB_SHA is required to verify the release commit.");
+  }
+  if (!COMMIT_SHA_PATTERN.test(commit)) {
+    throw new Error("GITHUB_SHA must be a 40-character commit SHA.");
+  }
+  return commit;
+}
+
+/**
+ * Verify that a release commit is included in the repository's main branch.
+ *
+ * @param {string} commit
+ * @param {{ cwd?: string; runGit?: typeof spawnSync }} [options]
+ */
+export function verifyReleaseCommitAncestry(
+  commit,
+  { cwd = process.cwd(), runGit = spawnSync } = {},
+) {
+  const result = runGit("git", ["merge-base", "--is-ancestor", commit, RELEASE_MAIN_REF], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.error) {
+    throw new Error(`Unable to verify release commit ancestry: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+
+  if (result.status === 0) return;
+  if (result.status === 1) {
+    throw new Error(`Release commit ${commit} is not reachable from ${RELEASE_MAIN_REF}.`);
+  }
+
+  const details = String(result.stderr ?? "").trim();
+  throw new Error(`Unable to verify release commit ancestry${details ? `: ${details}` : "."}`);
+}
+
+function main() {
+  const commit = readReleaseCommit();
+  verifyReleaseCommitAncestry(commit);
+  process.stdout.write(
+    `Release commit ${commit} is reachable from ${RELEASE_MAIN_REF}; release may proceed.\n`,
+  );
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === resolve(scriptPath)) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`check-release-tag-ancestry: ${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/release-tag-ancestry.test.mjs
+++ b/tests/release-tag-ancestry.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const workflowPath = join(repoRoot, ".github", "workflows", "release.yml");
+const ancestryScript = join(repoRoot, "scripts", "check-release-tag-ancestry.mjs");
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr || String(result.error));
+  return result.stdout.trim();
+}
+
+function createRepository(t) {
+  const root = mkdtempSync(join(tmpdir(), "tlh-release-tag-ancestry-test-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  runGit(root, ["init", "--initial-branch=main"]);
+  runGit(root, ["config", "user.email", "tlh-tests@example.invalid"]);
+  runGit(root, ["config", "user.name", "TLH Tests"]);
+
+  writeFileSync(join(root, "state.txt"), "initial\n");
+  runGit(root, ["add", "state.txt"]);
+  runGit(root, ["commit", "-m", "initial"]);
+  const initialCommit = runGit(root, ["rev-parse", "HEAD"]);
+  runGit(root, ["update-ref", "refs/remotes/origin/main", initialCommit]);
+
+  return { root, initialCommit };
+}
+
+function commitChange(root, content, message) {
+  writeFileSync(join(root, "state.txt"), `${content}\n`);
+  runGit(root, ["add", "state.txt"]);
+  runGit(root, ["commit", "-m", message]);
+  return runGit(root, ["rev-parse", "HEAD"]);
+}
+
+function runAncestryCheck(root, commit, env = {}) {
+  return spawnSync(process.execPath, [ancestryScript], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_REF_NAME: "v1.2.3",
+      GITHUB_SHA: commit,
+      ...env,
+    },
+  });
+}
+
+test("release commit ancestry check passes for a commit reachable from origin/main", (t) => {
+  const fixture = createRepository(t);
+  const mainCommit = commitChange(fixture.root, "main", "main change");
+  runGit(fixture.root, ["update-ref", "refs/remotes/origin/main", mainCommit]);
+
+  const result = runAncestryCheck(fixture.root, mainCommit);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /is reachable from origin\/main/);
+  assert.equal(result.stderr, "");
+});
+
+test("release commit ancestry check rejects a tag commit outside origin/main", (t) => {
+  const fixture = createRepository(t);
+  runGit(fixture.root, ["checkout", "-b", "release"]);
+  const releaseCommit = commitChange(fixture.root, "release", "release-only change");
+  runGit(fixture.root, ["checkout", "main"]);
+  const mainCommit = commitChange(fixture.root, "main", "main-only change");
+  runGit(fixture.root, ["update-ref", "refs/remotes/origin/main", mainCommit]);
+
+  const result = runAncestryCheck(fixture.root, releaseCommit);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Release commit .* is not reachable from origin\/main/);
+  assert.equal(result.stdout, "");
+});
+
+test("release commit ancestry check fails closed when origin/main is unavailable", (t) => {
+  const fixture = createRepository(t);
+  runGit(fixture.root, ["update-ref", "-d", "refs/remotes/origin/main"]);
+
+  const result = runAncestryCheck(fixture.root, fixture.initialCommit);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unable to verify release commit ancestry/);
+});
+
+test("release workflow gates install, validation, packaging, and publication on ancestry", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const ancestry = workflow.indexOf("node scripts/check-release-tag-ancestry.mjs");
+  const install = workflow.indexOf("run: npm ci");
+  const validation = workflow.indexOf("run: npm run validate");
+  const packaging = workflow.indexOf("npm pack --json");
+  const publication = workflow.indexOf("gh release create");
+
+  assert.ok(ancestry >= 0, "release workflow must invoke the ancestry check");
+  assert.ok(install > ancestry, "ancestry check must precede dependency installation");
+  assert.ok(validation > ancestry, "ancestry check must precede validation");
+  assert.ok(packaging > ancestry, "ancestry check must precede packaging");
+  assert.ok(publication > ancestry, "ancestry check must precede publication");
+});


### PR DESCRIPTION
## Summary

- Require release tag commits to be reachable from `origin/main` before release side effects.
- Add fail-closed ancestry checking with temporary-repository regression coverage.
- Document main-before-tag publishing order and exclude the contributor-only checker from the package.

Part of #574 (recommendation S29).

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [x] Docs
- [x] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Passed completely, including typechecks, tests, lint, formatting, installer smoke checks, and package checks.

Additional focused checks:

```sh
node --test tests/release-tag-ancestry.test.mjs
git diff --check
```

The focused suite passed 4/4 tests. Final code review found no blockers.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/release-tag-main-ancestry/install.sh | bash -s -- --ref release-tag-main-ancestry --track ref
```
