### PR TITLE
Preserve positive async job evidence

### DIFF
--- a/extensions/the-last-harness/activity-tracker.js
+++ b/extensions/the-last-harness/activity-tracker.js
@@ -211,6 +211,21 @@ export function createTlhEffectiveActivityTracker(options = {}) {
         }, retryGraceMs));
         syncRetryGraceReason();
     };
+    const mergeAsyncJobRecord = (existing, incoming) => {
+        const incomingAsyncDir = typeof incoming.asyncDir === "string" && incoming.asyncDir.length > 0
+            ? incoming.asyncDir
+            : undefined;
+        const existingAsyncDir = typeof existing?.asyncDir === "string" && existing.asyncDir.length > 0
+            ? existing.asyncDir
+            : undefined;
+        const asyncDir = incomingAsyncDir ?? existingAsyncDir;
+        const pid = toValidPid(incoming.pid) ?? toValidPid(existing?.pid);
+        return {
+            source: incoming.source,
+            ...(asyncDir ? { asyncDir } : {}),
+            ...(pid !== undefined ? { pid } : {}),
+        };
+    };
     const setAsyncJobActive = (runId, record) => {
         if (disposed)
             return;
@@ -218,8 +233,7 @@ export function createTlhEffectiveActivityTracker(options = {}) {
         if (!runId || recentlyCompletedAsyncJobs.has(runId)) {
             return;
         }
-        const existing = activeAsyncJobs.get(runId);
-        activeAsyncJobs.set(runId, existing ? { ...existing, ...record } : record);
+        activeAsyncJobs.set(runId, mergeAsyncJobRecord(activeAsyncJobs.get(runId), record));
         scheduleLivenessCheck();
     };
     const drainDeadAsyncJobs = () => {
@@ -432,12 +446,14 @@ export function createTlhEffectiveActivityTracker(options = {}) {
             if (!isRecord(data) || typeof data.id !== "string" || data.id.length === 0) {
                 return;
             }
+            const record = { source: "started" };
+            const asyncDir = readNonEmptyStringField(data, "asyncDir");
+            if (asyncDir)
+                record.asyncDir = asyncDir;
             const pid = toValidPid(data.pid);
-            setAsyncJobActive(data.id, {
-                asyncDir: typeof data.asyncDir === "string" && data.asyncDir.length > 0 ? data.asyncDir : undefined,
-                pid,
-                source: "started",
-            });
+            if (pid !== undefined)
+                record.pid = pid;
+            setAsyncJobActive(data.id, record);
             notifyIfChanged();
         },
         handleAsyncComplete(data) {
@@ -463,11 +479,12 @@ export function createTlhEffectiveActivityTracker(options = {}) {
             if (!isAsyncControlContext(data, data.event)) {
                 return;
             }
-            setAsyncJobActive(data.event.runId, {
-                asyncDir: readNonEmptyStringField(data, "asyncDir") ??
-                    readNonEmptyStringField(data.event, "asyncDir"),
-                source: "control",
-            });
+            const record = { source: "control" };
+            const asyncDir = readNonEmptyStringField(data, "asyncDir") ??
+                readNonEmptyStringField(data.event, "asyncDir");
+            if (asyncDir)
+                record.asyncDir = asyncDir;
+            setAsyncJobActive(data.event.runId, record);
             notifyIfChanged();
         },
     };

--- a/extensions/the-last-harness/activity-tracker.ts
+++ b/extensions/the-last-harness/activity-tracker.ts
@@ -341,14 +341,34 @@ export function createTlhEffectiveActivityTracker(
     syncRetryGraceReason();
   };
 
+  const mergeAsyncJobRecord = (
+    existing: AsyncJobRecord | undefined,
+    incoming: AsyncJobRecord,
+  ): AsyncJobRecord => {
+    const incomingAsyncDir =
+      typeof incoming.asyncDir === "string" && incoming.asyncDir.length > 0
+        ? incoming.asyncDir
+        : undefined;
+    const existingAsyncDir =
+      typeof existing?.asyncDir === "string" && existing.asyncDir.length > 0
+        ? existing.asyncDir
+        : undefined;
+    const asyncDir = incomingAsyncDir ?? existingAsyncDir;
+    const pid = toValidPid(incoming.pid) ?? toValidPid(existing?.pid);
+    return {
+      source: incoming.source,
+      ...(asyncDir ? { asyncDir } : {}),
+      ...(pid !== undefined ? { pid } : {}),
+    };
+  };
+
   const setAsyncJobActive = (runId: string, record: AsyncJobRecord): void => {
     if (disposed) return;
     cleanupCompletedAsyncJobTombstones();
     if (!runId || recentlyCompletedAsyncJobs.has(runId)) {
       return;
     }
-    const existing = activeAsyncJobs.get(runId);
-    activeAsyncJobs.set(runId, existing ? { ...existing, ...record } : record);
+    activeAsyncJobs.set(runId, mergeAsyncJobRecord(activeAsyncJobs.get(runId), record));
     // Start the periodic liveness drain if it isn't already running.
     scheduleLivenessCheck();
   };
@@ -609,13 +629,12 @@ export function createTlhEffectiveActivityTracker(
       }
       // Validate pid: must be a positive integer. Reject 0 (targets the current process
       // group on POSIX and would report "alive" forever) and any non-integer value.
+      const record: AsyncJobRecord = { source: "started" };
+      const asyncDir = readNonEmptyStringField(data, "asyncDir");
+      if (asyncDir) record.asyncDir = asyncDir;
       const pid = toValidPid(data.pid);
-      setAsyncJobActive(data.id, {
-        asyncDir:
-          typeof data.asyncDir === "string" && data.asyncDir.length > 0 ? data.asyncDir : undefined,
-        pid,
-        source: "started",
-      });
+      if (pid !== undefined) record.pid = pid;
+      setAsyncJobActive(data.id, record);
       notifyIfChanged();
     },
     handleAsyncComplete(data) {
@@ -642,12 +661,12 @@ export function createTlhEffectiveActivityTracker(
       if (!isAsyncControlContext(data, data.event)) {
         return;
       }
-      setAsyncJobActive(data.event.runId, {
-        asyncDir:
-          readNonEmptyStringField(data, "asyncDir") ??
-          readNonEmptyStringField(data.event, "asyncDir"),
-        source: "control",
-      });
+      const record: AsyncJobRecord = { source: "control" };
+      const asyncDir =
+        readNonEmptyStringField(data, "asyncDir") ??
+        readNonEmptyStringField(data.event, "asyncDir");
+      if (asyncDir) record.asyncDir = asyncDir;
+      setAsyncJobActive(data.event.runId, record);
       notifyIfChanged();
     },
   };

--- a/tests/the-last-harness-activity-tracker.test.mjs
+++ b/tests/the-last-harness-activity-tracker.test.mjs
@@ -650,6 +650,78 @@ test("regression: job is retained when asyncDir exists but status.json not yet w
   }
 });
 
+test("regression: partial control events preserve started async anchors during startup", () => {
+  const root = mkdtempSync(join(tmpdir(), "tlh-start-control-anchors-"));
+  try {
+    const asyncDir = join(root, "run-start-control");
+    mkdirSync(asyncDir, { recursive: true });
+    const tracker = createTlhEffectiveActivityTracker({
+      checkPidLiveness: () => "alive",
+    });
+
+    // The parent emits async-started before the child has written status.json.
+    tracker.handleAsyncStarted({ id: "run-start-control", asyncDir, pid: 12345 });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-start-control"]);
+
+    // Duplicate async-started events can omit or invalidate the PID. Losing the
+    // PID in this missing-status startup window would make the job unverifiable.
+    tracker.handleAsyncStarted({ id: "run-start-control", asyncDir });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-start-control"]);
+    tracker.handleAsyncStarted({ id: "run-start-control", asyncDir, pid: 0 });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-start-control"]);
+
+    // A later control event can also be partial: neither an omitted nor an invalid
+    // asyncDir may erase the startup evidence needed to bridge that race.
+    tracker.handleAsyncControl({
+      event: { runId: "run-start-control", mode: "background" },
+    });
+    tracker.handleAsyncControl({
+      event: { runId: "run-start-control", mode: "background" },
+      asyncDir: {},
+    });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-start-control"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("regression: valid control and started evidence survives a later partial started event", () => {
+  const root = mkdtempSync(join(tmpdir(), "tlh-control-start-anchors-"));
+  try {
+    const originalDir = makeAsyncDir(root, "run-control-start-original", {
+      runId: "run-control-start",
+      state: "running",
+      pid: 12346,
+    });
+    const newerDir = makeAsyncDir(root, "run-control-start-newer", {
+      runId: "run-control-start",
+      state: "running",
+      pid: 12347,
+    });
+    const tracker = createTlhEffectiveActivityTracker({
+      checkPidLiveness: () => "alive",
+    });
+
+    tracker.handleAsyncControl({
+      event: { runId: "run-control-start", mode: "background" },
+      asyncDir: originalDir,
+    });
+    tracker.handleAsyncStarted({ id: "run-control-start", asyncDir: newerDir, pid: 12347 });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-control-start"]);
+
+    // Make the old anchor terminal. If the valid newer evidence was not retained,
+    // the next partial started event would either follow this tombstone or be dropped.
+    writeFileSync(
+      join(originalDir, "status.json"),
+      JSON.stringify({ runId: "run-control-start", state: "complete", pid: 12346 }),
+    );
+    tracker.handleAsyncStarted({ id: "run-control-start", asyncDir: "", pid: -1 });
+    assert.deepEqual(tracker.getSnapshot().activeAsyncJobIds, ["run-control-start"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("regression: started job with dead pid and no status.json is dropped (startup window with dead pid)", () => {
   const root = mkdtempSync(join(tmpdir(), "tlh-start-race-dead-"));
   try {


### PR DESCRIPTION
## Summary

- preserve previously validated async job `asyncDir` and PID anchors when later partial events omit or invalidate them
- keep positive newer evidence last-valid-wins without changing tombstone or liveness policy
- add regression coverage for started-to-control and control-to-started event ordering

Implements simplification S07 from #574.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
node --test tests/the-last-harness-activity-tracker.test.mjs
```

All standard validation passed; the focused tracker suite passed 34/34 tests. Generated TypeScript/JavaScript parity, typecheck, lint, formatting, and `git diff --check` also passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this internal correctness fix)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/preserve-positive-async-evidence/install.sh | bash -s -- --ref preserve-positive-async-evidence --track ref
```
