### PR TITLE
Stabilize timeout digest integration test

### DIFF
--- a/extensions/subagents/test/integration/single-execution.test.ts
+++ b/extensions/subagents/test/integration/single-execution.test.ts
@@ -41,6 +41,7 @@ import {
   INVALID_LAZY_SKILL_TOOL_POLICY_ERROR,
 } from "../../src/runs/shared/pi-args.ts";
 import { waitForAsyncResultFile } from "../support/async-execution-helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
 
 interface ModelAttempt {
   success?: boolean;
@@ -3962,16 +3963,21 @@ describe(
         noStagedFiles: true,
       });
       const report = ["Done", "```acceptance-report", reportBody, "```"].join("\n");
+      // Verify timeout artifact semantics, not 150ms latency: scale both budgets so
+      // the report arrives before timeout while the mock remains alive past it; keep
+      // the report non-terminal so the fixed 1s final-stop drain cannot win.
+      const timeoutMs = scaleTestTimeout(1_000);
+      const keepAliveAfterFinalMessageMs = scaleTestTimeout(10_000);
       mockPi.onCall({
-        jsonl: [events.assistantMessage(report)],
-        keepAliveAfterFinalMessageMs: 10000,
+        jsonl: [mockAssistantMessage(report, "tool_use")],
+        keepAliveAfterFinalMessageMs,
       });
       const agents = makeAgentConfigs(["slow"]);
       const digestArtifactsDir = path.join(tempDir, "artifacts-timeout-digest");
 
       const result = await runSync(tempDir, agents, "slow", "Slow task", {
         runId: "timeout-digest-split",
-        timeoutMs: 150,
+        timeoutMs,
         artifactsDir: digestArtifactsDir,
         artifactConfig: { enabled: true, includeOutput: true, includeMetadata: false },
       });


### PR DESCRIPTION
## Summary

Stabilize the timeout-digest integration fixture that flaked in [CI job 98596750883](https://github.com/diegopetrucci/the-last-harness/actions/runs/33094792557/job/98596750883). Scale the timeout and mock keepalive together, and keep the mocked report non-terminal so the fixed final-stop drain cannot preempt the timeout path under test.

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed in 171 seconds. Subagent suites passed with unit 1184/1184, integration 615/615, and e2e 1/1. The targeted CI-scaled test also passed repeatedly.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted for this test-only change)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/timeout-digest-test-flake/install.sh | bash -s -- --ref fix/timeout-digest-test-flake --track ref
```
