### PR TITLE
Show main install commit in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Main-ref installs now persist the installed commit subject and display `TLH main • <commit subject>` in the footer, with the bullet-and-subject suffix dimmed; legacy main state without metadata remains `TLH main`.
+
 ## [0.40.0] - 2026-09-06
 
 ### Built-in, and custom, agents

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/main
     TLH_WRAPPER_NAME=tlh TLH_AGENT_DIR=~/.the-last-harness/agent bash -s -- --ref main --track ref
   ```
 
-These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH identifies those installs with a footer track label such as `TLH v0.40.0`, `TLH main`, `TLH local`, or `TLH unknown`. Official latest-release installs omit that footer label, though interactive starts may still show a quiet startup tip.
+These alternatives keep TLH isolated, but they are not the official latest stable install path. On interactive startup, TLH identifies those installs with a footer track label such as `TLH v0.40.0`, `TLH main`, `TLH local`, or `TLH unknown`. Official latest-release installs omit that footer label, though interactive starts may still show a quiet startup tip. A `main` ref install also appends its persisted installed checkout commit subject as a dim suffix, for example `TLH main • Add the main footer subject`; older main-track state without that metadata continues to show `TLH main`.
 
 ## Installer options
 

--- a/extensions/the-last-harness/footer.js
+++ b/extensions/the-last-harness/footer.js
@@ -190,6 +190,17 @@ export function formatReauthWarningLine(providers, width, theme) {
     const countStyled = theme.fg("warning", countText);
     return truncateToWidth(countStyled, width, theme.fg("warning", "..."));
 }
+function formatTlhInstallNoticeLine(notice, width, theme) {
+    const label = formatTlhInstallNoticeTrackLabel(notice);
+    const commitSubject = notice.kind === "ref" && label === "main" && typeof notice.commitSubject === "string"
+        ? sanitizeStatusText(notice.commitSubject)
+        : "";
+    const commitSubjectSuffix = commitSubject
+        ? `${theme.fg("dim", " • ")}${theme.fg("dim", commitSubject)}`
+        : "";
+    const warningStr = `${theme.fg("dim", "TLH ")}${theme.fg("warning", label)}` + commitSubjectSuffix;
+    return truncateToWidth(warningStr, width, theme.fg("dim", "..."));
+}
 export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usageOptions = {}, gitCache, installNotice, providerAuthHealth) {
     let mcpContextEstimateCache;
     return {
@@ -295,9 +306,7 @@ export function createTlhFooter(pi, ctx, theme, getPrimaryName, footerData, usag
                 }
             }
             if (installNotice) {
-                const label = formatTlhInstallNoticeTrackLabel(installNotice);
-                const warningStr = `${theme.fg("dim", "TLH ")}${theme.fg("warning", label)}`;
-                lines.push(truncateToWidth(warningStr, width, theme.fg("dim", "...")));
+                lines.push(formatTlhInstallNoticeLine(installNotice, width, theme));
             }
             return lines;
         },

--- a/extensions/the-last-harness/footer.js
+++ b/extensions/the-last-harness/footer.js
@@ -190,10 +190,13 @@ export function formatReauthWarningLine(providers, width, theme) {
     const countStyled = theme.fg("warning", countText);
     return truncateToWidth(countStyled, width, theme.fg("warning", "..."));
 }
+function sanitizeCommitSubject(text) {
+    return sanitizeStatusText(text.replace(/\p{Cc}/gu, (character) => character === "\r" || character === "\n" || character === "\t" ? " " : ""));
+}
 function formatTlhInstallNoticeLine(notice, width, theme) {
     const label = formatTlhInstallNoticeTrackLabel(notice);
     const commitSubject = notice.kind === "ref" && label === "main" && typeof notice.commitSubject === "string"
-        ? sanitizeStatusText(notice.commitSubject)
+        ? sanitizeCommitSubject(notice.commitSubject)
         : "";
     const commitSubjectSuffix = commitSubject
         ? `${theme.fg("dim", " • ")}${theme.fg("dim", commitSubject)}`

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -262,6 +262,20 @@ export function formatReauthWarningLine(
   return truncateToWidth(countStyled, width, theme.fg("warning", "..."));
 }
 
+function formatTlhInstallNoticeLine(notice: TlhInstallNotice, width: number, theme: Theme): string {
+  const label = formatTlhInstallNoticeTrackLabel(notice);
+  const commitSubject =
+    notice.kind === "ref" && label === "main" && typeof notice.commitSubject === "string"
+      ? sanitizeStatusText(notice.commitSubject)
+      : "";
+  const commitSubjectSuffix = commitSubject
+    ? `${theme.fg("dim", " • ")}${theme.fg("dim", commitSubject)}`
+    : "";
+  const warningStr =
+    `${theme.fg("dim", "TLH ")}${theme.fg("warning", label)}` + commitSubjectSuffix;
+  return truncateToWidth(warningStr, width, theme.fg("dim", "..."));
+}
+
 export function createTlhFooter(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
@@ -431,9 +445,7 @@ export function createTlhFooter(
       // Install notice line (last line): shown when running from a non-release track.
       // render() uses the value captured at session start — no file I/O.
       if (installNotice) {
-        const label = formatTlhInstallNoticeTrackLabel(installNotice);
-        const warningStr = `${theme.fg("dim", "TLH ")}${theme.fg("warning", label)}`;
-        lines.push(truncateToWidth(warningStr, width, theme.fg("dim", "...")));
+        lines.push(formatTlhInstallNoticeLine(installNotice, width, theme));
       }
 
       return lines;

--- a/extensions/the-last-harness/footer.ts
+++ b/extensions/the-last-harness/footer.ts
@@ -262,11 +262,19 @@ export function formatReauthWarningLine(
   return truncateToWidth(countStyled, width, theme.fg("warning", "..."));
 }
 
+function sanitizeCommitSubject(text: string): string {
+  return sanitizeStatusText(
+    text.replace(/\p{Cc}/gu, (character) =>
+      character === "\r" || character === "\n" || character === "\t" ? " " : "",
+    ),
+  );
+}
+
 function formatTlhInstallNoticeLine(notice: TlhInstallNotice, width: number, theme: Theme): string {
   const label = formatTlhInstallNoticeTrackLabel(notice);
   const commitSubject =
     notice.kind === "ref" && label === "main" && typeof notice.commitSubject === "string"
-      ? sanitizeStatusText(notice.commitSubject)
+      ? sanitizeCommitSubject(notice.commitSubject)
       : "";
   const commitSubjectSuffix = commitSubject
     ? `${theme.fg("dim", " • ")}${theme.fg("dim", commitSubject)}`

--- a/extensions/the-last-harness/install-state.js
+++ b/extensions/the-last-harness/install-state.js
@@ -42,6 +42,7 @@ export function classifyTlhInstallState(state) {
     const ref = normalizedString(state?.ref);
     const packageSource = normalizedString(state?.packageSource);
     const defaultPackageSource = isDefaultPackageSource(state);
+    const mainCommitSubject = track === "ref" && ref === "main" ? normalizedString(state?.commitSubject) : undefined;
     if (!repo ||
         !track ||
         !VALID_TRACKS.has(track) ||
@@ -77,6 +78,7 @@ export function classifyTlhInstallState(state) {
             kind: "ref",
             summary: "TLH follows a non-stable git ref.",
             detail: ref,
+            ...(mainCommitSubject ? { commitSubject: mainCommitSubject } : {}),
         };
     }
     if (defaultPackageSource === false) {
@@ -101,6 +103,7 @@ export function classifyTlhInstallState(state) {
             kind: "ref",
             summary: "TLH follows a non-stable git ref.",
             detail: ref,
+            ...(mainCommitSubject ? { commitSubject: mainCommitSubject } : {}),
         };
     }
     return {

--- a/extensions/the-last-harness/install-state.ts
+++ b/extensions/the-last-harness/install-state.ts
@@ -53,6 +53,8 @@ export function classifyTlhInstallState(
   const ref = normalizedString(state?.ref);
   const packageSource = normalizedString(state?.packageSource);
   const defaultPackageSource = isDefaultPackageSource(state);
+  const mainCommitSubject =
+    track === "ref" && ref === "main" ? normalizedString(state?.commitSubject) : undefined;
 
   if (
     !repo ||
@@ -94,6 +96,7 @@ export function classifyTlhInstallState(
       kind: "ref",
       summary: "TLH follows a non-stable git ref.",
       detail: ref,
+      ...(mainCommitSubject ? { commitSubject: mainCommitSubject } : {}),
     };
   }
 
@@ -120,6 +123,7 @@ export function classifyTlhInstallState(
       kind: "ref",
       summary: "TLH follows a non-stable git ref.",
       detail: ref,
+      ...(mainCommitSubject ? { commitSubject: mainCommitSubject } : {}),
     };
   }
   return {

--- a/extensions/the-last-harness/types.ts
+++ b/extensions/the-last-harness/types.ts
@@ -193,6 +193,7 @@ export type TlhInstallState = {
   track?: string;
   packageSource?: string;
   packageSourceIsDefault?: boolean;
+  commitSubject?: string;
   rawBase?: string;
   agentDir?: string;
   binDir?: string;
@@ -212,6 +213,8 @@ export type TlhInstallNotice = {
   kind: TlhInstallNoticeKind;
   summary: string;
   detail?: string;
+  /** Persisted checkout subject for the displayed `main` ref track, when available. */
+  commitSubject?: string;
 };
 
 export type TlhTelemetryState = {

--- a/scripts/tlh-install-state.mjs
+++ b/scripts/tlh-install-state.mjs
@@ -25,6 +25,7 @@ Options:
   --agent-dir DIR                   Isolated Pi agent dir
   --bin-dir DIR                     Wrapper install dir
   --wrapper-name NAME               Wrapper command name
+  --commit-subject SUBJECT          Installed TLH checkout HEAD subject (optional)
   --pi-installed-by-tlh BOOL        Whether TLH installed Pi globally (true|false; omit to leave field absent)
   --dry-run                         Print intended changes without writing
   --quiet                           Suppress non-essential output
@@ -44,6 +45,7 @@ function parseArgs(argv) {
     agentDir: undefined,
     binDir: undefined,
     wrapperName: undefined,
+    commitSubject: undefined,
     piInstalledByTlh: undefined,
     dryRun: false,
     quiet: false,
@@ -126,6 +128,17 @@ function parseArgs(argv) {
       index = wrapperNameIndex;
       continue;
     }
+    const commitSubjectIndex = assignOptionValue(
+      args,
+      "commitSubject",
+      argv,
+      index,
+      "--commit-subject",
+    );
+    if (commitSubjectIndex !== undefined) {
+      index = commitSubjectIndex;
+      continue;
+    }
     const piInstalledByTlh = readOptionValue(argv, index, "--pi-installed-by-tlh");
     if (piInstalledByTlh) {
       const raw = piInstalledByTlh.value;
@@ -194,6 +207,10 @@ function buildState(args) {
     wrapperName: args.wrapperName,
     installedAt: new Date().toISOString(),
   };
+  const commitSubject = args.commitSubject?.trim();
+  if (commitSubject) {
+    state.commitSubject = commitSubject;
+  }
   if (args.piInstalledByTlh !== undefined) {
     state.piInstalledByTlh = args.piInstalledByTlh;
   }

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -7,7 +7,7 @@ import { delimiter, dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { criticalGitSourceSpec, packageSourceInstallDir, packageSourcePiSource, parseGitSource, } from "./lib/tlh-install-package-source.mjs";
-import { assertProfilePathWithinAgent, assertSafeSettingsTarget, copySafeProfileFile, ensureSafeProfileDir, isSymlink, validateInstallerTargets, validateProfileRelativePath, } from "./lib/tlh-install-paths.mjs";
+import { assertProfilePathWithinAgent, assertSafeSettingsTarget, copySafeProfileFile, ensureSafeProfileDir, isSymlink, realpathForCompare, validateInstallerTargets, validateProfileRelativePath, } from "./lib/tlh-install-paths.mjs";
 import { FORCE_REMOVED_RETIRED_DEFAULT_EXTENSION_SOURCES, disabledDefaultExtensionIds, packageIdentity, packageSourceOf, readDefaultExtensions, RETIRED_TLH_DEFAULT_PACKAGE_SOURCES, } from "./lib/default-extensions.mjs";
 import { assignRequiredEqualsValue, backupPathWithTimestamp, isTlhOwnedBackupFilename, readJsonFile, renderShellWords, requiredValue, selectExpiredBackups, shellWord, } from "./lib/tlh-install-utils.mjs";
 import { TLH_SUBAGENT_PROMPTS, captureManagedRetiredSubagentPackages, captureRetiredSubagentNpmCommand, cleanupManagedRetiredSubagentPackages, copyTlhSubagentPrompts, defaultExtensionsRequireCriticalInstall as defaultExtensionsFileRequiresCriticalInstall, findTlhSubagentsDir as findTlhSubagentsDirFromSources, missingTlhSubagentPrompts, provisionSubagentExtensionConfig, subagentExtensionConfigMissingDefaults, } from "./lib/tlh-install-subagents.mjs";
@@ -475,6 +475,28 @@ function spawnCapture(config, commandArgs, { cwd, env = {}, allowFailure = false
         throw new Error(output || result.error?.message || `command failed: ${commandDisplay(commandArgs)}`);
     }
     return result;
+}
+function readInstalledCommitSubject(config) {
+    if (config.dryRun)
+        return undefined;
+    const topLevelResult = spawnCapture(config, ["git", "-C", config.packageRoot, "rev-parse", "--show-toplevel"], { allowFailure: true });
+    if (topLevelResult.error || topLevelResult.status !== 0)
+        return undefined;
+    const topLevel = topLevelResult.stdout.trim();
+    if (!topLevel)
+        return undefined;
+    try {
+        if (realpathForCompare(topLevel) !== realpathForCompare(config.packageRoot))
+            return undefined;
+    }
+    catch {
+        return undefined;
+    }
+    const result = spawnCapture(config, ["git", "-C", config.packageRoot, "log", "-1", "--format=%s"], { allowFailure: true });
+    if (result.error || result.status !== 0)
+        return undefined;
+    const subject = result.stdout.trim();
+    return subject || undefined;
 }
 function runNodeScript(config, scriptPath, args, { captureStdout = false } = {}) {
     const commandArgs = [process.execPath, scriptPath, ...args];
@@ -1277,6 +1299,9 @@ async function writeInstallState(config) {
         "--wrapper-name",
         config.wrapperName,
     ];
+    const commitSubject = readInstalledCommitSubject(config);
+    if (commitSubject)
+        args.push(`--commit-subject=${commitSubject}`);
     const existingPiInstalledByTlhPreference = readPiInstalledByTlhPreference(config);
     const piInstalledByTlhForWrite = config.piInstalledByTlh === true || existingPiInstalledByTlhPreference === true
         ? true

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -32,6 +32,7 @@ import {
   copySafeProfileFile,
   ensureSafeProfileDir,
   isSymlink,
+  realpathForCompare,
   validateInstallerTargets,
   validateProfileRelativePath,
 } from "./lib/tlh-install-paths.mjs";
@@ -721,6 +722,35 @@ function spawnCapture(
     );
   }
   return result;
+}
+
+function readInstalledCommitSubject(config: InstallConfig): string | undefined {
+  if (config.dryRun) return undefined;
+
+  const topLevelResult = spawnCapture(
+    config,
+    ["git", "-C", config.packageRoot, "rev-parse", "--show-toplevel"],
+    { allowFailure: true },
+  );
+  if (topLevelResult.error || topLevelResult.status !== 0) return undefined;
+
+  const topLevel = topLevelResult.stdout.trim();
+  if (!topLevel) return undefined;
+  try {
+    if (realpathForCompare(topLevel) !== realpathForCompare(config.packageRoot)) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  const result = spawnCapture(
+    config,
+    ["git", "-C", config.packageRoot, "log", "-1", "--format=%s"],
+    { allowFailure: true },
+  );
+  if (result.error || result.status !== 0) return undefined;
+
+  const subject = result.stdout.trim();
+  return subject || undefined;
 }
 
 function runNodeScript(
@@ -1684,6 +1714,9 @@ async function writeInstallState(config: InstallConfig): Promise<void> {
     "--wrapper-name",
     config.wrapperName,
   ];
+  const commitSubject = readInstalledCommitSubject(config);
+  if (commitSubject) args.push(`--commit-subject=${commitSubject}`);
+
   const existingPiInstalledByTlhPreference = readPiInstalledByTlhPreference(config);
   const piInstalledByTlhForWrite =
     config.piInstalledByTlh === true || existingPiInstalledByTlhPreference === true

--- a/tests/install-stage1.test.mjs
+++ b/tests/install-stage1.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import test from "node:test";
 
@@ -20,6 +20,13 @@ import {
 import { buildInstallConfig, parseArgs, usage } from "../scripts/tlh-install.mjs";
 import { validateInstallerTargets } from "../scripts/lib/tlh-install-paths.mjs";
 
+const repoNestedFixtureParent = join(repoRoot, ".symphony", "tlh-sessions");
+
+function makeRepoNestedFixture(prefix) {
+  mkdirSync(repoNestedFixtureParent, { recursive: true });
+  return mkdtempSync(join(repoNestedFixtureParent, prefix));
+}
+
 test("stage-1 hides PATH-adjustment and refresh fallback detail lines unless --verbose", (t) => {
   for (const verbose of [false, true]) {
     const { result, agentDir } = runStage1LocalPackageInstall(t, { verbose });
@@ -31,6 +38,7 @@ test("stage-1 hides PATH-adjustment and refresh fallback detail lines unless --v
       /Running settings-wide extension refresh from merged settings; fallback retries only 9 non-critical bundled default source\(s\) individually\./;
 
     assert.equal(result.status, 0, output);
+    assert.equal(readJson(join(agentDir, "tlh", "install-state.json")).commitSubject, undefined);
     if (verbose) {
       assert.ok(output.includes(pathNotice), output);
       assert.match(output, refreshDetailPattern);
@@ -39,6 +47,54 @@ test("stage-1 hides PATH-adjustment and refresh fallback detail lines unless --v
       assert.doesNotMatch(output, refreshDetailPattern);
     }
   }
+});
+
+test("stage-1 records checkout subjects that begin with a hyphen", (t) => {
+  const packageRoot = makeRepoNestedFixture(".tlh-test-git-package-");
+  const emptyHooksDir = join(packageRoot, "empty-hooks");
+  mkdirSync(emptyHooksDir);
+  t.after(() => rmSync(packageRoot, { recursive: true, force: true }));
+  execFileSync("git", ["-C", packageRoot, "init", "--quiet"]);
+  execFileSync("git", ["-C", packageRoot, "config", "user.email", "tlh-tests@example.invalid"]);
+  execFileSync("git", ["-C", packageRoot, "config", "user.name", "TLH tests"]);
+  execFileSync("git", [
+    "-C",
+    packageRoot,
+    "-c",
+    "commit.gpgSign=false",
+    "-c",
+    `core.hooksPath=${emptyHooksDir}`,
+    "commit",
+    "--quiet",
+    "--no-verify",
+    "--allow-empty",
+    "-m",
+    "-cosmetic install metadata",
+  ]);
+
+  const { result, agentDir } = runStage1LocalPackageInstall(t, {
+    envOverrides: { TLH_PACKAGE_SOURCE: `file:${packageRoot}` },
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 0, output);
+  assert.equal(
+    readJson(join(agentDir, "tlh", "install-state.json")).commitSubject,
+    "-cosmetic install metadata",
+  );
+});
+
+test("stage-1 ignores an ancestor Git commit for a non-Git nested package source", (t) => {
+  const packageRoot = makeRepoNestedFixture(".tlh-test-non-git-package-");
+  t.after(() => rmSync(packageRoot, { recursive: true, force: true }));
+
+  const { result, agentDir } = runStage1LocalPackageInstall(t, {
+    envOverrides: { TLH_PACKAGE_SOURCE: `file:${packageRoot}` },
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 0, output);
+  assert.equal(readJson(join(agentDir, "tlh", "install-state.json")).commitSubject, undefined);
 });
 
 test("stage-1 rejects legacy ticket integration flags", () => {
@@ -514,9 +570,13 @@ test("stage-1 normalizes absolute file: sources for Pi while preserving raw inst
       .slice(0, 3),
     ["--version", `install ${repoRoot}`, `update ${repoRoot}`],
   );
+  const state = readJson(join(agentDir, "tlh", "install-state.json"));
+  assert.equal(state.packageSource, filePackageSource);
   assert.equal(
-    readJson(join(agentDir, "tlh", "install-state.json")).packageSource,
-    filePackageSource,
+    state.commitSubject,
+    execFileSync("git", ["-C", repoRoot, "log", "-1", "--format=%s"], {
+      encoding: "utf8",
+    }).trim(),
   );
   const settings = readJson(join(agentDir, "settings.json"));
   assert.equal(settings.packages[0], repoRoot);

--- a/tests/the-last-harness-extension-startup-warning.test.mjs
+++ b/tests/the-last-harness-extension-startup-warning.test.mjs
@@ -914,6 +914,19 @@ test("production footer wiring preserves every install-track label and keeps the
   }
 });
 
+test("production footer wiring appends the persisted subject for a main ref install", async () => {
+  const { footerLines } = await runSessionStart({
+    reason: "startup",
+    installState: {
+      ...REF_INSTALL_STATE,
+      commitSubject: "Add the main footer subject",
+    },
+  });
+
+  assert.ok(footerLines);
+  assert.equal(footerLines.at(-1), "TLH main • Add the main footer subject");
+});
+
 test("production footer wiring: footer remains visible on non-startup session reasons", async () => {
   const { footerLines, headerLines } = await runSessionStart({
     reason: "resume",

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -989,8 +989,13 @@ test("non-context-cap extension statuses are still rendered in the footer", () =
 // NEW: install notice warning line (last line of footer)
 // ---------------------------------------------------------------------------
 
-function makeInstallNotice(kind, detail) {
-  return { kind, summary: "TLH install notice", detail };
+function makeInstallNotice(kind, detail, commitSubject) {
+  return {
+    kind,
+    summary: "TLH install notice",
+    detail,
+    ...(commitSubject !== undefined ? { commitSubject } : {}),
+  };
 }
 
 test("footer appends no warning line when no install notice is provided", () => {
@@ -1096,6 +1101,69 @@ test("footer install notice line uses dim for 'TLH ' prefix and warning color fo
   const lastLine = lines.at(-1) ?? "";
   assert.match(lastLine, /<dim>TLH <\/dim>/);
   assert.match(lastLine, /<warning>main<\/warning>/);
+});
+
+test("footer appends a persisted subject to the main ref label with a dim suffix", () => {
+  const ctx = createCtx({ entries: [] });
+  const notice = makeInstallNotice("ref", "main", "Add the main footer subject");
+  const footer = createTlhFooter(
+    pi,
+    ctx,
+    theme,
+    () => "architect",
+    createFooterData(),
+    {},
+    null,
+    notice,
+  );
+  assert.equal(footer.render(WIDTH).at(-1), "TLH main • Add the main footer subject");
+});
+
+test("footer dims both the main subject separator and subject without changing main styling", () => {
+  const ctx = createCtx({ entries: [] });
+  const notice = makeInstallNotice("ref", "main", "Add the main footer subject");
+  const footer = createTlhFooter(
+    pi,
+    ctx,
+    colorTheme,
+    () => "architect",
+    createFooterData(),
+    {},
+    null,
+    notice,
+  );
+  const lastLine = footer.render(COLOR_WIDTH).at(-1) ?? "";
+  assert.equal(
+    lastLine,
+    "<dim>TLH </dim><warning>main</warning><dim> • </dim><dim>Add the main footer subject</dim>",
+  );
+});
+
+test("footer omits the subject for legacy, invalid, and non-main install notices", () => {
+  const cases = [
+    [makeInstallNotice("ref", "main"), "TLH main"],
+    [makeInstallNotice("ref", "main", "   "), "TLH main"],
+    [makeInstallNotice("ref", "main", 42), "TLH main"],
+    [makeInstallNotice("ref", "feature/footer", "Feature commit subject"), "TLH feature/footer"],
+    [makeInstallNotice("pinned-tag", "main", "Pinned commit subject"), "TLH main"],
+    [makeInstallNotice("custom-track", "custom", "Custom commit subject"), "TLH custom"],
+    [makeInstallNotice("unknown", undefined, "Unknown commit subject"), "TLH unknown"],
+  ];
+
+  for (const [notice, expected] of cases) {
+    const ctx = createCtx({ entries: [] });
+    const footer = createTlhFooter(
+      pi,
+      ctx,
+      theme,
+      () => "architect",
+      createFooterData(),
+      {},
+      null,
+      notice,
+    );
+    assert.equal(footer.render(WIDTH).at(-1), expected);
+  }
 });
 
 test("footer warning line stays within narrow widths", () => {

--- a/tests/the-last-harness-footer-usage.test.mjs
+++ b/tests/the-last-harness-footer-usage.test.mjs
@@ -1139,6 +1139,40 @@ test("footer dims both the main subject separator and subject without changing m
   );
 });
 
+test("footer strips ESC from a persisted main commit subject", () => {
+  const ctx = createCtx({ entries: [] });
+  const notice = makeInstallNotice("ref", "main", "Add the \u001bmain footer subject");
+  const footer = createTlhFooter(
+    pi,
+    ctx,
+    theme,
+    () => "architect",
+    createFooterData(),
+    {},
+    null,
+    notice,
+  );
+
+  assert.equal(footer.render(WIDTH).at(-1), "TLH main • Add the main footer subject");
+});
+
+test("footer strips C1 controls from a persisted main commit subject", () => {
+  const ctx = createCtx({ entries: [] });
+  const notice = makeInstallNotice("ref", "main", "Add the \u009bmain footer subject");
+  const footer = createTlhFooter(
+    pi,
+    ctx,
+    theme,
+    () => "architect",
+    createFooterData(),
+    {},
+    null,
+    notice,
+  );
+
+  assert.equal(footer.render(WIDTH).at(-1), "TLH main • Add the main footer subject");
+});
+
 test("footer omits the subject for legacy, invalid, and non-main install notices", () => {
   const cases = [
     [makeInstallNotice("ref", "main"), "TLH main"],

--- a/tests/the-last-harness-install-state-classifier.test.mjs
+++ b/tests/the-last-harness-install-state-classifier.test.mjs
@@ -99,6 +99,51 @@ test("formats ref install notices with the ref label", () => {
   assertNoticeLabel(notice, "main");
 });
 
+test("preserves a valid installed subject only for the main ref label", () => {
+  const mainNotice = classifyTlhInstallState({
+    ...OFFICIAL_LATEST_STABLE,
+    track: "ref",
+    ref: "main",
+    packageSource: "git:github.com/diegopetrucci/the-last-harness@main",
+    commitSubject: "  Add the main footer subject  ",
+  });
+  assert.deepEqual(mainNotice, {
+    kind: "ref",
+    summary: "TLH follows a non-stable git ref.",
+    detail: "main",
+    commitSubject: "Add the main footer subject",
+  });
+  assertNoticeLabel(mainNotice, "main");
+
+  const otherRefNotice = classifyTlhInstallState({
+    ...OFFICIAL_LATEST_STABLE,
+    track: "ref",
+    ref: "feature/footer",
+    packageSource: "git:github.com/diegopetrucci/the-last-harness@feature/footer",
+    commitSubject: "Feature commit subject",
+  });
+  assert.deepEqual(otherRefNotice, {
+    kind: "ref",
+    summary: "TLH follows a non-stable git ref.",
+    detail: "feature/footer",
+  });
+
+  for (const commitSubject of [undefined, "   ", 42]) {
+    const notice = classifyTlhInstallState({
+      ...OFFICIAL_LATEST_STABLE,
+      track: "ref",
+      ref: "main",
+      packageSource: "git:github.com/diegopetrucci/the-last-harness@main",
+      commitSubject,
+    });
+    assert.deepEqual(notice, {
+      kind: "ref",
+      summary: "TLH follows a non-stable git ref.",
+      detail: "main",
+    });
+  }
+});
+
 test("prefers the ref label over a custom package-source label", () => {
   const notice = classifyTlhInstallState({
     ...OFFICIAL_LATEST_STABLE,

--- a/tests/tlh-install-state.test.mjs
+++ b/tests/tlh-install-state.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,8 +17,9 @@ import test from "node:test";
 const repoRoot = resolve(import.meta.dirname, "..");
 const installStateScript = join(repoRoot, "scripts", "tlh-install-state.mjs");
 
-function tempFixture() {
+function tempFixture(t) {
   const dir = mkdtempSync(join(tmpdir(), "tlh-install-state-test-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
   const agentDir = join(dir, "agent");
   const statePath = join(agentDir, "tlh", "install-state.json");
   const binDir = join(dir, "bin");
@@ -62,8 +64,8 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
-test("tlh-install-state dry-run reports the write without creating install-state.json", () => {
-  const fixture = tempFixture();
+test("tlh-install-state dry-run reports the write without creating install-state.json", (t) => {
+  const fixture = tempFixture(t);
 
   const output = runInstallState(fixture, ["--pi-installed-by-tlh", "false", "--dry-run"]);
 
@@ -71,16 +73,16 @@ test("tlh-install-state dry-run reports the write without creating install-state
   assert.equal(existsSync(fixture.statePath), false);
 });
 
-test("tlh-install-state accepts a hyphen-leading installed commit subject", () => {
-  const fixture = tempFixture();
+test("tlh-install-state accepts a hyphen-leading installed commit subject", (t) => {
+  const fixture = tempFixture(t);
 
   runInstallState(fixture, ["--commit-subject=-Record the installed commit subject"]);
 
   assert.equal(readJson(fixture.statePath).commitSubject, "-Record the installed commit subject");
 });
 
-test("tlh-install-state preserves install-state file mode when overwriting", () => {
-  const fixture = tempFixture();
+test("tlh-install-state preserves install-state file mode when overwriting", (t) => {
+  const fixture = tempFixture(t);
   mkdirSync(join(fixture.agentDir, "tlh"), { recursive: true });
   writeFileSync(fixture.statePath, "{}\n", { mode: 0o640 });
   chmodSync(fixture.statePath, 0o640);
@@ -93,8 +95,8 @@ test("tlh-install-state preserves install-state file mode when overwriting", () 
   assert.equal(lstatSync(fixture.statePath).mode & 0o777, 0o640);
 });
 
-test("tlh-install-state refuses to write install-state outside the isolated tlh profile", () => {
-  const fixture = tempFixture();
+test("tlh-install-state refuses to write install-state outside the isolated tlh profile", (t) => {
+  const fixture = tempFixture(t);
   const outsideStatePath = join(fixture.dir, "outside-install-state.json");
 
   const result = spawnSync(

--- a/tests/tlh-install-state.test.mjs
+++ b/tests/tlh-install-state.test.mjs
@@ -71,6 +71,14 @@ test("tlh-install-state dry-run reports the write without creating install-state
   assert.equal(existsSync(fixture.statePath), false);
 });
 
+test("tlh-install-state accepts a hyphen-leading installed commit subject", () => {
+  const fixture = tempFixture();
+
+  runInstallState(fixture, ["--commit-subject=-Record the installed commit subject"]);
+
+  assert.equal(readJson(fixture.statePath).commitSubject, "-Record the installed commit subject");
+});
+
 test("tlh-install-state preserves install-state file mode when overwriting", () => {
   const fixture = tempFixture();
   mkdirSync(join(fixture.agentDir, "tlh"), { recursive: true });


### PR DESCRIPTION
## Summary

Persist the installed checkout commit subject for main-ref installs and show it as a dim suffix in the footer: `TLH main • <commit subject>`. Legacy install state and non-main tracks retain their existing footer behavior.

## Change type

- [x] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [x] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation:**

```sh
npm run validate
```

Result: passed.

Focused installer, install-state classifier, footer styling, production wiring, legacy fallback, and edge-case tests also pass. Generated runtime outputs are fresh.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/feature/main-install-commit-footer/install.sh | bash -s -- --ref feature/main-install-commit-footer --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Main-track installations now display the installed commit subject in the footer as `TLH main • <commit subject>`.
  - Commit subjects are sanitized and shown with a dimmed bullet-and-subject suffix.
  - Older installations without commit metadata continue to display `TLH main`.

- **Documentation**
  - Installation documentation and the unreleased changelog now describe the updated main-track footer information.
  - Pinned installation examples now use version `v0.40.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->