### PR TITLE
Harden installer backup cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to The Last Harness will be documented in this file.
 
 - Updated packaged review-agent defaults: `code-reviewer` uses Anthropic Claude Opus 5 at max effort; `oracle` and `contrarian` use Anthropic Claude Fable 5.1 at medium effort. OpenAI Codex and OpenRouter defaults are unchanged.
 
+### Fixed
+
+- Installer backup cleanup now rejects impossible calendar days and skips disappearing or unreadable cleanup candidates without aborting the install.
+
 ## [0.40.0] - 2026-09-06
 
 ### Built-in, and custom, agents

--- a/scripts/lib/tlh-install-utils.mjs
+++ b/scripts/lib/tlh-install-utils.mjs
@@ -174,6 +174,16 @@ export function backupPathWithTimestamp(path, { marker = "", date = new Date(), 
 // ---------------------------------------------------------------------------
 // Backup-retention helpers (pure / deterministic)
 // ---------------------------------------------------------------------------
+function isValidBackupCalendarDate(datePart) {
+    const year = Number(datePart.slice(0, 4));
+    const month = Number(datePart.slice(5, 7));
+    const day = Number(datePart.slice(8, 10));
+    if (month < 1 || month > 12 || day < 1)
+        return false;
+    const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+    const monthLengths = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    return day <= monthLengths[month - 1];
+}
 /**
  * Parse the ISO-8601-derived timestamp embedded in a backup filename produced
  * by backupPathWithTimestamp. Handles all four naming variants:
@@ -191,6 +201,8 @@ export function parseBackupTimestamp(filename) {
     if (!match)
         return undefined;
     const [, datePart, hh, mm, ss, ms] = match;
+    if (!isValidBackupCalendarDate(datePart))
+        return undefined;
     const iso = ms ? `${datePart}T${hh}:${mm}:${ss}.${ms}Z` : `${datePart}T${hh}:${mm}:${ss}Z`;
     const date = new Date(iso);
     if (Number.isNaN(date.getTime()))

--- a/scripts/lib/tlh-install-utils.mts
+++ b/scripts/lib/tlh-install-utils.mts
@@ -288,6 +288,17 @@ export function backupPathWithTimestamp(
 // Backup-retention helpers (pure / deterministic)
 // ---------------------------------------------------------------------------
 
+function isValidBackupCalendarDate(datePart: string): boolean {
+  const year = Number(datePart.slice(0, 4));
+  const month = Number(datePart.slice(5, 7));
+  const day = Number(datePart.slice(8, 10));
+  if (month < 1 || month > 12 || day < 1) return false;
+
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const monthLengths = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= monthLengths[month - 1];
+}
+
 /**
  * Parse the ISO-8601-derived timestamp embedded in a backup filename produced
  * by backupPathWithTimestamp. Handles all four naming variants:
@@ -304,6 +315,7 @@ export function parseBackupTimestamp(filename: string): Date | undefined {
   const match = /(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})(?:-(\d{3}))?Z$/.exec(filename);
   if (!match) return undefined;
   const [, datePart, hh, mm, ss, ms] = match;
+  if (!isValidBackupCalendarDate(datePart)) return undefined;
   const iso = ms ? `${datePart}T${hh}:${mm}:${ss}.${ms}Z` : `${datePart}T${hh}:${mm}:${ss}Z`;
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return undefined;

--- a/scripts/tlh-install.mjs
+++ b/scripts/tlh-install.mjs
@@ -932,6 +932,23 @@ function cleanupRelativeProfileDirs(config, relativePaths) {
 export function cleanupRetiredProfileDirectories(config) {
     cleanupRelativeProfileDirs(config, RETIRED_PROFILE_DIRECTORIES);
 }
+function isMissingCleanupMetadataError(error) {
+    return (typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT");
+}
+function readCleanupMetadata(config, target, label) {
+    try {
+        return config.cleanupMetadata ? config.cleanupMetadata(target) : lstatSync(target);
+    }
+    catch (error) {
+        if (isMissingCleanupMetadataError(error))
+            return undefined;
+        warn(`Skipping ${label}: cannot inspect ${target}: ${error instanceof Error ? error.message : String(error)}`);
+        return undefined;
+    }
+}
 function cleanupRelativeProfileFiles(config, relativePaths) {
     for (const relativePath of relativePaths) {
         try {
@@ -951,11 +968,8 @@ function cleanupRelativeProfileFiles(config, relativePaths) {
             warn(`Skipping retired profile file cleanup (unsafe path): ${target}: ${error instanceof Error ? error.message : String(error)}`);
             continue;
         }
-        if (isSymlink(target))
-            continue;
-        if (!existsSync(target))
-            continue;
-        if (!lstatSync(target).isFile())
+        const metadata = readCleanupMetadata(config, target, "retired profile file cleanup");
+        if (!metadata || metadata.isSymbolicLink() || !metadata.isFile())
             continue;
         if (config.dryRun) {
             log(config, `Would remove retired profile file: ${target}`);
@@ -1063,12 +1077,9 @@ export function cleanupOldSettingsBackups(config) {
             warn(`Skipping stale settings backup cleanup (unsafe path): ${target}: ${error instanceof Error ? error.message : String(error)}`);
             continue;
         }
-        if (isSymlink(target))
-            continue; // Conservative: never remove or follow symlinks
-        if (!existsSync(target))
-            continue; // Idempotent: absent is fine
-        if (!lstatSync(target).isFile())
-            continue; // Conservative: only regular files
+        const metadata = readCleanupMetadata(config, target, "stale settings backup");
+        if (!metadata || metadata.isSymbolicLink() || !metadata.isFile())
+            continue;
         if (config.dryRun) {
             log(config, `Would remove stale settings backup: ${target}`);
             continue;

--- a/scripts/tlh-install.mts
+++ b/scripts/tlh-install.mts
@@ -154,11 +154,20 @@ interface ParsedArgs extends Record<string, unknown> {
   piInstalledByTlhOverride: boolean | undefined;
 }
 
+interface CleanupMetadata {
+  isSymbolicLink(): boolean;
+  isFile(): boolean;
+}
+
+type CleanupMetadataReader = (path: string) => CleanupMetadata | undefined;
+
 interface ProfileCleanupConfig {
   agentDir: string;
   dryRun: boolean;
   quiet: boolean;
   verbose: boolean;
+  /** Narrow seam for deterministic metadata-failure tests; production uses lstatSync. */
+  cleanupMetadata?: CleanupMetadataReader;
 }
 
 interface InstallConfig extends ParsedArgs {
@@ -1273,6 +1282,31 @@ export function cleanupRetiredProfileDirectories(config: ProfileCleanupConfig): 
   cleanupRelativeProfileDirs(config, RETIRED_PROFILE_DIRECTORIES);
 }
 
+function isMissingCleanupMetadataError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function readCleanupMetadata(
+  config: ProfileCleanupConfig,
+  target: string,
+  label: string,
+): CleanupMetadata | undefined {
+  try {
+    return config.cleanupMetadata ? config.cleanupMetadata(target) : lstatSync(target);
+  } catch (error) {
+    if (isMissingCleanupMetadataError(error)) return undefined;
+    warn(
+      `Skipping ${label}: cannot inspect ${target}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
 function cleanupRelativeProfileFiles(
   config: ProfileCleanupConfig,
   relativePaths: readonly string[],
@@ -1301,9 +1335,8 @@ function cleanupRelativeProfileFiles(
       continue;
     }
 
-    if (isSymlink(target)) continue;
-    if (!existsSync(target)) continue;
-    if (!lstatSync(target).isFile()) continue;
+    const metadata = readCleanupMetadata(config, target, "retired profile file cleanup");
+    if (!metadata || metadata.isSymbolicLink() || !metadata.isFile()) continue;
     if (config.dryRun) {
       log(config, `Would remove retired profile file: ${target}`);
       continue;
@@ -1434,9 +1467,8 @@ export function cleanupOldSettingsBackups(config: InstallConfig): void {
       continue;
     }
 
-    if (isSymlink(target)) continue; // Conservative: never remove or follow symlinks
-    if (!existsSync(target)) continue; // Idempotent: absent is fine
-    if (!lstatSync(target).isFile()) continue; // Conservative: only regular files
+    const metadata = readCleanupMetadata(config, target, "stale settings backup");
+    if (!metadata || metadata.isSymbolicLink() || !metadata.isFile()) continue;
 
     if (config.dryRun) {
       log(config, `Would remove stale settings backup: ${target}`);

--- a/tests/install-stage1-backup-cleanup.test.mjs
+++ b/tests/install-stage1-backup-cleanup.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -31,6 +39,25 @@ function recentBackupName(base, daysAgo = 2) {
 
 function makeConfig(agentDir, extra = {}) {
   return { agentDir, dryRun: false, quiet: true, verbose: false, ...extra };
+}
+
+const seededInstallBackups = Object.freeze({
+  "settings.json.backup-2000-01-01T00-00-00Z": "old backup content\n",
+  "settings.json.backup-2026-08-01T00-00-00Z": "newer backup one\n",
+  "settings.json.backup-2026-08-02T00-00-00Z": "newer backup two\n",
+});
+
+function metadataReaderWithFailures(failures, visits = []) {
+  return (path) => {
+    visits.push(path);
+    const failure = failures.get(path);
+    if (failure) {
+      const error = new Error(failure.message);
+      error.code = failure.code;
+      throw error;
+    }
+    return lstatSync(path);
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -207,19 +234,41 @@ test("cleanupOldSettingsBackups is skipped when agentDir is a symlink", (t) => {
   assert.match(stderr, /agentDir is a symlink/);
 });
 
-test("--no-settings skips stale backup cleanup on install", (t) => {
-  const { result } = runStage1LocalPackageInstall(t, { noSettings: true });
+test("--no-settings preserves eligible stale backups during install", (t) => {
+  const oldBackup = Object.keys(seededInstallBackups)[0];
+  const { result, agentDir } = runStage1LocalPackageInstall(t, {
+    noSettings: true,
+    existingAgentFiles: seededInstallBackups,
+  });
 
   assert.equal(result.status, 0, `install failed:\n${result.stderr}`);
-
-  // Create an old backup after the fact to check that it was not touched.
-  // (In --no-settings mode cleanupOldSettingsBackups should never be called.)
-  // We verify the function is not called by observing that no log output mentions backup cleanup.
+  assert.equal(
+    readFileSync(join(agentDir, oldBackup), "utf8"),
+    seededInstallBackups[oldBackup],
+    "--no-settings must leave the eligible old backup untouched",
+  );
   assert.doesNotMatch(
     result.stdout + result.stderr,
     /Would remove stale settings backup|Removed stale settings backup/,
     "--no-settings install must not log stale backup cleanup",
   );
+});
+
+test("normal install removes eligible stale backups while retaining the newest two", (t) => {
+  const oldBackup = Object.keys(seededInstallBackups)[0];
+  const { result, agentDir } = runStage1LocalPackageInstall(t, {
+    existingAgentFiles: seededInstallBackups,
+  });
+
+  assert.equal(result.status, 0, `install failed:\n${result.stderr}`);
+  assert.equal(existsSync(join(agentDir, oldBackup)), false, "normal install removes old backups");
+  for (const newerBackup of Object.keys(seededInstallBackups).slice(1)) {
+    assert.equal(
+      existsSync(join(agentDir, newerBackup)),
+      true,
+      `${newerBackup} remains within the newest-two floor`,
+    );
+  }
 });
 
 test("cleanupOldSettingsBackups is idempotent when agentDir is empty", (t) => {
@@ -299,6 +348,27 @@ test("cleanupOldSettingsBackups does not delete user files with no parseable tim
   );
 });
 
+test("cleanupOldSettingsBackups does not delete backup-named file with an impossible calendar day", (t) => {
+  const root = makeTempDir("tlh-backup-cleanup-invalid-day-");
+  const agentDir = join(root, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const invalidDayFile = "settings.json.backup-2026-02-30T00-00-00Z";
+  const invalidContent = '{"custom": true}';
+  writeFileSync(join(agentDir, invalidDayFile), invalidContent, "utf8");
+  const newer1 = recentBackupName("settings.json", 1);
+  const newer2 = recentBackupName("settings.json", 2);
+  writeFileSync(join(agentDir, newer1), "{}", "utf8");
+  writeFileSync(join(agentDir, newer2), "{}", "utf8");
+
+  cleanupOldSettingsBackups(makeConfig(agentDir));
+
+  assert.equal(readFileSync(join(agentDir, invalidDayFile), "utf8"), invalidContent);
+  assert.ok(existsSync(join(agentDir, newer1)), "newest TLH backup should be retained");
+  assert.ok(existsSync(join(agentDir, newer2)), "second-newest TLH backup should be retained");
+});
+
 test("cleanupOldSettingsBackups does not delete user file with shape-valid but semantically invalid timestamp (PR-376 regression)", (t) => {
   // Regression: a filename like `settings.json.backup-2026-99-99T99-99-99Z` passes
   // the BACKUP_TIMESTAMP_FULL shape regex but parseBackupTimestamp returns undefined
@@ -330,6 +400,54 @@ test("cleanupOldSettingsBackups does not delete user file with shape-valid but s
   );
   assert.ok(existsSync(join(agentDir, newer1)), "newest TLH backup should be retained");
   assert.ok(existsSync(join(agentDir, newer2)), "second-newest TLH backup should be retained");
+});
+
+test("cleanupOldSettingsBackups skips missing and unreadable metadata while processing later entries", (t) => {
+  const root = makeTempDir("tlh-backup-cleanup-metadata-errors-");
+  const agentDir = join(root, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const missingName = "settings.json.backup-2000-01-01T00-00-00Z";
+  const unreadableName = "settings.json.backup-2000-01-02T00-00-00Z";
+  const laterName = "settings.json.backup-1999-12-31T00-00-00Z";
+  const newer1 = "settings.json.backup-2026-08-01T00-00-00Z";
+  const newer2 = "settings.json.backup-2026-08-02T00-00-00Z";
+  for (const name of [missingName, unreadableName, laterName, newer1, newer2]) {
+    writeFileSync(join(agentDir, name), name, "utf8");
+  }
+
+  const metadataVisits = [];
+  const metadataReader = metadataReaderWithFailures(
+    new Map([
+      [join(agentDir, missingName), { code: "ENOENT", message: "simulated missing entry" }],
+      [join(agentDir, unreadableName), { code: "EIO", message: "simulated metadata failure" }],
+    ]),
+    metadataVisits,
+  );
+  const stderr = captureConsole("error", () => {
+    assert.doesNotThrow(() =>
+      cleanupOldSettingsBackups(makeConfig(agentDir, { cleanupMetadata: metadataReader })),
+    );
+  });
+
+  assert.ok(existsSync(join(agentDir, missingName)), "missing metadata entry must be skipped");
+  assert.ok(
+    existsSync(join(agentDir, unreadableName)),
+    "unreadable metadata entry must be skipped",
+  );
+  assert.equal(
+    existsSync(join(agentDir, laterName)),
+    false,
+    "later eligible entries must still be processed",
+  );
+  assert.deepEqual(metadataVisits, [
+    join(agentDir, unreadableName),
+    join(agentDir, missingName),
+    join(agentDir, laterName),
+  ]);
+  assert.doesNotMatch(stderr, /simulated missing entry/);
+  assert.match(stderr, /simulated metadata failure/);
 });
 
 test("cleanupOldSettingsBackups does not delete user file with unknown marker and parseable trailing timestamp (Finding 1 regression)", (t) => {

--- a/tests/install-stage1-core-test-helpers.mjs
+++ b/tests/install-stage1-core-test-helpers.mjs
@@ -151,6 +151,7 @@ export function runStage1LocalPackageInstall(
     force = false,
     verbose = false,
     existingSupportFiles,
+    existingAgentFiles,
     existingLibrarianConfig,
     existingManagedRtk = false,
     envOverrides = {},
@@ -167,6 +168,13 @@ export function runStage1LocalPackageInstall(
   const npmLog = join(root, "npm.log");
   mkdirSync(homeDir, { recursive: true });
   mkdirSync(packageDir, { recursive: true });
+  if (existingAgentFiles) {
+    for (const [relativePath, content] of Object.entries(existingAgentFiles)) {
+      const target = join(agentDir, relativePath);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, content);
+    }
+  }
   writeFakeTk(fakebin);
   writeLoggingPi(fakebin, piLog);
   // Fake npm so installPiIfNeeded never hits the network. The fake npm copies a

--- a/tests/install-stage1-retired-profile.test.mjs
+++ b/tests/install-stage1-retired-profile.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import test from "node:test";
 
 import {
@@ -9,6 +9,18 @@ import {
   cleanupRetiredProfileFiles,
 } from "../scripts/tlh-install.mjs";
 import { captureConsole, makeTempDir } from "./install-stage1-test-helpers.mjs";
+
+function metadataReaderWithFailures(failures) {
+  return (path) => {
+    const failure = failures.get(path);
+    if (failure) {
+      const error = new Error(failure.message);
+      error.code = failure.code;
+      throw error;
+    }
+    return lstatSync(path);
+  };
+}
 
 test("cleanupLegacyManagedProfileArtifacts removes regular legacy managed RTK files", (t) => {
   const root = makeTempDir("tlh-cleanup-legacy-rtk-present-");
@@ -45,6 +57,65 @@ test("cleanupLegacyManagedProfileArtifacts preserves symlinked and parent-symlin
   assert.equal(existsSync(externalRtk), true);
   assert.equal(existsSync(join(agentDir, "bin", "rtk")), true);
   assert.equal(existsSync(join(agentDir, "tlh", "tlh-rtk.mjs")), true);
+});
+
+test("cleanupLegacyManagedProfileArtifacts skips missing metadata and processes later files", (t) => {
+  const root = makeTempDir("tlh-cleanup-legacy-rtk-missing-metadata-");
+  const agentDir = join(root, "agent");
+  const missingFile = join(agentDir, "bin", "rtk");
+  const laterFile = join(agentDir, "tlh", "tlh-rtk.mjs");
+  mkdirSync(dirname(missingFile), { recursive: true });
+  mkdirSync(dirname(laterFile), { recursive: true });
+  writeFileSync(missingFile, "legacy rtk\n", "utf8");
+  writeFileSync(laterFile, "legacy helper\n", "utf8");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const metadataReader = metadataReaderWithFailures(
+    new Map([[missingFile, { code: "ENOENT", message: "simulated missing entry" }]]),
+  );
+  assert.doesNotThrow(() =>
+    cleanupLegacyManagedProfileArtifacts({
+      agentDir,
+      dryRun: false,
+      quiet: true,
+      verbose: false,
+      cleanupMetadata: metadataReader,
+    }),
+  );
+
+  assert.equal(existsSync(missingFile), true, "missing metadata entry must be preserved");
+  assert.equal(existsSync(laterFile), false, "later eligible file must still be removed");
+});
+
+test("cleanupLegacyManagedProfileArtifacts warns on metadata errors and processes later files", (t) => {
+  const root = makeTempDir("tlh-cleanup-legacy-rtk-metadata-error-");
+  const agentDir = join(root, "agent");
+  const unreadableFile = join(agentDir, "bin", "rtk");
+  const laterFile = join(agentDir, "tlh", "tlh-rtk.mjs");
+  mkdirSync(dirname(unreadableFile), { recursive: true });
+  mkdirSync(dirname(laterFile), { recursive: true });
+  writeFileSync(unreadableFile, "legacy rtk\n", "utf8");
+  writeFileSync(laterFile, "legacy helper\n", "utf8");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const metadataReader = metadataReaderWithFailures(
+    new Map([[unreadableFile, { code: "EIO", message: "simulated metadata failure" }]]),
+  );
+  const stderr = captureConsole("error", () => {
+    assert.doesNotThrow(() =>
+      cleanupLegacyManagedProfileArtifacts({
+        agentDir,
+        dryRun: false,
+        quiet: true,
+        verbose: false,
+        cleanupMetadata: metadataReader,
+      }),
+    );
+  });
+
+  assert.equal(existsSync(unreadableFile), true, "unreadable metadata entry must be preserved");
+  assert.equal(existsSync(laterFile), false, "later eligible file must still be removed");
+  assert.match(stderr, /simulated metadata failure/);
 });
 
 test("cleanupLegacyManagedProfileArtifacts preserves non-files and unrelated profile content", (t) => {

--- a/tests/install-utils.test.mjs
+++ b/tests/install-utils.test.mjs
@@ -206,6 +206,20 @@ test("parseBackupTimestamp: parses all four backup filename variants", () => {
   );
 });
 
+test("parseBackupTimestamp: rejects impossible calendar days and preserves valid ISO hour-24 normalization", () => {
+  assert.equal(parseBackupTimestamp("settings.json.backup-2025-02-29T00-00-00Z"), undefined);
+  assert.equal(parseBackupTimestamp("settings.json.backup-2024-02-30T00-00-00Z"), undefined);
+  assert.equal(parseBackupTimestamp("settings.json.backup-2024-04-31T00-00-00Z"), undefined);
+  assert.deepEqual(
+    parseBackupTimestamp("settings.json.backup-2024-02-29T23-59-59-999Z"),
+    new Date("2024-02-29T23:59:59.999Z"),
+  );
+  assert.deepEqual(
+    parseBackupTimestamp("settings.json.backup-2024-02-29T24-00-00Z"),
+    new Date("2024-03-01T00:00:00Z"),
+  );
+});
+
 test("parseBackupTimestamp: returns undefined for unrecognised filenames", () => {
   assert.equal(parseBackupTimestamp("settings.json"), undefined);
   assert.equal(parseBackupTimestamp("settings.json.bak"), undefined);


### PR DESCRIPTION
## Summary

Closes #416.

- Reject impossible calendar days in backup filenames while preserving valid leap days and ISO hour-24 normalization.
- Guard candidate metadata reads in stale-backup and retired-profile file cleanup: missing entries skip silently, other metadata failures warn and skip, and later eligible files still process.
- Replace the ineffective `--no-settings` assertion with seeded temporary-profile install regressions and a normal-install positive control. Retention, ownership, symlink, and dry-run rules remain unchanged.

## Change type

- [x] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed with exit code 0, including installer smoke, all test suites, runtime freshness, lint/format, and packaging checks.

Focused installer regressions passed **56/56**:

```sh
node --test tests/install-utils.test.mjs tests/install-stage1-backup-cleanup.test.mjs tests/install-stage1-retired-profile.test.mjs tests/install-stage1-subagents-retirement.test.mjs
npm run typecheck:runtime
npm run check:runtime
npm run lint
npm run format:check
git diff --check
```

Independent final review found no required changes and independently re-ran the three touched test files (**55/55**), runtime/type checks, lint, formatting, and diff checks. Metadata failures are injected through a narrow optional reader seam; no module mocking, timing races, permission-dependent tests, or real home-profile installs.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user normal Pi configuration)
  - installer Pi commands retain isolated `PI_CODING_AGENT_DIR`
  - settings merge behavior and backups remain conservative
  - unmanaged wrapper overwrite rules remain unchanged
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/settings-backup-cleanup/install.sh | bash -s -- --ref fix/settings-backup-cleanup --track ref
```