### PR TITLE
Preserve supervisor lifecycle failure diagnostics

### DIFF
--- a/extensions/subagents/src/runs/background/subagent-runner.js
+++ b/extensions/subagents/src/runs/background/subagent-runner.js
@@ -34,7 +34,7 @@ import { resolveEffectiveThinking } from "../../shared/model-info.js";
 import { acceptanceFailureMessage, appendAcceptanceReportDigest, buildSkippedAcceptanceLedger, composeAcceptanceFailureError, evaluateAcceptance, formatAcceptancePrompt, parseAndStripAcceptanceReport, } from "../shared/acceptance.js";
 import { cleanupOwnedProcessGroup, formatOwnedProcessGroupCleanup, skipOwnedProcessGroupCleanup, supportsOwnedProcessGroupCleanup, } from "../shared/process-group-cleanup.js";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.js";
-import { ACTIVE_RUNTIME_CHECKPOINT_INTERVAL_MS, TERMINAL_RUN_STATES, applyActiveRuntimeCheckpoint, boundSupervisorSummary, boundedActiveRuntimeMs, createActiveRuntimeTracker, finalizeLifecycleContinuationLaunch, lifecycleGeneration, normalizeActiveRuntimeCheckpointAt, normalizeActiveRuntimeMs, mergeAndWriteSourceRunnerStatus, transitionLifecycleStatus, writeNormalizedLifecycleStatus, } from "../shared/lifecycle-state.js";
+import { ACTIVE_RUNTIME_CHECKPOINT_INTERVAL_MS, TERMINAL_RUN_STATES, applyActiveRuntimeCheckpoint, boundSupervisorSummary, boundedActiveRuntimeMs, createActiveRuntimeTracker, finalizeLifecycleContinuationLaunch, isLifecycleTransitionContentionError, lifecycleGeneration, normalizeActiveRuntimeCheckpointAt, normalizeActiveRuntimeMs, mergeAndWriteSourceRunnerStatus, transitionLifecycleStatus, writeNormalizedLifecycleStatus, } from "../shared/lifecycle-state.js";
 import { formatForegroundSupervisorPauseMessage } from "../../shared/foreground-pause.js";
 import { assistantStopReason, classifyContextExhaustedTermination, CONTEXT_EXHAUSTED_TERMINATION_MESSAGE, hasUsableSessionArtifact, parseContextPressureCrossedThresholds, parseContextPressureProjection, parseContextUsageDiagnostics, mergeContextUsageDiagnostics, resolveSubagentTerminationReason, updateContextUsageDiagnostics, detectContextPressureCrossing, formatContextPressureGuidance, } from "../../shared/context-diagnostics.js";
 import { splitKnownThinkingSuffix } from "../../shared/model-info.js";
@@ -133,6 +133,37 @@ function appendDiagnosticJsonl(filePath, line, droppedEventType) {
         appendJsonl(filePath, marker);
     }
     state.diagnosticsTruncated = true;
+}
+const LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES = 4 * 1024;
+function lifecycleTransitionErrorDetail(error, depth = 0) {
+    try {
+        if (!(error instanceof Error))
+            return boundChildError(String(error), LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES) ?? "unknown";
+        const errnoError = error;
+        const code = typeof errnoError.code === "string" ? `code=${errnoError.code}` : undefined;
+        const cause = error.cause !== undefined && depth < 2
+            ? `cause=${lifecycleTransitionErrorDetail(error.cause, depth + 1)}`
+            : undefined;
+        return (boundChildError([error.name ? `name=${error.name}` : undefined, code, `message=${error.message}`, cause]
+            .filter((part) => part !== undefined)
+            .join("; "), LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES) ?? "unknown");
+    }
+    catch {
+        return "unavailable";
+    }
+}
+function appendLifecycleTransitionDiagnostic(eventsPath, runId, phase, error) {
+    try {
+        appendDiagnosticJsonl(eventsPath, JSON.stringify({
+            type: "subagent.run.lifecycle_transition_failed",
+            ts: Date.now(),
+            runId,
+            phase,
+            cause: lifecycleTransitionErrorDetail(error),
+        }), "subagent.run.lifecycle_transition_failed");
+    }
+    catch {
+    }
 }
 function shouldPersistChildEvent(event) {
     return event.type !== "message_update";
@@ -2420,7 +2451,9 @@ async function runSubagentWithInput(config, plan) {
             durablePausingCheckpointPersisted = true;
             pausedCheckpointCommitted = true;
         }
-        catch {
+        catch (error) {
+            if (!isLifecycleTransitionContentionError(error))
+                appendLifecycleTransitionDiagnostic(eventsPath, id, "running->pausing", error);
             supervisorPauseTransitionFailed = !adoptConcurrentTerminalStatus();
         }
         interrupted = true;
@@ -3671,7 +3704,9 @@ async function runSubagentWithInput(config, plan) {
                     });
                     Object.assign(statusPayload, transition.status);
                 }
-                catch {
+                catch (error) {
+                    if (!isLifecycleTransitionContentionError(error))
+                        appendLifecycleTransitionDiagnostic(eventsPath, id, "pausing->paused", error);
                     adoptConcurrentTerminalStatus();
                 }
                 const nestedDescendantsStoppedAfterFinalization = await waitForNestedAsyncDescendantsToStop();

--- a/extensions/subagents/src/runs/background/subagent-runner.ts
+++ b/extensions/subagents/src/runs/background/subagent-runner.ts
@@ -170,6 +170,7 @@ import {
   boundedActiveRuntimeMs,
   createActiveRuntimeTracker,
   finalizeLifecycleContinuationLaunch,
+  isLifecycleTransitionContentionError,
   lifecycleGeneration,
   normalizeActiveRuntimeCheckpointAt,
   normalizeActiveRuntimeMs,
@@ -349,6 +350,55 @@ function appendDiagnosticJsonl(filePath: string, line: string, droppedEventType?
     appendJsonl(filePath, marker);
   }
   state.diagnosticsTruncated = true;
+}
+
+const LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES = 4 * 1024;
+type LifecycleTransitionPhase = "running->pausing" | "pausing->paused";
+
+function lifecycleTransitionErrorDetail(error: unknown, depth = 0): string {
+  try {
+    if (!(error instanceof Error))
+      return boundChildError(String(error), LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES) ?? "unknown";
+    const errnoError = error as NodeJS.ErrnoException;
+    const code = typeof errnoError.code === "string" ? `code=${errnoError.code}` : undefined;
+    const cause =
+      error.cause !== undefined && depth < 2
+        ? `cause=${lifecycleTransitionErrorDetail(error.cause, depth + 1)}`
+        : undefined;
+    return (
+      boundChildError(
+        [error.name ? `name=${error.name}` : undefined, code, `message=${error.message}`, cause]
+          .filter((part): part is string => part !== undefined)
+          .join("; "),
+        LIFECYCLE_TRANSITION_DIAGNOSTIC_MAX_BYTES,
+      ) ?? "unknown"
+    );
+  } catch {
+    return "unavailable";
+  }
+}
+
+function appendLifecycleTransitionDiagnostic(
+  eventsPath: string,
+  runId: string,
+  phase: LifecycleTransitionPhase,
+  error: unknown,
+): void {
+  try {
+    appendDiagnosticJsonl(
+      eventsPath,
+      JSON.stringify({
+        type: "subagent.run.lifecycle_transition_failed",
+        ts: Date.now(),
+        runId,
+        phase,
+        cause: lifecycleTransitionErrorDetail(error),
+      }),
+      "subagent.run.lifecycle_transition_failed",
+    );
+  } catch {
+    // Lifecycle diagnostics are best effort and must not interrupt teardown.
+  }
 }
 
 function shouldPersistChildEvent(event: Record<string, unknown>): boolean {
@@ -3479,7 +3529,9 @@ async function runSubagentWithInput(
       supervisorPauseTransitionFailed = false;
       durablePausingCheckpointPersisted = true;
       pausedCheckpointCommitted = true;
-    } catch {
+    } catch (error) {
+      if (!isLifecycleTransitionContentionError(error))
+        appendLifecycleTransitionDiagnostic(eventsPath, id, "running->pausing", error);
       supervisorPauseTransitionFailed = !adoptConcurrentTerminalStatus();
     }
     interrupted = true;
@@ -4908,7 +4960,9 @@ async function runSubagentWithInput(
             }),
           });
           Object.assign(statusPayload, transition.status);
-        } catch {
+        } catch (error) {
+          if (!isLifecycleTransitionContentionError(error))
+            appendLifecycleTransitionDiagnostic(eventsPath, id, "pausing->paused", error);
           adoptConcurrentTerminalStatus();
         }
         const nestedDescendantsStoppedAfterFinalization =

--- a/extensions/subagents/src/runs/shared/lifecycle-state.js
+++ b/extensions/subagents/src/runs/shared/lifecycle-state.js
@@ -96,6 +96,16 @@ class LifecycleLockExhaustedError extends Error {
         this.name = "LifecycleLockExhaustedError";
     }
 }
+export class LifecycleGenerationConflictError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "LifecycleGenerationConflictError";
+    }
+}
+export function isLifecycleTransitionContentionError(error) {
+    return (error instanceof LifecycleGenerationConflictError ||
+        error instanceof LifecycleLockExhaustedError);
+}
 function replaceControlCharacters(value) {
     return [...value]
         .map((character) => {
@@ -658,7 +668,7 @@ export function transitionLifecycleStatus(options) {
         const normalizedCurrent = normalizeAsyncLifecycleStatus(current);
         const currentGeneration = lifecycleGeneration(normalizedCurrent);
         if (currentGeneration !== options.expectedGeneration) {
-            throw new Error(`Lifecycle transition rejected for run '${runLabel(options.asyncDir)}': expected generation ${options.expectedGeneration}, found ${currentGeneration}.`);
+            throw new LifecycleGenerationConflictError(`Lifecycle transition rejected for run '${runLabel(options.asyncDir)}': expected generation ${options.expectedGeneration}, found ${currentGeneration}.`);
         }
         const mutated = normalizeAsyncLifecycleStatus(options.mutate(normalizedCurrent));
         const nextStatus = {
@@ -728,7 +738,7 @@ export function markLifecycleContinuationSpawned(asyncDir, index, claimToken, co
         return { status: transitioned.status, transitioned: true, final: false, lost: false };
     }
     catch (error) {
-        if (error instanceof Error && /expected generation/.test(error.message)) {
+        if (error instanceof LifecycleGenerationConflictError) {
             return markLifecycleContinuationSpawned(asyncDir, index, claimToken, continuationRunId, options);
         }
         throw error;
@@ -758,7 +768,7 @@ export function finalizeLifecycleContinuationLaunch(asyncDir, index, claimToken,
         return { status: transitioned.status, finalized: true, lost: false };
     }
     catch (error) {
-        if (error instanceof Error && /expected generation/.test(error.message)) {
+        if (error instanceof LifecycleGenerationConflictError) {
             return finalizeLifecycleContinuationLaunch(asyncDir, index, claimToken, continuationRunId, options);
         }
         throw error;

--- a/extensions/subagents/src/runs/shared/lifecycle-state.ts
+++ b/extensions/subagents/src/runs/shared/lifecycle-state.ts
@@ -197,6 +197,26 @@ class LifecycleLockExhaustedError extends Error {
   }
 }
 
+/**
+ * Thrown when a lifecycle CAS reaches the lock but the persisted generation has
+ * already advanced. Callers can treat this as benign contention without relying
+ * on the human-readable error message.
+ */
+export class LifecycleGenerationConflictError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LifecycleGenerationConflictError";
+  }
+}
+
+/** Recognize only the lifecycle errors that represent expected contention. */
+export function isLifecycleTransitionContentionError(error: unknown): boolean {
+  return (
+    error instanceof LifecycleGenerationConflictError ||
+    error instanceof LifecycleLockExhaustedError
+  );
+}
+
 interface LifecycleLockOptions {
   kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
   now?: () => number;
@@ -1009,7 +1029,7 @@ export function transitionLifecycleStatus(
       const normalizedCurrent = normalizeAsyncLifecycleStatus(current);
       const currentGeneration = lifecycleGeneration(normalizedCurrent);
       if (currentGeneration !== options.expectedGeneration) {
-        throw new Error(
+        throw new LifecycleGenerationConflictError(
           `Lifecycle transition rejected for run '${runLabel(options.asyncDir)}': expected generation ${options.expectedGeneration}, found ${currentGeneration}.`,
         );
       }
@@ -1099,7 +1119,7 @@ export function markLifecycleContinuationSpawned(
     });
     return { status: transitioned.status, transitioned: true, final: false, lost: false };
   } catch (error) {
-    if (error instanceof Error && /expected generation/.test(error.message)) {
+    if (error instanceof LifecycleGenerationConflictError) {
       return markLifecycleContinuationSpawned(
         asyncDir,
         index,
@@ -1150,7 +1170,7 @@ export function finalizeLifecycleContinuationLaunch(
     });
     return { status: transitioned.status, finalized: true, lost: false };
   } catch (error) {
-    if (error instanceof Error && /expected generation/.test(error.message)) {
+    if (error instanceof LifecycleGenerationConflictError) {
       return finalizeLifecycleContinuationLaunch(
         asyncDir,
         index,

--- a/extensions/subagents/test/integration/async-lifecycle-diagnostics.test.ts
+++ b/extensions/subagents/test/integration/async-lifecycle-diagnostics.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Production-runner regressions for supervisor lifecycle CAS diagnostics.
+ *
+ * The child runner is faulted in a subprocess before it imports lifecycle code;
+ * no production fault-injection hooks are involved.
+ */
+
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  createMockPi,
+  createTempDir,
+  events,
+  makeAgent,
+  removeTempDir,
+} from "../support/helpers.ts";
+import type { MockPi } from "../support/helpers.ts";
+import {
+  ASYNC_DIR,
+  type AsyncResultPayload,
+  type AsyncStatusPayload,
+  executeAsyncSingle,
+  startedMockPiPids,
+  waitForAsyncResultFile,
+  waitForAsyncStatusPredicate,
+  waitForMockPiCall,
+  waitForPidsToExit,
+} from "../support/async-execution-helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
+
+const LIFECYCLE_FAULT_PRELOAD = pathToFileURL(
+  path.resolve("extensions/subagents/test/support/lifecycle-fault-preload.mjs"),
+).href;
+const LIFECYCLE_FAULT_ENV_KEYS = [
+  "NODE_OPTIONS",
+  "TLH_TEST_LIFECYCLE_FAULT_DIR",
+  "TLH_TEST_LIFECYCLE_FAULT_GENERATION",
+  "TLH_TEST_LIFECYCLE_FAULT_MARKER",
+  "TLH_TEST_LIFECYCLE_FAULT_CAUSE",
+  "TLH_TEST_LIFECYCLE_FAULT_CAUSE_BYTES",
+  "TLH_TEST_LIFECYCLE_DIAGNOSTIC_WRITE_FAILURE",
+] as const;
+
+type LifecycleFaultPhase = "running->pausing" | "pausing->paused";
+type LifecycleOutcome = "failed" | "paused";
+
+type FaultCase = {
+  phase: LifecycleFaultPhase;
+  generation: number;
+  outcome: LifecycleOutcome;
+  writtenState: "pausing" | "paused";
+};
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJsonl(filePath: string): JsonRecord[] {
+  return fs
+    .readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown)
+    .filter(isRecord);
+}
+
+function lifecycleDiagnostics(asyncDir: string): JsonRecord[] {
+  return readJsonl(path.join(asyncDir, "events.jsonl")).filter(
+    (entry) => entry.type === "subagent.run.lifecycle_transition_failed",
+  );
+}
+
+function killPids(pids: readonly (number | undefined)[]): void {
+  for (const pid of pids) {
+    if (typeof pid !== "number" || pid <= 0 || pid === process.pid) continue;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The process may already have exited or the platform may not expose SIGKILL.
+    }
+  }
+}
+
+function setFaultEnvironment(options: {
+  asyncDir: string;
+  generation: number;
+  markerPath: string;
+  causeMarker: string;
+  causeBytes?: number;
+  diagnosticWriteFailure?: boolean;
+}): Map<string, string | undefined> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of LIFECYCLE_FAULT_ENV_KEYS) previous.set(key, process.env[key]);
+  process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, `--import=${LIFECYCLE_FAULT_PRELOAD}`]
+    .filter(Boolean)
+    .join(" ");
+  process.env.TLH_TEST_LIFECYCLE_FAULT_DIR = options.asyncDir;
+  process.env.TLH_TEST_LIFECYCLE_FAULT_GENERATION = String(options.generation);
+  process.env.TLH_TEST_LIFECYCLE_FAULT_MARKER = options.markerPath;
+  process.env.TLH_TEST_LIFECYCLE_FAULT_CAUSE = options.causeMarker;
+  process.env.TLH_TEST_LIFECYCLE_FAULT_CAUSE_BYTES = String(options.causeBytes ?? 0);
+  if (options.diagnosticWriteFailure) {
+    process.env.TLH_TEST_LIFECYCLE_DIAGNOSTIC_WRITE_FAILURE = "1";
+  } else {
+    delete process.env.TLH_TEST_LIFECYCLE_DIAGNOSTIC_WRITE_FAILURE;
+  }
+  return previous;
+}
+
+function restoreFaultEnvironment(previous: Map<string, string | undefined>): void {
+  for (const key of LIFECYCLE_FAULT_ENV_KEYS) {
+    const value = previous.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+let nextRun = 0;
+
+async function runLifecycleFaultCase(
+  tempDir: string,
+  mockPi: MockPi,
+  faultCase: FaultCase,
+  options: { diagnosticWriteFailure?: boolean; causeBytes?: number } = {},
+): Promise<{ payload: AsyncResultPayload; status: AsyncStatusPayload; diagnostics: JsonRecord[] }> {
+  const id = `async-lifecycle-diagnostic-${faultCase.phase.replaceAll("->", "-")}-${nextRun++}`;
+  const asyncDir = path.join(ASYNC_DIR, id);
+  const markerPath = path.join(tempDir, `${id}-fault.json`);
+  const childGate = path.join(tempDir, `${id}-child-ready`);
+  const causeMarker = `TLH-LIFECYCLE-CAUSE-${id}`;
+  const previousEnvironment = setFaultEnvironment({
+    asyncDir,
+    generation: faultCase.generation,
+    markerPath,
+    causeMarker,
+    causeBytes: options.causeBytes,
+    diagnosticWriteFailure: options.diagnosticWriteFailure,
+  });
+  let runnerPid: number | undefined;
+  let childPids: number[] = [];
+  try {
+    const callIndex = mockPi.callCount();
+    mockPi.onCall({
+      steps: [
+        {
+          jsonl: [
+            events.toolStart("contact_supervisor", {
+              reason: "need_decision",
+              message: "Need a supervisor decision",
+            }),
+          ],
+        },
+      ],
+      ignoreSigint: true,
+      ignoreSigterm: true,
+      keepAliveAfterFinalMessageMs: 30_000,
+      waitForMarker: childGate,
+    });
+    executeAsyncSingle(id, {
+      agent: "worker",
+      task: "Ask for a supervisor decision and stop there.",
+      agentConfig: makeAgent("worker"),
+      ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+      artifactConfig: {
+        mode: "compact",
+        enabled: true,
+        includeInput: false,
+        includeOutput: true,
+        includeJsonl: false,
+        includeTranscript: false,
+        includeMetadata: true,
+        cleanupDays: 7,
+      },
+      shareEnabled: false,
+      sessionRoot: path.join(tempDir, "sessions"),
+      maxSubagentDepth: 2,
+    });
+
+    const runningStatus = await waitForAsyncStatusPredicate(
+      asyncDir,
+      (status) => status.state === "running" && typeof status.pid === "number",
+      `${faultCase.phase} runner startup`,
+    );
+    runnerPid = runningStatus.pid;
+    await waitForMockPiCall(mockPi, callIndex);
+    childPids = startedMockPiPids(mockPi);
+    fs.writeFileSync(childGate, "", "utf-8");
+
+    const resultPath = await waitForAsyncResultFile(id, scaleTestTimeout(30_000));
+    const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+    const status = JSON.parse(
+      fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"),
+    ) as AsyncStatusPayload;
+    assert.equal(payload.state, faultCase.outcome);
+    assert.equal(status.state, faultCase.outcome);
+    const fault = JSON.parse(fs.readFileSync(markerPath, "utf-8")) as JsonRecord;
+    assert.equal(fault.generation, faultCase.generation);
+    assert.equal(fault.state, faultCase.writtenState);
+    assert.equal(path.dirname(path.resolve(String(fault.filePath))), asyncDir);
+    assert.match(path.basename(String(fault.filePath)), /^\.status\.json\..+\.tmp$/);
+
+    const diagnostics = lifecycleDiagnostics(asyncDir);
+    if (options.diagnosticWriteFailure) {
+      assert.equal(diagnostics.length, 0, "diagnostic append failure must not add an event");
+    } else {
+      assert.equal(diagnostics.length, 1);
+      const diagnostic = diagnostics[0]!;
+      assert.equal(diagnostic.runId, id);
+      assert.equal(diagnostic.phase, faultCase.phase);
+      assert.match(String(diagnostic.cause), new RegExp(causeMarker));
+      assert.match(String(diagnostic.cause), /code=ENOSPC/);
+      assert.ok(
+        Buffer.byteLength(String(diagnostic.cause), "utf8") <= 4 * 1024,
+        "transition cause detail must remain bounded",
+      );
+    }
+
+    await waitForPidsToExit(
+      [runnerPid, ...childPids],
+      `${faultCase.phase} lifecycle fault processes`,
+      scaleTestTimeout(15_000),
+    );
+    return { payload, status, diagnostics };
+  } finally {
+    // Keep cleanup unconditional even when a production-path assertion or wait fails.
+    if (runnerPid === undefined) {
+      try {
+        const status = JSON.parse(
+          fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"),
+        ) as AsyncStatusPayload;
+        runnerPid = status.pid;
+      } catch {
+        // The runner may have failed before creating its status file.
+      }
+    }
+    childPids = [...new Set([...childPids, ...startedMockPiPids(mockPi)])];
+    const knownPids = [runnerPid, ...childPids];
+    killPids(knownPids);
+    try {
+      await waitForPidsToExit(
+        knownPids,
+        `${faultCase.phase} lifecycle fault cleanup`,
+        scaleTestTimeout(5_000),
+      );
+    } catch {
+      // Do not mask the original test failure with best-effort process cleanup.
+    }
+    restoreFaultEnvironment(previousEnvironment);
+  }
+}
+
+describe("async supervisor lifecycle transition diagnostics", () => {
+  let tempDir: string;
+  let mockPi: MockPi;
+
+  before(() => {
+    mockPi = createMockPi();
+    mockPi.install();
+  });
+
+  after(() => {
+    mockPi.uninstall();
+  });
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    mockPi.reset();
+  });
+
+  afterEach(() => {
+    // The child helper owns the run-specific cleanup; this removes the test cwd
+    // after every case without touching the isolated profile or normal Pi config.
+    removeTempDir(tempDir);
+  });
+
+  it(
+    "records the original pre-checkpoint CAS cause and preserves failed teardown",
+    {
+      skip:
+        process.platform === "win32"
+          ? "cross-process supervisor pause delivery unreliable on Windows CI"
+          : undefined,
+    },
+    async () => {
+      const result = await runLifecycleFaultCase(
+        tempDir,
+        mockPi,
+        {
+          phase: "running->pausing",
+          generation: 1,
+          outcome: "failed",
+          writtenState: "pausing",
+        },
+        { causeBytes: 12_000 },
+      );
+      assert.equal(result.payload.state, "failed");
+      assert.equal(result.status.state, "failed");
+      assert.equal(result.payload.pause, undefined);
+      assert.equal(result.status.pause, undefined);
+      assert.equal(result.status.steps?.[0]?.processCleanup?.terminated, true);
+    },
+  );
+
+  it(
+    "retains post-checkpoint diagnostics in compact mode and preserves safe pause",
+    {
+      skip:
+        process.platform === "win32"
+          ? "cross-process supervisor pause delivery unreliable on Windows CI"
+          : undefined,
+    },
+    async () => {
+      const result = await runLifecycleFaultCase(tempDir, mockPi, {
+        phase: "pausing->paused",
+        generation: 2,
+        outcome: "paused",
+        writtenState: "paused",
+      });
+      assert.equal(result.payload.state, "paused");
+      assert.equal(result.status.state, "paused");
+      assert.equal(result.payload.pause?.kind, "awaiting_supervisor");
+      assert.equal(result.status.pause?.kind, "awaiting_supervisor");
+      assert.equal(result.status.steps?.[0]?.processCleanup?.terminated, true);
+      assert.equal(result.diagnostics[0]?.phase, "pausing->paused");
+    },
+  );
+
+  it(
+    "keeps both lifecycle outcomes when diagnostic storage fails",
+    {
+      skip:
+        process.platform === "win32"
+          ? "cross-process supervisor pause delivery unreliable on Windows CI"
+          : undefined,
+    },
+    async () => {
+      const preCheckpoint = await runLifecycleFaultCase(
+        tempDir,
+        mockPi,
+        {
+          phase: "running->pausing",
+          generation: 1,
+          outcome: "failed",
+          writtenState: "pausing",
+        },
+        { diagnosticWriteFailure: true },
+      );
+      const postCheckpoint = await runLifecycleFaultCase(
+        tempDir,
+        mockPi,
+        {
+          phase: "pausing->paused",
+          generation: 2,
+          outcome: "paused",
+          writtenState: "paused",
+        },
+        { diagnosticWriteFailure: true },
+      );
+      assert.equal(preCheckpoint.payload.state, "failed");
+      assert.equal(preCheckpoint.status.state, "failed");
+      assert.equal(postCheckpoint.payload.state, "paused");
+      assert.equal(postCheckpoint.status.state, "paused");
+      assert.equal(postCheckpoint.payload.pause?.kind, "awaiting_supervisor");
+      assert.equal(preCheckpoint.status.steps?.[0]?.processCleanup?.terminated, true);
+      assert.equal(postCheckpoint.status.steps?.[0]?.processCleanup?.terminated, true);
+    },
+  );
+});

--- a/extensions/subagents/test/support/lifecycle-fault-preload.mjs
+++ b/extensions/subagents/test/support/lifecycle-fault-preload.mjs
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+
+const targetDir = process.env.TLH_TEST_LIFECYCLE_FAULT_DIR
+  ? path.resolve(process.env.TLH_TEST_LIFECYCLE_FAULT_DIR)
+  : undefined;
+const targetGeneration = Number.parseInt(process.env.TLH_TEST_LIFECYCLE_FAULT_GENERATION ?? "", 10);
+const markerPath = process.env.TLH_TEST_LIFECYCLE_FAULT_MARKER;
+const diagnosticWriteFailure = process.env.TLH_TEST_LIFECYCLE_DIAGNOSTIC_WRITE_FAILURE === "1";
+const causeMarker = process.env.TLH_TEST_LIFECYCLE_FAULT_CAUSE ?? "synthetic lifecycle fault";
+const causeBytes = Number.parseInt(process.env.TLH_TEST_LIFECYCLE_FAULT_CAUSE_BYTES ?? "0", 10);
+
+const originalWriteFileSync = fs.writeFileSync;
+const originalAppendFileSync = fs.appendFileSync;
+let faultFired = false;
+
+function payloadText(data) {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  return undefined;
+}
+
+function lifecycleStatusPayload(filePath, data) {
+  if (!targetDir || !Number.isSafeInteger(targetGeneration)) return undefined;
+  if (typeof filePath !== "string") return undefined;
+  const resolvedPath = path.resolve(filePath);
+  if (path.dirname(resolvedPath) !== targetDir) return undefined;
+  const baseName = path.basename(resolvedPath);
+  if (!baseName.startsWith(".status.json.") || !baseName.endsWith(".tmp")) return undefined;
+  try {
+    const parsed = JSON.parse(payloadText(data) ?? "");
+    if (parsed?.lifecycle?.generation !== targetGeneration) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeFaultMarker(filePath, status) {
+  if (!markerPath) return;
+  originalWriteFileSync(
+    markerPath,
+    JSON.stringify({
+      filePath,
+      generation: status.lifecycle.generation,
+      state: status.state,
+    }),
+    "utf8",
+  );
+}
+
+function makeEnospcError() {
+  const suffix = Number.isSafeInteger(causeBytes) && causeBytes > 0 ? "x".repeat(causeBytes) : "";
+  const nested = new Error(`nested ${causeMarker}`);
+  const error = new Error(`${causeMarker}${suffix}`, { cause: nested });
+  error.code = "ENOSPC";
+  error.syscall = "write";
+  return error;
+}
+
+fs.writeFileSync = function patchedWriteFileSync(filePath, data, ...options) {
+  const status = lifecycleStatusPayload(filePath, data);
+  if (status && !faultFired) {
+    faultFired = true;
+    writeFaultMarker(filePath, status);
+    throw makeEnospcError();
+  }
+  return originalWriteFileSync(filePath, data, ...options);
+};
+
+fs.appendFileSync = function patchedAppendFileSync(filePath, data, ...options) {
+  if (
+    diagnosticWriteFailure &&
+    typeof filePath === "string" &&
+    path.basename(filePath) === "events.jsonl" &&
+    typeof payloadText(data) === "string" &&
+    payloadText(data).includes('"subagent.run.lifecycle_transition_failed"')
+  ) {
+    const error = new Error("synthetic diagnostic append failure");
+    error.code = "EIO";
+    throw error;
+  }
+  return originalAppendFileSync(filePath, data, ...options);
+};
+
+syncBuiltinESMExports();

--- a/extensions/subagents/test/unit/lifecycle-contention-classification.test.ts
+++ b/extensions/subagents/test/unit/lifecycle-contention-classification.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+  isLifecycleTransitionContentionError,
+  LifecycleGenerationConflictError,
+  transitionLifecycleStatus,
+  withLifecycleStatusLock,
+  writeNormalizedLifecycleStatus,
+} from "../../src/runs/shared/lifecycle-state.ts";
+
+function tempRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("lifecycle transition contention classification", () => {
+  it("classifies the real generation conflict and lock exhaustion errors nominally", () => {
+    const root = tempRoot("pi-lifecycle-contention-classes-");
+    try {
+      const asyncDir = path.join(root, "run");
+      writeNormalizedLifecycleStatus(asyncDir, {
+        runId: "run",
+        mode: "single",
+        state: "running",
+        startedAt: 100,
+        steps: [{ agent: "worker", status: "running" }],
+        lifecycle: { generation: 2 },
+      });
+
+      let generationError: unknown;
+      try {
+        transitionLifecycleStatus({
+          asyncDir,
+          expectedGeneration: 1,
+          mutate: (status) => status,
+        });
+      } catch (error) {
+        generationError = error;
+      }
+      assert.ok(generationError instanceof LifecycleGenerationConflictError);
+      assert.equal(isLifecycleTransitionContentionError(generationError), true);
+      assert.match((generationError as Error).message, /expected generation 1, found 2/);
+
+      let lockError: unknown;
+      withLifecycleStatusLock(asyncDir, () => {
+        try {
+          transitionLifecycleStatus({
+            asyncDir,
+            expectedGeneration: 2,
+            mutate: (status) => status,
+            lockOptions: { retryDelaysMs: [] },
+          });
+        } catch (error) {
+          lockError = error;
+        }
+      });
+      assert.equal(isLifecycleTransitionContentionError(lockError), true);
+      assert.equal((lockError as Error).name, "LifecycleLockExhaustedError");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not classify unrelated errors by name or misleading messages", () => {
+    assert.equal(
+      isLifecycleTransitionContentionError(
+        new Error("Lifecycle transition rejected: expected generation 1, found 2"),
+      ),
+      false,
+    );
+    const misleadingName = new Error("unrelated I/O failure");
+    misleadingName.name = "LifecycleGenerationConflictError";
+    assert.equal(isLifecycleTransitionContentionError(misleadingName), false);
+    assert.equal(
+      isLifecycleTransitionContentionError({ name: "LifecycleLockExhaustedError" }),
+      false,
+    );
+    assert.equal(isLifecycleTransitionContentionError(undefined), false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #499.

- Distinguish nominal lifecycle generation conflicts and lock exhaustion from unexpected failures; use the nominal generation type in continuation retries too.
- Preserve bounded original-cause diagnostics at both supervisor pause CAS catches in `events.jsonl`, including compact artifact mode. Diagnostic formatting and writes are best effort and cannot interrupt teardown.
- Preserve pause outcomes, child cleanup, concurrent terminal winners, and safe-paused recovery. No ownership normalization, production fault hooks, or lifecycle/result schema redesign.
- Add subprocess-only production-runner fault regressions for both CAS writes, bounded causes, compact retention, and diagnostic-write failure. Regenerate the authoritative TypeScript runtime mirrors.

Limits: exhausted event budgets or unavailable storage can prevent diagnostic retention. New cross-process fault cases skip Windows; Linux/macOS remain the CI targets. This does not attempt general recovery from persistent filesystem failure.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
git diff --check
```

Full validation passed: subagents unit **1484/1484**, integration **618/618**, e2e **1/1**. Package contents, generated runtime freshness, typechecks, installer smoke, root tests, lint, formatting, shell lint, settings merge dry-run, and pack dry-run passed. No validation side effects.

Independent read-only review covered all seven changed/new files and relevant lifecycle callers: **no required fixes**.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants; no normal profile, settings merge, or wrapper changes.
- [x] Relevant tests or smoke checks pass.
- [x] Docs and `CHANGELOG.md` reviewed: no change needed for this internal diagnostic-only fix; public pause behavior is unchanged.
- [x] Diff contains no secrets, machine-local paths, or unintended generated files. Contributor-only tests remain excluded from publication.

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/lifecycle-cas-diagnostics/install.sh | bash -s -- --ref fix/lifecycle-cas-diagnostics --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic events when subagent lifecycle transitions fail, including error details.
  * Preserved existing retry and adoption behavior for expected lifecycle contention conflicts.

* **Bug Fixes**
  * Improved lifecycle conflict classification to distinguish expected contention from unexpected failures.
  * Ensured diagnostic recording failures do not interrupt lifecycle cleanup.

* **Tests**
  * Added coverage for lifecycle transition diagnostics, contention classification, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->