### PR TITLE
Ratchet complexity ceiling to 70

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,7 +25,7 @@
     }
   ],
   "rules": {
-    "complexity": ["error", { "max": 80, "variant": "classic" }],
+    "complexity": ["error", { "max": 70, "variant": "classic" }],
     "max-lines": ["error", { "max": 2000, "skipBlankLines": false, "skipComments": false }],
     // Anti-slop rules are adopted one at a time after reviewing their diagnostics.
     "anti-slop/no-chained-type-assertions": "error",

--- a/extensions/subagents/src/runs/background/subagent-runner.js
+++ b/extensions/subagents/src/runs/background/subagent-runner.js
@@ -248,6 +248,34 @@ function writeRunLog(logPath, input) {
 function isPausedStepStatus(status) {
     return status === "paused";
 }
+function normalizeFailedSupervisorPauseResults(results, steps, requesterIndex, fallbackAgent) {
+    for (const result of results) {
+        if (result.interrupted ||
+            result.pause?.kind === "awaiting_supervisor" ||
+            result.pause?.kind === "cohort_pause") {
+            result.output = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+            result.error = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+            result.success = false;
+            result.exitCode = 1;
+            result.terminationReason = result.terminationReason ?? "process_exit";
+            result.interrupted = undefined;
+            result.pause = undefined;
+        }
+    }
+    if (results.length === 0) {
+        results.push({
+            agent: steps[requesterIndex]?.agent ?? fallbackAgent,
+            ...(steps[requesterIndex]?.projectAgent
+                ? { projectAgent: steps[requesterIndex].projectAgent }
+                : {}),
+            output: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
+            error: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
+            success: false,
+            exitCode: 1,
+            terminationReason: "process_exit",
+        });
+    }
+}
 const ASYNC_RUNNER_MISSING_PLAN_ERROR = "Async runner config must include a valid direct plan.";
 const ASYNC_RUNNER_RETIRED_STRUCTURED_OUTPUT_ERROR = "Async runner config contains unsupported structuredOutput or structuredOutputSchema task properties. Structured output contracts are retired; restart with a new direct single or parallel run without those properties.";
 const ASYNC_RUNNER_RETIRED_TIMEOUT_ERROR = "Async runner config contains retired timeoutMs execution control. Configure execution.maxRunTimeMs in <agent-dir>/extensions/subagent/config.json; caller-selected execution timeouts are no longer supported. Restart with a new direct single or parallel run after removing timeoutMs.";
@@ -1326,36 +1354,7 @@ async function runSubagentWithInput(config, plan) {
                 }
                 : step);
             summary = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-            for (const result of results) {
-                if (result.interrupted ||
-                    result.pause?.kind === "awaiting_supervisor" ||
-                    result.pause?.kind === "cohort_pause") {
-                    result.output = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-                    result.error = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-                    result.success = false;
-                    result.exitCode = 1;
-                    result.terminationReason = result.terminationReason ?? "process_exit";
-                    result.interrupted = undefined;
-                    result.pause = undefined;
-                }
-            }
-            if (results.length === 0) {
-                results.push({
-                    agent: statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]?.agent ??
-                        agentName,
-                    ...(statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]?.projectAgent
-                        ? {
-                            projectAgent: statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]
-                                .projectAgent,
-                        }
-                        : {}),
-                    output: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
-                    error: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
-                    success: false,
-                    exitCode: 1,
-                    terminationReason: "process_exit",
-                });
-            }
+            normalizeFailedSupervisorPauseResults(results, statusPayload.steps, statusOwner.supervisorPauseRequest.requesterIndex, agentName);
         }
     }
     const persistTerminalRun = () => {

--- a/extensions/subagents/src/runs/background/subagent-runner.ts
+++ b/extensions/subagents/src/runs/background/subagent-runner.ts
@@ -367,6 +367,42 @@ function isPausedStepStatus(status: RunnerStatusStep["status"]): boolean {
 type SingleStepResult = Awaited<ReturnType<typeof runSingleStep>>;
 type ParallelStepExecutionResult = SingleStepResult & { skipped?: boolean };
 
+function normalizeFailedSupervisorPauseResults(
+  results: StepResult[],
+  steps: RunnerStatusStep[],
+  requesterIndex: number,
+  fallbackAgent: string,
+): void {
+  for (const result of results) {
+    if (
+      result.interrupted ||
+      result.pause?.kind === "awaiting_supervisor" ||
+      result.pause?.kind === "cohort_pause"
+    ) {
+      result.output = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+      result.error = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
+      result.success = false;
+      result.exitCode = 1;
+      result.terminationReason = result.terminationReason ?? "process_exit";
+      result.interrupted = undefined;
+      result.pause = undefined;
+    }
+  }
+  if (results.length === 0) {
+    results.push({
+      agent: steps[requesterIndex]?.agent ?? fallbackAgent,
+      ...(steps[requesterIndex]?.projectAgent
+        ? { projectAgent: steps[requesterIndex].projectAgent }
+        : {}),
+      output: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
+      error: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
+      success: false,
+      exitCode: 1,
+      terminationReason: "process_exit",
+    });
+  }
+}
+
 const ASYNC_RUNNER_MISSING_PLAN_ERROR = "Async runner config must include a valid direct plan.";
 const ASYNC_RUNNER_RETIRED_STRUCTURED_OUTPUT_ERROR =
   "Async runner config contains unsupported structuredOutput or structuredOutputSchema task properties. Structured output contracts are retired; restart with a new direct single or parallel run without those properties.";
@@ -1683,40 +1719,12 @@ async function runSubagentWithInput(
           : step,
       );
       summary = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-      for (const result of results) {
-        if (
-          result.interrupted ||
-          result.pause?.kind === "awaiting_supervisor" ||
-          result.pause?.kind === "cohort_pause"
-        ) {
-          result.output = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-          result.error = ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE;
-          result.success = false;
-          result.exitCode = 1;
-          result.terminationReason = result.terminationReason ?? "process_exit";
-          result.interrupted = undefined;
-          result.pause = undefined;
-        }
-      }
-      if (results.length === 0) {
-        results.push({
-          agent:
-            statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]?.agent ??
-            agentName,
-          ...(statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]?.projectAgent
-            ? {
-                projectAgent:
-                  statusPayload.steps[statusOwner.supervisorPauseRequest.requesterIndex]
-                    .projectAgent,
-              }
-            : {}),
-          output: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
-          error: ASYNC_SUPERVISOR_LIFECYCLE_ERROR_MESSAGE,
-          success: false,
-          exitCode: 1,
-          terminationReason: "process_exit",
-        });
-      }
+      normalizeFailedSupervisorPauseResults(
+        results,
+        statusPayload.steps,
+        statusOwner.supervisorPauseRequest.requesterIndex,
+        agentName,
+      );
     }
   }
   const persistTerminalRun = (): void => {

--- a/extensions/subagents/src/runs/foreground/execution-paths.js
+++ b/extensions/subagents/src/runs/foreground/execution-paths.js
@@ -155,6 +155,14 @@ export function buildParallelModeError(message) {
 function resolveParallelTaskCwd(task, paramsCwd) {
     return resolveChildCwd(paramsCwd, task.cwd);
 }
+function cohortPauseHealth(result, liveProgress) {
+    return {
+        activityState: result?.progress?.activityState ?? liveProgress?.activityState,
+        idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
+        durableAttentionReasons: result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
+        compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+    };
+}
 function findDuplicateParallelOutputPath(input) {
     const seen = new Map();
     for (let index = 0; index < input.tasks.length; index++) {
@@ -218,10 +226,7 @@ async function runForegroundParallelTasks(input) {
                     thinking: result?.thinking,
                     modelIdentity: result?.modelIdentity,
                     modelResolution: result?.modelResolution,
-                    activityState: result?.progress?.activityState ?? liveProgress?.activityState,
-                    idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
-                    durableAttentionReasons: result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
-                    compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+                    ...cohortPauseHealth(result, liveProgress),
                     contextUsage: result?.contextUsage,
                     contextPressure: result?.contextPressure,
                     contextPressureCrossedThresholds: result?.contextPressureCrossedThresholds,
@@ -239,10 +244,7 @@ async function runForegroundParallelTasks(input) {
                 thinking: result?.thinking,
                 modelIdentity: result?.modelIdentity,
                 modelResolution: result?.modelResolution,
-                activityState: result?.progress?.activityState ?? liveProgress?.activityState,
-                idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
-                durableAttentionReasons: result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
-                compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+                ...cohortPauseHealth(result, liveProgress),
                 contextUsage: result?.contextUsage,
                 contextPressure: result?.contextPressure,
                 contextPressureCrossedThresholds: result?.contextPressureCrossedThresholds,

--- a/extensions/subagents/src/runs/foreground/execution-paths.ts
+++ b/extensions/subagents/src/runs/foreground/execution-paths.ts
@@ -390,6 +390,22 @@ function resolveParallelTaskCwd(task: TaskParam, paramsCwd: string): string {
   return resolveChildCwd(paramsCwd, task.cwd);
 }
 
+function cohortPauseHealth(
+  result: SingleResult | undefined,
+  liveProgress: AgentProgress | undefined,
+): Pick<
+  AgentProgress,
+  "activityState" | "idleEpisodeId" | "durableAttentionReasons" | "compaction"
+> {
+  return {
+    activityState: result?.progress?.activityState ?? liveProgress?.activityState,
+    idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
+    durableAttentionReasons:
+      result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
+    compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+  };
+}
+
 function findDuplicateParallelOutputPath(input: {
   tasks: TaskParam[];
   behaviors: ResolvedStepBehavior[];
@@ -484,11 +500,7 @@ async function runForegroundParallelTasks(
           thinking: result?.thinking,
           modelIdentity: result?.modelIdentity,
           modelResolution: result?.modelResolution,
-          activityState: result?.progress?.activityState ?? liveProgress?.activityState,
-          idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
-          durableAttentionReasons:
-            result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
-          compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+          ...cohortPauseHealth(result, liveProgress),
           contextUsage: result?.contextUsage,
           contextPressure: result?.contextPressure,
           contextPressureCrossedThresholds: result?.contextPressureCrossedThresholds,
@@ -508,11 +520,7 @@ async function runForegroundParallelTasks(
         thinking: result?.thinking,
         modelIdentity: result?.modelIdentity,
         modelResolution: result?.modelResolution,
-        activityState: result?.progress?.activityState ?? liveProgress?.activityState,
-        idleEpisodeId: result?.progress?.idleEpisodeId ?? liveProgress?.idleEpisodeId,
-        durableAttentionReasons:
-          result?.progress?.durableAttentionReasons ?? liveProgress?.durableAttentionReasons,
-        compaction: result?.progress?.compaction ?? liveProgress?.compaction,
+        ...cohortPauseHealth(result, liveProgress),
         contextUsage: result?.contextUsage,
         contextPressure: result?.contextPressure,
         contextPressureCrossedThresholds: result?.contextPressureCrossedThresholds,

--- a/extensions/subagents/src/runs/foreground/execution.js
+++ b/extensions/subagents/src/runs/foreground/execution.js
@@ -27,6 +27,37 @@ import { hasUsableSessionArtifact, mergeContextUsageDiagnostics, resolveEffectiv
 import { CONFIGURED_RUN_DEADLINE_TIMEOUT_MESSAGE, applyHealthProgressProjection, clearHealthForProgress, evaluateSingleAcceptance, finalizeForegroundArtifacts, finalizeSingleAttempt, formatTimeoutMessage, prepareForegroundRunFinalization, resolveResultSessionFile, setupForegroundArtifacts, snapshotProgress, snapshotResult, transitionHealthForProgress, } from "./execution-finalization.js";
 import { createHealthTransitionState, resetHealthTransitionState, } from "../shared/health-transition.js";
 const FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE = "Foreground pause process cleanup could not be confirmed. Status does not claim the child stopped.";
+function settleForegroundAcceptance(result, acceptance, options, interruptedAcceptance, healthState) {
+    result.acceptance = acceptance;
+    if (!result.protocolOutputLimit &&
+        !result.timedOut &&
+        !result.interrupted &&
+        options.interruptSignal?.aborted) {
+        result.interrupted = true;
+        result.exitCode = 0;
+        result.error = undefined;
+        result.finalOutput = "Interrupted. Waiting for explicit next action.";
+        result.acceptance = interruptedAcceptance;
+        if (result.progress) {
+            clearHealthForProgress(healthState, result.progress);
+            result.progress.error = undefined;
+        }
+    }
+    const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
+    if (acceptanceFailure &&
+        result.acceptance.explicit &&
+        result.exitCode === 0 &&
+        !result.interrupted &&
+        !result.timedOut &&
+        !result.protocolOutputLimit) {
+        result.exitCode = 1;
+        result.error = composeAcceptanceFailureError(result.error, acceptanceFailure);
+        if (result.progress) {
+            result.progress.status = "failed";
+            result.progress.error = result.error;
+        }
+    }
+}
 function emptyUsage() {
     return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 }
@@ -1320,35 +1351,8 @@ export async function runSync(runtimeCwd, agents, agentName, task, options) {
         runtimeCwd,
     });
     const { interruptedAcceptance, acceptance } = acceptanceEvaluation;
-    result.acceptance = acceptance instanceof Promise ? await acceptance : acceptance;
-    if (!result.protocolOutputLimit &&
-        !result.timedOut &&
-        !result.interrupted &&
-        options.interruptSignal?.aborted) {
-        result.interrupted = true;
-        result.exitCode = 0;
-        result.error = undefined;
-        result.finalOutput = "Interrupted. Waiting for explicit next action.";
-        result.acceptance = interruptedAcceptance;
-        if (result.progress) {
-            clearHealthForProgress(healthState, result.progress);
-            result.progress.error = undefined;
-        }
-    }
-    const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
-    if (acceptanceFailure &&
-        result.acceptance.explicit &&
-        result.exitCode === 0 &&
-        !result.interrupted &&
-        !result.timedOut &&
-        !result.protocolOutputLimit) {
-        result.exitCode = 1;
-        result.error = composeAcceptanceFailureError(result.error, acceptanceFailure);
-        if (result.progress) {
-            result.progress.status = "failed";
-            result.progress.error = result.error;
-        }
-    }
+    const evaluatedAcceptance = acceptance instanceof Promise ? await acceptance : acceptance;
+    settleForegroundAcceptance(result, evaluatedAcceptance, options, interruptedAcceptance, healthState);
     finalizeForegroundArtifacts({
         result,
         options,

--- a/extensions/subagents/src/runs/foreground/execution.ts
+++ b/extensions/subagents/src/runs/foreground/execution.ts
@@ -10,6 +10,7 @@ import type { AgentConfig } from "../../agents/agents.ts";
 import type { ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import {
   type AgentProgress,
+  type AcceptanceLedger,
   type ArtifactPaths,
   type ContextPressureProjection,
   type ContextPressureThreshold,
@@ -147,6 +148,48 @@ import {
 
 const FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE =
   "Foreground pause process cleanup could not be confirmed. Status does not claim the child stopped.";
+
+function settleForegroundAcceptance(
+  result: SingleResult,
+  acceptance: AcceptanceLedger,
+  options: RunSyncOptions,
+  interruptedAcceptance: AcceptanceLedger,
+  healthState: HealthTransitionBox,
+): void {
+  result.acceptance = acceptance;
+  if (
+    !result.protocolOutputLimit &&
+    !result.timedOut &&
+    !result.interrupted &&
+    options.interruptSignal?.aborted
+  ) {
+    result.interrupted = true;
+    result.exitCode = 0;
+    result.error = undefined;
+    result.finalOutput = "Interrupted. Waiting for explicit next action.";
+    result.acceptance = interruptedAcceptance;
+    if (result.progress) {
+      clearHealthForProgress(healthState, result.progress);
+      result.progress.error = undefined;
+    }
+  }
+  const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
+  if (
+    acceptanceFailure &&
+    result.acceptance.explicit &&
+    result.exitCode === 0 &&
+    !result.interrupted &&
+    !result.timedOut &&
+    !result.protocolOutputLimit
+  ) {
+    result.exitCode = 1;
+    result.error = composeAcceptanceFailureError(result.error, acceptanceFailure);
+    if (result.progress) {
+      result.progress.status = "failed";
+      result.progress.error = result.error;
+    }
+  }
+}
 
 function emptyUsage(): Usage {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
@@ -1668,39 +1711,14 @@ export async function runSync(
     runtimeCwd,
   });
   const { interruptedAcceptance, acceptance } = acceptanceEvaluation;
-  result.acceptance = acceptance instanceof Promise ? await acceptance : acceptance;
-  if (
-    !result.protocolOutputLimit &&
-    !result.timedOut &&
-    !result.interrupted &&
-    options.interruptSignal?.aborted
-  ) {
-    result.interrupted = true;
-    result.exitCode = 0;
-    result.error = undefined;
-    result.finalOutput = "Interrupted. Waiting for explicit next action.";
-    result.acceptance = interruptedAcceptance;
-    if (result.progress) {
-      clearHealthForProgress(healthState, result.progress);
-      result.progress.error = undefined;
-    }
-  }
-  const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
-  if (
-    acceptanceFailure &&
-    result.acceptance.explicit &&
-    result.exitCode === 0 &&
-    !result.interrupted &&
-    !result.timedOut &&
-    !result.protocolOutputLimit
-  ) {
-    result.exitCode = 1;
-    result.error = composeAcceptanceFailureError(result.error, acceptanceFailure);
-    if (result.progress) {
-      result.progress.status = "failed";
-      result.progress.error = result.error;
-    }
-  }
+  const evaluatedAcceptance = acceptance instanceof Promise ? await acceptance : acceptance;
+  settleForegroundAcceptance(
+    result,
+    evaluatedAcceptance,
+    options,
+    interruptedAcceptance,
+    healthState,
+  );
 
   finalizeForegroundArtifacts({
     result,

--- a/extensions/subagents/src/runs/foreground/foreground-resume.js
+++ b/extensions/subagents/src/runs/foreground/foreground-resume.js
@@ -132,6 +132,16 @@ function resolveResumeTarget(params, state, options = {}) {
         throw asyncError;
     throw new Error("Run not found. Provide id.");
 }
+function revivedPressureOptions(target, claimedPause) {
+    return {
+        ...(target.kind === "revive" && !claimedPause && "contextPressure" in target
+            ? { contextPressure: target.contextPressure }
+            : {}),
+        ...(target.kind === "revive" && !claimedPause && "contextPressureCrossedThresholds" in target
+            ? { contextPressureCrossedThresholds: target.contextPressureCrossedThresholds }
+            : {}),
+    };
+}
 function claimPausedAwaitingSupervisorTarget(target, continuationRunId, effectiveContextWindow) {
     if (target.kind !== "revive" || !("asyncDir" in target) || !target.asyncDir)
         return undefined;
@@ -887,12 +897,7 @@ export async function resumeAsyncRun(input) {
             ...(target.kind === "revive" && "contextUsage" in target && target.contextUsage
                 ? { contextUsage: target.contextUsage }
                 : {}),
-            ...(target.kind === "revive" && !claimedPause && "contextPressure" in target
-                ? { contextPressure: target.contextPressure }
-                : {}),
-            ...(target.kind === "revive" && !claimedPause && "contextPressureCrossedThresholds" in target
-                ? { contextPressureCrossedThresholds: target.contextPressureCrossedThresholds }
-                : {}),
+            ...revivedPressureOptions(target, claimedPause),
             agentConfig,
             projectAgent: persistedProjectAuthorization?.capture,
             ctx: {

--- a/extensions/subagents/src/runs/foreground/foreground-resume.ts
+++ b/extensions/subagents/src/runs/foreground/foreground-resume.ts
@@ -247,6 +247,23 @@ type PausedContinuationClaim = {
   markSpawned: () => void;
 };
 
+function revivedPressureOptions(
+  target: ResumeSourceTarget,
+  claimedPause: PausedContinuationClaim | undefined,
+): Pick<
+  Parameters<typeof executeAsyncSingle>[1],
+  "contextPressure" | "contextPressureCrossedThresholds"
+> {
+  return {
+    ...(target.kind === "revive" && !claimedPause && "contextPressure" in target
+      ? { contextPressure: target.contextPressure }
+      : {}),
+    ...(target.kind === "revive" && !claimedPause && "contextPressureCrossedThresholds" in target
+      ? { contextPressureCrossedThresholds: target.contextPressureCrossedThresholds }
+      : {}),
+  };
+}
+
 type ContinuationClaimDecision = PausedContinuationClaim | { blockedMessage: string } | undefined;
 
 function claimPausedAwaitingSupervisorTarget(
@@ -1175,12 +1192,7 @@ export async function resumeAsyncRun(input: {
       // A same-segment revival restores the latest display projection and the
       // machine deduplication history independently. A claimed pause creates a
       // new continuation segment and intentionally starts with neither.
-      ...(target.kind === "revive" && !claimedPause && "contextPressure" in target
-        ? { contextPressure: target.contextPressure }
-        : {}),
-      ...(target.kind === "revive" && !claimedPause && "contextPressureCrossedThresholds" in target
-        ? { contextPressureCrossedThresholds: target.contextPressureCrossedThresholds }
-        : {}),
+      ...revivedPressureOptions(target, claimedPause),
       agentConfig,
       projectAgent: persistedProjectAuthorization?.capture,
       ctx: {

--- a/extensions/subagents/src/runs/foreground/subagent-executor.js
+++ b/extensions/subagents/src/runs/foreground/subagent-executor.js
@@ -589,6 +589,9 @@ async function executeSteerAction(params, ctx, deps) {
         projectLookup: privateProjectLookup,
     });
 }
+function isPersistedCancellationState(status) {
+    return (status?.state === "paused" || status?.state === "continued" || status?.state === "cancelled");
+}
 async function executeInterruptAction(params, ctx, deps) {
     deps.state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
     const requestedProjectLookup = lookupPrivateProjectActionReference(params);
@@ -783,9 +786,7 @@ async function executeInterruptAction(params, ctx, deps) {
         else {
             const pausedAsyncDir = pausedForegroundStatusPath(resolved.id);
             const persistedStatus = readStatus(pausedAsyncDir);
-            if (persistedStatus?.state === "paused" ||
-                persistedStatus?.state === "continued" ||
-                persistedStatus?.state === "cancelled") {
+            if (isPersistedCancellationState(persistedStatus)) {
                 return cancelPersistedPausedForegroundRun(deps.state, pausedAsyncDir, resolved.id, params.index);
             }
         }
@@ -817,9 +818,7 @@ async function executeInterruptAction(params, ctx, deps) {
         targetRunId?.trim() &&
         asyncInterruptTarget.location.asyncDir) {
         const persistedStatus = readStatus(asyncInterruptTarget.location.asyncDir);
-        if (persistedStatus?.state === "paused" ||
-            persistedStatus?.state === "continued" ||
-            persistedStatus?.state === "cancelled") {
+        if (isPersistedCancellationState(persistedStatus)) {
             return cancelPersistedPausedForegroundRun(deps.state, asyncInterruptTarget.location.asyncDir, asyncInterruptTarget.id, params.index);
         }
     }

--- a/extensions/subagents/src/runs/foreground/subagent-executor.ts
+++ b/extensions/subagents/src/runs/foreground/subagent-executor.ts
@@ -112,6 +112,7 @@ import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/
 import { inspectSubagentStatus } from "../background/run-status.ts";
 import {
   type AcceptanceInput,
+  type AsyncStatus,
   type ControlConfig,
   type Details,
   type ExtensionConfig,
@@ -947,6 +948,12 @@ async function executeSteerAction(
   });
 }
 
+function isPersistedCancellationState(status: AsyncStatus | null | undefined): boolean {
+  return (
+    status?.state === "paused" || status?.state === "continued" || status?.state === "cancelled"
+  );
+}
+
 async function executeInterruptAction(
   params: SubagentParamsLike,
   ctx: ExtensionContext,
@@ -1170,11 +1177,7 @@ async function executeInterruptAction(
     } else {
       const pausedAsyncDir = pausedForegroundStatusPath(resolved.id);
       const persistedStatus = readStatus(pausedAsyncDir);
-      if (
-        persistedStatus?.state === "paused" ||
-        persistedStatus?.state === "continued" ||
-        persistedStatus?.state === "cancelled"
-      ) {
+      if (isPersistedCancellationState(persistedStatus)) {
         return cancelPersistedPausedForegroundRun(
           deps.state,
           pausedAsyncDir,
@@ -1218,11 +1221,7 @@ async function executeInterruptAction(
     asyncInterruptTarget.location.asyncDir
   ) {
     const persistedStatus = readStatus(asyncInterruptTarget.location.asyncDir);
-    if (
-      persistedStatus?.state === "paused" ||
-      persistedStatus?.state === "continued" ||
-      persistedStatus?.state === "cancelled"
-    ) {
+    if (isPersistedCancellationState(persistedStatus)) {
       return cancelPersistedPausedForegroundRun(
         deps.state,
         asyncInterruptTarget.location.asyncDir,

--- a/extensions/subagents/src/runs/shared/acceptance.js
+++ b/extensions/subagents/src/runs/shared/acceptance.js
@@ -203,6 +203,44 @@ function explicitAcceptanceCanDisable(explicit) {
         typeof explicit.reason === "string" &&
         explicit.reason.trim().length > 0);
 }
+function validateAcceptanceCriteria(value, pathLabel, errors) {
+    if (value.criteria !== undefined && !Array.isArray(value.criteria))
+        errors.push(`${pathLabel}.criteria must be an array.`);
+    if (Array.isArray(value.criteria)) {
+        for (const [index, criterion] of value.criteria.entries()) {
+            if (typeof criterion === "string")
+                continue;
+            const criterionPath = `${pathLabel}.criteria[${index}]`;
+            if (!criterion || typeof criterion !== "object" || Array.isArray(criterion)) {
+                errors.push(`${criterionPath} must be a string or an object.`);
+                continue;
+            }
+            const gate = criterion;
+            for (const key of Object.keys(gate)) {
+                if (!ACCEPTANCE_GATE_KEYS.has(key))
+                    errors.push(`${criterionPath}.${key} is not supported.`);
+            }
+            if (typeof gate.id !== "string" || !gate.id.trim())
+                errors.push(`${criterionPath}.id is required.`);
+            if (typeof gate.must !== "string" || !gate.must.trim())
+                errors.push(`${criterionPath}.must is required.`);
+            if (gate.evidence !== undefined && !Array.isArray(gate.evidence))
+                errors.push(`${criterionPath}.evidence must be an array.`);
+            if (Array.isArray(gate.evidence)) {
+                for (const [evidenceIndex, item] of gate.evidence.entries()) {
+                    if (typeof item !== "string" || !VALID_EVIDENCE.has(item)) {
+                        errors.push(`${criterionPath}.evidence[${evidenceIndex}] is not a supported evidence kind.`);
+                    }
+                }
+            }
+            if (gate.severity !== undefined &&
+                gate.severity !== "required" &&
+                gate.severity !== "recommended") {
+                errors.push(`${criterionPath}.severity must be required or recommended.`);
+            }
+        }
+    }
+}
 function validateAcceptanceReview(reviewInput, pathLabel, errors) {
     if (reviewInput === undefined || reviewInput === false)
         return;
@@ -251,42 +289,7 @@ export function validateAcceptanceInput(input, pathLabel = "acceptance") {
     }
     if (value.reason !== undefined && typeof value.reason !== "string")
         errors.push(`${pathLabel}.reason must be a string.`);
-    if (value.criteria !== undefined && !Array.isArray(value.criteria))
-        errors.push(`${pathLabel}.criteria must be an array.`);
-    if (Array.isArray(value.criteria)) {
-        for (const [index, criterion] of value.criteria.entries()) {
-            if (typeof criterion === "string")
-                continue;
-            const criterionPath = `${pathLabel}.criteria[${index}]`;
-            if (!criterion || typeof criterion !== "object" || Array.isArray(criterion)) {
-                errors.push(`${criterionPath} must be a string or an object.`);
-                continue;
-            }
-            const gate = criterion;
-            for (const key of Object.keys(gate)) {
-                if (!ACCEPTANCE_GATE_KEYS.has(key))
-                    errors.push(`${criterionPath}.${key} is not supported.`);
-            }
-            if (typeof gate.id !== "string" || !gate.id.trim())
-                errors.push(`${criterionPath}.id is required.`);
-            if (typeof gate.must !== "string" || !gate.must.trim())
-                errors.push(`${criterionPath}.must is required.`);
-            if (gate.evidence !== undefined && !Array.isArray(gate.evidence))
-                errors.push(`${criterionPath}.evidence must be an array.`);
-            if (Array.isArray(gate.evidence)) {
-                for (const [evidenceIndex, item] of gate.evidence.entries()) {
-                    if (typeof item !== "string" || !VALID_EVIDENCE.has(item)) {
-                        errors.push(`${criterionPath}.evidence[${evidenceIndex}] is not a supported evidence kind.`);
-                    }
-                }
-            }
-            if (gate.severity !== undefined &&
-                gate.severity !== "required" &&
-                gate.severity !== "recommended") {
-                errors.push(`${criterionPath}.severity must be required or recommended.`);
-            }
-        }
-    }
+    validateAcceptanceCriteria(value, pathLabel, errors);
     if (Array.isArray(value.evidence)) {
         for (const [index, item] of value.evidence.entries()) {
             if (typeof item !== "string" || !VALID_EVIDENCE.has(item)) {

--- a/extensions/subagents/src/runs/shared/acceptance.ts
+++ b/extensions/subagents/src/runs/shared/acceptance.ts
@@ -297,6 +297,52 @@ function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {
   );
 }
 
+function validateAcceptanceCriteria(
+  value: Record<string, unknown>,
+  pathLabel: string,
+  errors: string[],
+): void {
+  if (value.criteria !== undefined && !Array.isArray(value.criteria))
+    errors.push(`${pathLabel}.criteria must be an array.`);
+  if (Array.isArray(value.criteria)) {
+    for (const [index, criterion] of value.criteria.entries()) {
+      if (typeof criterion === "string") continue;
+      const criterionPath = `${pathLabel}.criteria[${index}]`;
+      if (!criterion || typeof criterion !== "object" || Array.isArray(criterion)) {
+        errors.push(`${criterionPath} must be a string or an object.`);
+        continue;
+      }
+      const gate = criterion as Record<string, unknown>;
+      for (const key of Object.keys(gate)) {
+        if (!ACCEPTANCE_GATE_KEYS.has(key))
+          errors.push(`${criterionPath}.${key} is not supported.`);
+      }
+      if (typeof gate.id !== "string" || !gate.id.trim())
+        errors.push(`${criterionPath}.id is required.`);
+      if (typeof gate.must !== "string" || !gate.must.trim())
+        errors.push(`${criterionPath}.must is required.`);
+      if (gate.evidence !== undefined && !Array.isArray(gate.evidence))
+        errors.push(`${criterionPath}.evidence must be an array.`);
+      if (Array.isArray(gate.evidence)) {
+        for (const [evidenceIndex, item] of gate.evidence.entries()) {
+          if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {
+            errors.push(
+              `${criterionPath}.evidence[${evidenceIndex}] is not a supported evidence kind.`,
+            );
+          }
+        }
+      }
+      if (
+        gate.severity !== undefined &&
+        gate.severity !== "required" &&
+        gate.severity !== "recommended"
+      ) {
+        errors.push(`${criterionPath}.severity must be required or recommended.`);
+      }
+    }
+  }
+}
+
 function validateAcceptanceReview(reviewInput: unknown, pathLabel: string, errors: string[]): void {
   if (reviewInput === undefined || reviewInput === false) return;
   if (!reviewInput || typeof reviewInput !== "object" || Array.isArray(reviewInput)) {
@@ -346,45 +392,7 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
   }
   if (value.reason !== undefined && typeof value.reason !== "string")
     errors.push(`${pathLabel}.reason must be a string.`);
-  if (value.criteria !== undefined && !Array.isArray(value.criteria))
-    errors.push(`${pathLabel}.criteria must be an array.`);
-  if (Array.isArray(value.criteria)) {
-    for (const [index, criterion] of value.criteria.entries()) {
-      if (typeof criterion === "string") continue;
-      const criterionPath = `${pathLabel}.criteria[${index}]`;
-      if (!criterion || typeof criterion !== "object" || Array.isArray(criterion)) {
-        errors.push(`${criterionPath} must be a string or an object.`);
-        continue;
-      }
-      const gate = criterion as Record<string, unknown>;
-      for (const key of Object.keys(gate)) {
-        if (!ACCEPTANCE_GATE_KEYS.has(key))
-          errors.push(`${criterionPath}.${key} is not supported.`);
-      }
-      if (typeof gate.id !== "string" || !gate.id.trim())
-        errors.push(`${criterionPath}.id is required.`);
-      if (typeof gate.must !== "string" || !gate.must.trim())
-        errors.push(`${criterionPath}.must is required.`);
-      if (gate.evidence !== undefined && !Array.isArray(gate.evidence))
-        errors.push(`${criterionPath}.evidence must be an array.`);
-      if (Array.isArray(gate.evidence)) {
-        for (const [evidenceIndex, item] of gate.evidence.entries()) {
-          if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {
-            errors.push(
-              `${criterionPath}.evidence[${evidenceIndex}] is not a supported evidence kind.`,
-            );
-          }
-        }
-      }
-      if (
-        gate.severity !== undefined &&
-        gate.severity !== "required" &&
-        gate.severity !== "recommended"
-      ) {
-        errors.push(`${criterionPath}.severity must be required or recommended.`);
-      }
-    }
-  }
+  validateAcceptanceCriteria(value, pathLabel, errors);
   if (Array.isArray(value.evidence)) {
     for (const [index, item] of value.evidence.entries()) {
       if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {

--- a/extensions/subagents/test/integration/async-lifecycle-diagnostics.test.ts
+++ b/extensions/subagents/test/integration/async-lifecycle-diagnostics.test.ts
@@ -22,10 +22,12 @@ import {
   ASYNC_DIR,
   type AsyncResultPayload,
   type AsyncStatusPayload,
+  executeAsyncParallel,
   executeAsyncSingle,
   startedMockPiPids,
   waitForAsyncResultFile,
   waitForAsyncStatusPredicate,
+  waitForMarker,
   waitForMockPiCall,
   waitForPidsToExit,
 } from "../support/async-execution-helpers.ts";
@@ -254,6 +256,158 @@ async function runLifecycleFaultCase(
   }
 }
 
+async function runParallelLifecycleFaultCase(
+  tempDir: string,
+  mockPi: MockPi,
+): Promise<{ payload: AsyncResultPayload; status: AsyncStatusPayload; diagnostics: JsonRecord[] }> {
+  const id = `async-lifecycle-diagnostic-parallel-${nextRun++}`;
+  const asyncDir = path.join(ASYNC_DIR, id);
+  const markerPath = path.join(tempDir, `${id}-fault.json`);
+  const settledSiblingMarker = path.join(tempDir, `${id}-settled-sibling`);
+  const pauseRequestMarker = path.join(tempDir, `${id}-pause-request`);
+  const cohortReadyMarker = path.join(tempDir, `${id}-cohort-ready`);
+  const releasePauseMarker = path.join(tempDir, `${id}-release-pause`);
+  const causeMarker = `TLH-LIFECYCLE-CAUSE-${id}`;
+  const previousEnvironment = setFaultEnvironment({
+    asyncDir,
+    generation: 1,
+    markerPath,
+    causeMarker,
+  });
+  let runnerPid: number | undefined;
+  let childPids: number[] = [];
+  const existingChildPids = new Set(startedMockPiPids(mockPi));
+  try {
+    mockPi.onCall({
+      matchArgIncludes: "settled sibling",
+      output: "settled sibling output",
+      writeMarkerAfter: settledSiblingMarker,
+    });
+    mockPi.onCall({
+      matchArgIncludes: "request supervisor",
+      waitForMarker: settledSiblingMarker,
+      writeMarker: pauseRequestMarker,
+      steps: [
+        {
+          waitForMarker: releasePauseMarker,
+          jsonl: [
+            events.toolStart("contact_supervisor", {
+              reason: "need_decision",
+              message: "Need a supervisor decision",
+            }),
+          ],
+        },
+      ],
+      ignoreSigint: true,
+      ignoreSigterm: true,
+      keepAliveAfterFinalMessageMs: 30_000,
+    });
+    mockPi.onCall({
+      matchArgIncludes: "cohort child",
+      waitForMarker: pauseRequestMarker,
+      steps: [
+        {
+          writeMarker: cohortReadyMarker,
+          waitForMarker: releasePauseMarker,
+        },
+      ],
+      ignoreSigint: true,
+      ignoreSigterm: true,
+      keepAliveAfterFinalMessageMs: 30_000,
+    });
+    const started = executeAsyncParallel!(id, {
+      tasks: [
+        { agent: "settled", task: "settled sibling" },
+        { agent: "requester", task: "request supervisor" },
+        { agent: "cohort", task: "cohort child" },
+      ],
+      concurrency: 3,
+      agents: [makeAgent("settled"), makeAgent("requester"), makeAgent("cohort")],
+      ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+      artifactConfig: {
+        enabled: false,
+        includeInput: false,
+        includeOutput: false,
+        includeJsonl: false,
+        includeMetadata: false,
+        cleanupDays: 7,
+      },
+      shareEnabled: false,
+      sessionRoot: path.join(tempDir, "sessions"),
+      maxSubagentDepth: 2,
+    });
+    assert.equal(started.isError, undefined);
+
+    const runningStatus = await waitForAsyncStatusPredicate(
+      asyncDir,
+      (status) => status.state === "running" && typeof status.pid === "number",
+      "parallel lifecycle fault runner startup",
+    );
+    runnerPid = runningStatus.pid;
+    await waitForMarker(cohortReadyMarker);
+    await waitForAsyncStatusPredicate(
+      asyncDir,
+      (status) => status.steps?.[0]?.status === "complete",
+      "parallel lifecycle fault settled sibling completion",
+    );
+    fs.writeFileSync(releasePauseMarker, "", "utf-8");
+    childPids = startedMockPiPids(mockPi).filter((pid) => !existingChildPids.has(pid));
+
+    const resultPath = await waitForAsyncResultFile(id, scaleTestTimeout(30_000));
+    const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+    const status = JSON.parse(
+      fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"),
+    ) as AsyncStatusPayload;
+    assert.equal(payload.state, "failed");
+    assert.equal(status.state, "failed");
+    const fault = JSON.parse(fs.readFileSync(markerPath, "utf-8")) as JsonRecord;
+    assert.equal(fault.generation, 1);
+    assert.equal(fault.state, "pausing");
+    assert.equal(path.dirname(path.resolve(String(fault.filePath))), asyncDir);
+    assert.match(path.basename(String(fault.filePath)), /^\.status\.json\..+\.tmp$/);
+
+    const diagnostics = lifecycleDiagnostics(asyncDir);
+    assert.equal(diagnostics.length, 1);
+    assert.equal(diagnostics[0]?.phase, "running->pausing");
+    assert.match(String(diagnostics[0]?.cause), new RegExp(causeMarker));
+    await waitForPidsToExit(
+      [runnerPid, ...childPids],
+      `parallel lifecycle fault processes ${id}`,
+      scaleTestTimeout(15_000),
+    );
+    return { payload, status, diagnostics };
+  } finally {
+    if (runnerPid === undefined) {
+      try {
+        const status = JSON.parse(
+          fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"),
+        ) as AsyncStatusPayload;
+        runnerPid = status.pid;
+      } catch {
+        // The runner may have failed before creating its status file.
+      }
+    }
+    childPids = [
+      ...new Set([
+        ...childPids,
+        ...startedMockPiPids(mockPi).filter((pid) => !existingChildPids.has(pid)),
+      ]),
+    ];
+    const knownPids = [runnerPid, ...childPids];
+    killPids(knownPids);
+    try {
+      await waitForPidsToExit(
+        knownPids,
+        `parallel lifecycle fault cleanup ${id}`,
+        scaleTestTimeout(5_000),
+      );
+    } catch {
+      // Do not mask the original test failure with best-effort process cleanup.
+    }
+    restoreFaultEnvironment(previousEnvironment);
+  }
+}
+
 describe("async supervisor lifecycle transition diagnostics", () => {
   let tempDir: string;
   let mockPi: MockPi;
@@ -303,6 +457,21 @@ describe("async supervisor lifecycle transition diagnostics", () => {
       assert.equal(result.payload.pause, undefined);
       assert.equal(result.status.pause, undefined);
       assert.equal(result.status.steps?.[0]?.processCleanup?.terminated, true);
+      const [normalized] = result.payload.results;
+      assert.equal(normalized?.agent, "worker");
+      assert.equal(
+        normalized?.output,
+        "Async supervisor lifecycle update failed. The run was stopped safely and marked failed.",
+      );
+      assert.equal(
+        normalized?.error,
+        "Async supervisor lifecycle update failed. The run was stopped safely and marked failed.",
+      );
+      assert.equal(normalized?.success, false);
+      assert.equal(normalized?.exitCode, 1);
+      assert.equal(normalized?.interrupted, undefined);
+      assert.equal(normalized?.pause, undefined);
+      assert.equal(normalized?.terminationReason, "paused");
     },
   );
 
@@ -327,6 +496,44 @@ describe("async supervisor lifecycle transition diagnostics", () => {
       assert.equal(result.status.pause?.kind, "awaiting_supervisor");
       assert.equal(result.status.steps?.[0]?.processCleanup?.terminated, true);
       assert.equal(result.diagnostics[0]?.phase, "pausing->paused");
+    },
+  );
+
+  it(
+    "normalizes only paused children after a failed parallel supervisor finalization",
+    {
+      skip:
+        process.platform === "win32"
+          ? "cross-process supervisor pause delivery unreliable on Windows CI"
+          : undefined,
+    },
+    async () => {
+      const result = await runParallelLifecycleFaultCase(tempDir, mockPi);
+      const lifecycleError =
+        "Async supervisor lifecycle update failed. The run was stopped safely and marked failed.";
+      assert.deepEqual(
+        result.status.steps?.map((step) => step.status),
+        ["complete", "failed", "failed"],
+      );
+      assert.equal(result.payload.results.length, 3);
+      const settled = result.payload.results.find((child) => child.agent === "settled");
+      assert.ok(settled);
+      assert.equal(settled.output, "settled sibling output");
+      assert.equal(settled.success, true);
+      assert.equal(settled.exitCode, 0);
+      assert.equal(settled.interrupted, undefined);
+      assert.equal(settled.pause, undefined);
+      for (const agent of ["requester", "cohort"]) {
+        const child = result.payload.results.find((candidate) => candidate.agent === agent);
+        assert.ok(child);
+        assert.equal(child.output, lifecycleError);
+        assert.equal(child.error, lifecycleError);
+        assert.equal(child.success, false);
+        assert.equal(child.exitCode, 1);
+        assert.equal(child.interrupted, undefined);
+        assert.equal(child.pause, undefined);
+        assert.equal(child.terminationReason, "paused");
+      }
     },
   );
 

--- a/extensions/subagents/test/integration/child-process-hardening.test.ts
+++ b/extensions/subagents/test/integration/child-process-hardening.test.ts
@@ -50,6 +50,11 @@ interface ForegroundExecutionModule {
     interrupted?: boolean;
     progress: { status: string };
     transcriptPath?: string;
+    artifactPaths?: { outputPath: string; metadataPath: string };
+    acceptance?: {
+      status?: string;
+      runtimeChecks?: Array<{ id?: string; status?: string }>;
+    };
   }>;
 }
 
@@ -284,6 +289,7 @@ describe(
       { skip: process.platform === "win32" ? "POSIX signal escalation fixture" : undefined },
       async () => {
         const oversizedLine = `FG_PROTOCOL_BEGIN_${"x".repeat(MAX_CHILD_PENDING_LINE_BYTES)}_FG_PROTOCOL_END`;
+        const artifactsDir = path.join(tempDir, "foreground-protocol-artifacts");
         mockPi.onCall({
           rawStdout: oversizedLine,
           keepAliveAfterFinalMessageMs: 60_000,
@@ -297,6 +303,9 @@ describe(
             "Trigger overflow",
             {
               runId: "foreground-protocol-overflow",
+              artifactsDir,
+              artifactConfig: { enabled: true, includeOutput: true, includeMetadata: true },
+              acceptance: { level: "checked", criteria: ["The overflow is reported"] },
             },
           ),
           10_000,
@@ -308,6 +317,18 @@ describe(
         assert.equal(result.progress.status, "failed");
         assert.match(result.error ?? "", /protocol_output_limit/);
         assert.match(result.finalOutput ?? "", /protocol_output_limit/);
+        assert.equal(result.acceptance?.status, "rejected");
+        assert.equal(result.acceptance?.runtimeChecks?.[0]?.id, "attestation");
+        assert.ok(result.artifactPaths, "expected protocol overflow artifacts");
+        assert.equal(
+          fs.readFileSync(result.artifactPaths.outputPath, "utf-8"),
+          `${result.error}\n\nOutput:\n${result.finalOutput}`,
+        );
+        const metadata = JSON.parse(
+          fs.readFileSync(result.artifactPaths.metadataPath, "utf-8"),
+        ) as { exitCode?: number; terminationReason?: string };
+        assert.equal(metadata.exitCode, result.exitCode);
+        assert.equal(metadata.terminationReason, result.terminationReason);
         const pid = startedMockPiPids(mockPi)[0];
         assert.ok(pid);
         const signals = fs.readFileSync(path.join(mockPi.dir, `signals-${pid}.jsonl`), "utf8");
@@ -321,27 +342,53 @@ describe(
       { skip: process.platform === "win32" ? "POSIX signal escalation fixture" : undefined },
       async () => {
         const oversizedLine = `TIMEOUT_WON_FIRST_${"x".repeat(MAX_CHILD_PENDING_LINE_BYTES)}`;
+        const releaseMarker = path.join(tempDir, "foreground-timeout-release");
+        const artifactsDir = path.join(tempDir, "foreground-timeout-artifacts");
+        let resolveTimeout!: () => void;
+        const timeoutObserved = new Promise<void>((resolve) => {
+          resolveTimeout = resolve;
+        });
         mockPi.onCall({
-          delay: 100,
+          waitForMarker: releaseMarker,
           rawStdout: oversizedLine,
           keepAliveAfterFinalMessageMs: 10_000,
           ignoreSigint: true,
           ignoreSigterm: true,
         });
-        const result = await within(
-          execution!.runSync(tempDir, [makeAgent("worker")], "worker", "Timeout first", {
+        const resultPromise = execution!.runSync(
+          tempDir,
+          [makeAgent("worker")],
+          "worker",
+          "Timeout first",
+          {
             runId: "foreground-timeout-before-overflow",
             timeoutMs: 50,
-          }),
-          10_000,
-          "foreground timeout precedence run",
+            artifactsDir,
+            artifactConfig: { enabled: true, includeOutput: true, includeMetadata: true },
+            acceptance: { level: "checked", criteria: ["The timeout remains authoritative"] },
+            onUpdate: (update: { details?: { results?: Array<{ timedOut?: boolean }> } }) => {
+              if (update.details?.results?.[0]?.timedOut) resolveTimeout();
+            },
+          },
         );
+        await within(timeoutObserved, 10_000, "foreground timeout observation");
+        fs.writeFileSync(releaseMarker, "", "utf-8");
+        const result = await within(resultPromise, 10_000, "foreground timeout precedence run");
 
         assert.equal(result.exitCode, 1);
         assert.equal(result.timedOut, true);
         assert.equal(result.terminationReason, "timed_out");
         assert.equal(result.protocolOutputLimit, undefined);
+        assert.equal(result.acceptance?.status, "rejected");
+        assert.equal(result.acceptance?.runtimeChecks?.[0]?.id, "timeout");
         assert.match(result.error ?? "", /timed out/i);
+        assert.ok(result.artifactPaths, "expected timeout precedence artifacts");
+        assert.equal(fs.readFileSync(result.artifactPaths.outputPath, "utf-8"), result.finalOutput);
+        const metadata = JSON.parse(
+          fs.readFileSync(result.artifactPaths.metadataPath, "utf-8"),
+        ) as { exitCode?: number; terminationReason?: string };
+        assert.equal(metadata.exitCode, result.exitCode);
+        assert.equal(metadata.terminationReason, result.terminationReason);
       },
     );
 

--- a/extensions/subagents/test/integration/native-result-lifecycle-revival.test.ts
+++ b/extensions/subagents/test/integration/native-result-lifecycle-revival.test.ts
@@ -987,6 +987,205 @@ describe(
       }
     });
 
+    it("resume action preserves independent same-segment pressure diagnostics", async () => {
+      const contextUsage = { contextTokens: 400, contextWindow: 1_000 };
+      const contextPressure = {
+        severity: "warning" as const,
+        crossedThreshold: "warning" as const,
+        contextTokens: 850,
+        contextWindow: 1_000,
+        contextPercent: 85,
+        remainingTokens: 150,
+        warnedAt: 123,
+      };
+      const contextPressureCrossedThresholds = ["warning", "critical"] as const;
+      const cases = [
+        { label: "pressure-only", contextPressure },
+        { label: "history-only", contextPressureCrossedThresholds },
+        { label: "both", contextPressure, contextPressureCrossedThresholds },
+        { label: "neither" },
+      ] as const;
+
+      // Public target normalization drops present-but-undefined diagnostic fields before this
+      // seam; there is no public hook that can distinguish that case, so it is not fabricated.
+      for (const currentCase of cases) {
+        const runId = `resume-pressure-${currentCase.label}-${Date.now().toString(36)}`;
+        const sessionFile = path.join(tempDir, `${runId}.jsonl`);
+        const asyncDir = path.join(ASYNC_DIR, runId);
+        const { executor, state } = makeExecutor();
+        let revivedId: string | undefined;
+        fs.writeFileSync(sessionFile, "", "utf-8");
+        state.foregroundRuns.set(runId, {
+          runId,
+          mode: "single",
+          cwd: tempDir,
+          updatedAt: 1,
+          children: [
+            {
+              agent: "worker",
+              index: 0,
+              status: "completed",
+              sessionFile,
+              contextUsage,
+              ...("contextPressure" in currentCase
+                ? { contextPressure: currentCase.contextPressure }
+                : {}),
+              ...("contextPressureCrossedThresholds" in currentCase
+                ? { contextPressureCrossedThresholds: currentCase.contextPressureCrossedThresholds }
+                : {}),
+            },
+          ],
+        });
+        mockPi.onCall({ output: `revived ${currentCase.label}` });
+        try {
+          const result = await executor.execute(
+            `resume-pressure-${currentCase.label}`,
+            { action: "resume", id: runId, message: "Continue the diagnostic check." },
+            new AbortController().signal,
+            undefined,
+            makeMinimalCtx(tempDir),
+          );
+
+          assert.equal(result.isError, undefined, result.content[0]?.text ?? "");
+          revivedId = await waitForRevivedAsyncResult(result);
+          const status = readAsyncStatusJson<{
+            steps?: Array<{
+              contextUsage?: { contextTokens?: number; contextWindow?: number };
+              contextPressure?: typeof contextPressure;
+              contextPressureCrossedThresholds?: string[];
+            }>;
+          }>(revivedId);
+          const step = status.steps?.[0];
+          const expectedPressure =
+            "contextPressure" in currentCase ? currentCase.contextPressure : undefined;
+          const expectedHistory =
+            "contextPressureCrossedThresholds" in currentCase
+              ? currentCase.contextPressureCrossedThresholds
+              : undefined;
+          assert.equal(
+            Object.hasOwn(step ?? {}, "contextPressure"),
+            expectedPressure !== undefined,
+          );
+          assert.equal(
+            Object.hasOwn(step ?? {}, "contextPressureCrossedThresholds"),
+            expectedHistory !== undefined,
+          );
+          assert.deepEqual(step?.contextPressure, expectedPressure);
+          assert.deepEqual(step?.contextPressureCrossedThresholds, expectedHistory);
+          assert.equal(Object.hasOwn(step ?? {}, "contextUsage"), true);
+        } finally {
+          if (revivedId) {
+            fs.rmSync(path.join(ASYNC_DIR, revivedId), { recursive: true, force: true });
+            fs.rmSync(path.join(RESULTS_DIR, `${revivedId}.json`), { force: true });
+          }
+          fs.rmSync(asyncDir, { recursive: true, force: true });
+          fs.rmSync(sessionFile, { force: true });
+        }
+      }
+    });
+
+    it("resume action clears both pressure diagnostics for a claimed paused continuation", async () => {
+      const runId = `resume-pressure-claimed-${Date.now().toString(36)}`;
+      const asyncDir = path.join(ASYNC_DIR, runId);
+      const sessionFile = path.join(tempDir, `${runId}.jsonl`);
+      const contextUsage = { contextTokens: 400, contextWindow: 1_000 };
+      const contextPressure = {
+        severity: "warning" as const,
+        crossedThreshold: "warning" as const,
+        contextTokens: 850,
+        contextWindow: 1_000,
+        contextPercent: 85,
+        remainingTokens: 150,
+        warnedAt: 123,
+      };
+      const contextPressureCrossedThresholds = ["warning", "critical"] as const;
+      let revivedId: string | undefined;
+      try {
+        fs.mkdirSync(asyncDir, { recursive: true });
+        fs.writeFileSync(sessionFile, "", "utf-8");
+        fs.writeFileSync(
+          path.join(asyncDir, "status.json"),
+          JSON.stringify(
+            {
+              runId,
+              mode: "single",
+              state: "paused",
+              startedAt: 100,
+              lastUpdate: 200,
+              cwd: tempDir,
+              sessionFile,
+              pause: { kind: "awaiting_supervisor" },
+              steps: [
+                {
+                  agent: "worker",
+                  status: "paused",
+                  sessionFile,
+                  pause: { kind: "awaiting_supervisor" },
+                  contextUsage,
+                  contextPressure,
+                  contextPressureCrossedThresholds,
+                },
+              ],
+            },
+            null,
+            2,
+          ),
+          "utf-8",
+        );
+        const { executor, state } = makeExecutor();
+        state.foregroundRuns.set(runId, {
+          runId,
+          mode: "single",
+          cwd: tempDir,
+          updatedAt: 1,
+          children: [
+            {
+              agent: "worker",
+              index: 0,
+              status: "paused",
+              sessionFile,
+              pause: { kind: "awaiting_supervisor" },
+              contextUsage,
+              contextPressure,
+              contextPressureCrossedThresholds,
+            },
+          ],
+        });
+        mockPi.onCall({ output: "revived claimed continuation" });
+
+        const result = await executor.execute(
+          "resume-pressure-claimed",
+          { action: "resume", id: runId, message: "Continue the claimed diagnostic check." },
+          new AbortController().signal,
+          undefined,
+          makeMinimalCtx(tempDir),
+        );
+
+        assert.equal(result.isError, undefined, result.content[0]?.text ?? "");
+        revivedId = await waitForRevivedAsyncResult(result);
+        const status = readAsyncStatusJson<{
+          steps?: Array<{
+            contextUsage?: { contextTokens?: number; contextWindow?: number };
+            contextPressure?: unknown;
+            contextPressureCrossedThresholds?: unknown;
+          }>;
+        }>(revivedId);
+        const step = status.steps?.[0];
+        assert.equal(Object.hasOwn(step ?? {}, "contextPressure"), false);
+        assert.equal(Object.hasOwn(step ?? {}, "contextPressureCrossedThresholds"), false);
+        assert.equal(step?.contextPressure, undefined);
+        assert.equal(step?.contextPressureCrossedThresholds, undefined);
+        assert.equal(Object.hasOwn(step ?? {}, "contextUsage"), true);
+      } finally {
+        if (revivedId) {
+          fs.rmSync(path.join(ASYNC_DIR, revivedId), { recursive: true, force: true });
+          fs.rmSync(path.join(RESULTS_DIR, `${revivedId}.json`), { force: true });
+        }
+        fs.rmSync(asyncDir, { recursive: true, force: true });
+        fs.rmSync(sessionFile, { force: true });
+      }
+    });
+
     it("resume of a completed foreground child tolerates missing lifecycle status without mutation", async () => {
       mockPi.onCall({ output: "revived from remembered foreground state" });
       const runId = `resume-foreground-missing-status-${Date.now()}`;

--- a/extensions/subagents/test/integration/parallel-execution.test.ts
+++ b/extensions/subagents/test/integration/parallel-execution.test.ts
@@ -12,6 +12,7 @@ import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { ASYNC_DIR, type AgentProgress, type SingleResult } from "../../src/shared/types.ts";
 import type { MockPi } from "../support/helpers.ts";
 import {
   createEventBus,
@@ -20,6 +21,7 @@ import {
   events,
   makeAgent,
   makeAgentConfigs,
+  makeAgentProgress,
   makeMinimalCtx,
   removeTempDir,
   tryImport,
@@ -120,7 +122,11 @@ describe(
       removeTempDir(tempDir);
     });
 
-    function makeExecutor(agents = [makeAgent("echo")], config: Record<string, unknown> = {}) {
+    function makeExecutor(
+      agents = [makeAgent("echo")],
+      config: Record<string, unknown> = {},
+      runSyncOverride?: (...args: any[]) => Promise<SingleResult>,
+    ) {
       return createSubagentExecutor({
         pi: { events: createEventBus(), getSessionName: () => undefined },
         state: {
@@ -135,6 +141,7 @@ describe(
         getSubagentSessionRoot: () => tempDir,
         expandTilde: (value: string) => value,
         discoverAgents: () => ({ agents }),
+        runSync: runSyncOverride,
       });
     }
 
@@ -213,6 +220,251 @@ describe(
       const ok = results.filter((r: any) => r.exitCode === 0).length;
       assert.equal(ok, 2);
     });
+
+    it(
+      "persists independent requester, active, pending, and terminal cohort health through the public executor",
+      { skip: !createSubagentExecutor ? "executor not importable" : undefined },
+      async () => {
+        type PauseTransition = {
+          stage: "pausing" | "paused";
+          ownerPid?: number;
+          result: SingleResult;
+        };
+        type RunOptions = {
+          index?: number;
+          runId?: string;
+          onUpdate?: (update: unknown) => void;
+          onSupervisorPauseTransition?: (transition: PauseTransition) => void;
+        };
+        type PersistedStep = {
+          status?: string;
+          activityState?: string;
+          idleEpisodeId?: string;
+          durableAttentionReasons?: string[];
+          compaction?: { reason?: string };
+          pause?: { kind?: string };
+        };
+
+        const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+          let resolve!: () => void;
+          const promise = new Promise<void>((next) => {
+            resolve = next;
+          });
+          return { promise, resolve };
+        };
+        const waitForSignal = async (signal: Promise<void>, label: string): Promise<void> => {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          try {
+            await Promise.race([
+              signal,
+              new Promise<never>((_, reject) => {
+                timer = setTimeout(
+                  () => reject(new Error(`Timed out waiting for ${label}`)),
+                  5_000,
+                );
+              }),
+            ]);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+        };
+        const progress = (agent: string, overrides: Partial<AgentProgress> = {}): AgentProgress =>
+          makeAgentProgress({
+            agent,
+            status: "running",
+            task: `${agent} task`,
+            ...overrides,
+          });
+        const result = (
+          agent: string,
+          childProgress: AgentProgress,
+          overrides: Partial<SingleResult> = {},
+        ): SingleResult => ({
+          agent,
+          task: `${agent} task`,
+          exitCode: 0,
+          messages: [],
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+          progress: childProgress,
+          ...overrides,
+        });
+
+        const mixedReady = deferred();
+        const activeReady = deferred();
+        const terminalUpdate = deferred();
+        const terminalCheckpointReady = deferred();
+        const allowTerminal = deferred();
+        const allowRequester = deferred();
+        const requester = result(
+          "requester",
+          progress("requester", {
+            activityState: "needs_attention",
+            idleEpisodeId: "requester-idle",
+            durableAttentionReasons: ["tool_failures"],
+            compaction: { reason: "manual" },
+          }),
+          {
+            interrupted: true,
+            sessionFile: path.join(tempDir, "requester-session.jsonl"),
+            pause: {
+              kind: "awaiting_supervisor",
+              requestedAt: 10,
+              pausedAt: 11,
+              request: {
+                tool: "contact_supervisor",
+                reason: "need_decision",
+                summary: "Need a decision",
+              },
+            },
+          },
+        );
+        const active = result(
+          "active",
+          progress("active", {
+            activityState: "active_long_running",
+            durableAttentionReasons: ["context_pressure"],
+          }),
+        );
+        const live = progress("active", {
+          idleEpisodeId: "live-idle",
+          compaction: { reason: "threshold" },
+        });
+        const terminal = result(
+          "active",
+          progress("active", {
+            status: "completed",
+            activityState: "needs_attention",
+            idleEpisodeId: "terminal-idle",
+            durableAttentionReasons: ["completion_guard"],
+            compaction: { reason: "overflow" },
+          }),
+          {
+            interrupted: true,
+            sessionFile: path.join(tempDir, "active-session.jsonl"),
+            pause: {
+              kind: "awaiting_supervisor",
+              requestedAt: 20,
+              pausedAt: 21,
+              request: {
+                tool: "contact_supervisor",
+                reason: "need_decision",
+                summary: "Terminal snapshot",
+              },
+            },
+          },
+        );
+        let runId: string | undefined;
+        let runPromise: Promise<any> | undefined;
+        const runSyncOverride = async (...args: any[]): Promise<SingleResult> => {
+          const options = args[4] as RunOptions;
+          runId = options.runId;
+          const onPause = options.onSupervisorPauseTransition;
+          assert.ok(onPause, "parallel executor should provide the pause callback");
+          if (options.index === 0) {
+            await Promise.resolve();
+            onPause({ stage: "pausing", ownerPid: 1234, result: requester });
+            await activeReady.promise;
+            onPause({ stage: "paused", result: requester });
+            mixedReady.resolve();
+            await terminalUpdate.promise;
+            onPause({ stage: "paused", result: requester });
+            terminalCheckpointReady.resolve();
+            await allowRequester.promise;
+            return requester;
+          }
+          if (options.index === 1) {
+            options.onUpdate?.({
+              content: [],
+              details: { mode: "parallel", results: [active], progress: [live] },
+            });
+            activeReady.resolve();
+            await allowTerminal.promise;
+            options.onUpdate?.({
+              content: [],
+              details: { mode: "parallel", results: [terminal], progress: [terminal.progress] },
+            });
+            terminalUpdate.resolve();
+            await allowRequester.promise;
+            return terminal;
+          }
+          throw new Error(`unexpected foreground task index ${String(options.index)}`);
+        };
+        const executor = makeExecutor(
+          [makeAgent("requester"), makeAgent("active"), makeAgent("pending")],
+          { parallel: { concurrency: 2 } },
+          runSyncOverride,
+        );
+        const readCheckpoint = (): { steps?: PersistedStep[] } => {
+          assert.ok(runId, "expected a run id from the public executor");
+          return JSON.parse(
+            fs.readFileSync(path.join(ASYNC_DIR, runId, "status.json"), "utf8"),
+          ) as { steps?: PersistedStep[] };
+        };
+
+        try {
+          runPromise = executor.execute(
+            "parallel-health-checkpoint",
+            {
+              tasks: [
+                { agent: "requester", task: "Request supervisor input" },
+                { agent: "active", task: "Continue active work" },
+                { agent: "pending", task: "Wait for a slot" },
+              ],
+            },
+            new AbortController().signal,
+            () => undefined,
+            makeMinimalCtx(tempDir),
+          );
+
+          await waitForSignal(mixedReady.promise, "mixed cohort checkpoint");
+          const mixed = readCheckpoint();
+          assert.deepEqual(
+            mixed.steps?.map((step) => step.status),
+            ["paused", "pausing", "pending"],
+          );
+          assert.equal(mixed.steps?.[0]?.pause?.kind, "awaiting_supervisor");
+          assert.equal(mixed.steps?.[0]?.activityState, "needs_attention");
+          assert.equal(mixed.steps?.[0]?.idleEpisodeId, "requester-idle");
+          assert.deepEqual(mixed.steps?.[0]?.durableAttentionReasons, ["tool_failures"]);
+          assert.deepEqual(mixed.steps?.[0]?.compaction, { reason: "manual" });
+          assert.equal(mixed.steps?.[1]?.activityState, "active_long_running");
+          assert.equal(mixed.steps?.[1]?.idleEpisodeId, "live-idle");
+          assert.deepEqual(mixed.steps?.[1]?.durableAttentionReasons, ["context_pressure"]);
+          assert.deepEqual(mixed.steps?.[1]?.compaction, { reason: "threshold" });
+          assert.equal(mixed.steps?.[2]?.activityState, undefined);
+          assert.equal(mixed.steps?.[2]?.idleEpisodeId, undefined);
+          assert.equal(mixed.steps?.[2]?.durableAttentionReasons, undefined);
+          assert.equal(mixed.steps?.[2]?.compaction, undefined);
+
+          allowTerminal.resolve();
+          await waitForSignal(terminalCheckpointReady.promise, "terminal cohort checkpoint");
+          const terminalCheckpoint = readCheckpoint();
+          assert.deepEqual(
+            terminalCheckpoint.steps?.map((step) => step.status),
+            ["paused", "paused", "pending"],
+          );
+          assert.equal(terminalCheckpoint.steps?.[0]?.idleEpisodeId, "requester-idle");
+          assert.equal(terminalCheckpoint.steps?.[1]?.activityState, "needs_attention");
+          assert.equal(terminalCheckpoint.steps?.[1]?.idleEpisodeId, "terminal-idle");
+          assert.deepEqual(terminalCheckpoint.steps?.[1]?.durableAttentionReasons, [
+            "completion_guard",
+          ]);
+          assert.deepEqual(terminalCheckpoint.steps?.[1]?.compaction, { reason: "overflow" });
+
+          allowRequester.resolve();
+          const completed = await runPromise;
+          assert.equal(completed.details?.results?.length, 3);
+        } finally {
+          activeReady.resolve();
+          terminalUpdate.resolve();
+          terminalCheckpointReady.resolve();
+          allowTerminal.resolve();
+          allowRequester.resolve();
+          if (runPromise) await runPromise.catch(() => undefined);
+          if (runId) fs.rmSync(path.join(ASYNC_DIR, runId), { recursive: true, force: true });
+        }
+      },
+    );
 
     it(
       "carries one resolved tk ticket to the matching active foreground parallel child",

--- a/extensions/subagents/test/integration/single-execution-acceptance-artifacts.test.ts
+++ b/extensions/subagents/test/integration/single-execution-acceptance-artifacts.test.ts
@@ -188,6 +188,32 @@ describe(
       assert.equal(result.progress.status, "failed");
     });
 
+    it("preserves process failure while settling explicit acceptance rejection", async () => {
+      mockPi.onCall({ exitCode: 1, stderr: "Something went wrong" });
+      const artifactsDir = path.join(tempDir, "process-failure-acceptance-artifacts");
+
+      const result = await runSync(tempDir, makeAgentConfigs(["fail"]), "fail", "Task", {
+        runId: "process-failure-acceptance",
+        artifactsDir,
+        artifactConfig: { enabled: true, includeOutput: true, includeMetadata: true },
+        acceptance: { level: "checked", criteria: ["The task is complete"] },
+      });
+
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.error, "Something went wrong");
+      assert.equal(result.acceptance?.explicit, true);
+      assert.equal(result.acceptance?.status, "rejected");
+      assert.equal(result.progress.status, "failed");
+      assert.ok(result.artifactPaths, "expected process-failure artifacts");
+      assert.equal(fs.readFileSync(result.artifactPaths.outputPath, "utf-8"), result.error);
+      const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as {
+        exitCode?: number;
+        error?: string;
+      };
+      assert.equal(metadata.exitCode, result.exitCode);
+      assert.equal(metadata.error, result.error);
+    });
+
     it("handles multi-turn conversation from JSONL", async () => {
       mockPi.onCall({
         jsonl: [

--- a/extensions/subagents/test/integration/single-execution-supervisor-pause.test.ts
+++ b/extensions/subagents/test/integration/single-execution-supervisor-pause.test.ts
@@ -32,6 +32,7 @@ interface RunSyncResult {
   progress: {
     status: string;
     activityState?: string;
+    error?: string;
   };
   pause?: {
     kind?: string;
@@ -44,6 +45,7 @@ interface RunSyncResult {
     };
   };
   artifactPaths?: {
+    outputPath: string;
     metadataPath: string;
   };
   acceptance?: {
@@ -94,6 +96,54 @@ const createSubagentExecutor = executorMod?.createSubagentExecutor;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shellQuote(value: string): string {
+  if (process.platform === "win32") return `"${value.replaceAll('"', '\\"')}"`;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function waitForMarker(markerPath: string, timeoutMs = 10_000): Promise<void> {
+  if (fs.existsSync(markerPath)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let watcher: fs.FSWatcher | undefined;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      watcher?.close();
+    };
+    const complete = () => {
+      if (!fs.existsSync(markerPath)) return;
+      cleanup();
+      resolve();
+    };
+    watcher = fs.watch(path.dirname(markerPath), complete);
+    watcher.on("error", (error) => {
+      cleanup();
+      reject(error);
+    });
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for marker: ${markerPath}`));
+    }, timeoutMs);
+    complete();
+  });
+}
+
+async function waitForPidExit(pid: number, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw error;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for verifier pid ${pid} to exit`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
 }
 
 describe(
@@ -169,45 +219,135 @@ describe(
       mockPi.onCall({ jsonl: [events.assistantMessage(report)] });
       const agents = makeAgentConfigs(["slow"]);
       const controller = new AbortController();
-      setTimeout(() => controller.abort(), 200);
-      const startedAt = Date.now();
-
+      const verificationStartedMarker = path.join(tempDir, "acceptance-verification-started");
+      const verificationPidMarker = path.join(tempDir, "acceptance-verification-pid");
+      const verificationCleanupMarker = path.join(tempDir, "acceptance-verification-cleaned");
+      const verificationScriptPath = path.join(tempDir, "acceptance-verification-child.cjs");
+      fs.writeFileSync(
+        verificationScriptPath,
+        [
+          "const fs = require('node:fs');",
+          "const pidPath = process.env.VERIFICATION_PID;",
+          "const startedPath = process.env.VERIFICATION_STARTED;",
+          "const cleanupPath = process.env.VERIFICATION_CLEANED;",
+          "let cleanupMarked = false;",
+          "const markCleanup = () => {",
+          "  if (cleanupMarked) return;",
+          "  cleanupMarked = true;",
+          "  fs.writeFileSync(cleanupPath, String(process.pid));",
+          "};",
+          "process.once('SIGTERM', () => { markCleanup(); process.exit(0); });",
+          "process.once('exit', markCleanup);",
+          "fs.writeFileSync(pidPath, String(process.pid));",
+          "fs.writeFileSync(startedPath, 'started');",
+          "setTimeout(() => process.exit(0), 5000);",
+        ].join("\n"),
+        "utf-8",
+      );
+      const verificationCommand = [
+        ...(process.platform === "win32" ? [] : ["exec"]),
+        shellQuote(process.execPath),
+        shellQuote(verificationScriptPath),
+      ].join(" ");
       const acceptanceArtifactsDir = path.join(tempDir, "artifacts-acceptance-interrupt");
-      const result = await runSync(tempDir, agents, "slow", "Slow task", {
+      let verificationPid: number | undefined;
+      const reapVerification = async (): Promise<void> => {
+        if (verificationPid === undefined) return;
+        try {
+          process.kill(verificationPid, "SIGTERM");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+        }
+        await waitForPidExit(verificationPid);
+      };
+      const resultPromise = runSync(tempDir, agents, "slow", "Slow task", {
         runId: "acceptance-interrupt-metadata",
         artifactsDir: acceptanceArtifactsDir,
-        artifactConfig: { enabled: true, includeMetadata: true },
+        artifactConfig: { enabled: true, includeOutput: true, includeMetadata: true },
         interruptSignal: controller.signal,
         acceptance: {
           level: "verified",
           verify: [
             {
               id: "slow",
-              command: `${process.execPath} -e "setTimeout(()=>process.exit(0), 5000)"`,
+              command: verificationCommand,
+              env: {
+                VERIFICATION_STARTED: verificationStartedMarker,
+                VERIFICATION_PID: verificationPidMarker,
+                VERIFICATION_CLEANED: verificationCleanupMarker,
+              },
               timeoutMs: 10_000,
             },
           ],
         },
       });
+      const resultSettlement = resultPromise.then(
+        (result) => ({ status: "fulfilled" as const, result }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
 
-      assert.ok(Date.now() - startedAt < 3_000, "interrupt should abort verification promptly");
-      assert.equal(result.exitCode, 0);
-      assert.equal(result.interrupted, true);
-      assert.equal(result.error, undefined);
-      assert.equal(result.acceptance?.status, "skipped");
-      assert.equal(result.acceptance?.runtimeChecks?.[0]?.id, "paused");
-      assert.equal(result.acceptance?.verifyRuns?.[0]?.status, undefined);
-      assert.match(result.finalOutput ?? "", /Interrupted/);
-      assert.ok(result.artifactPaths?.metadataPath);
-      const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as {
-        exitCode?: number;
-        terminationReason?: string;
-      };
-      // Acceptance interruption happens after the initial child finalization; the
-      // metadata must agree with the final returned result, not the pre-acceptance snapshot.
-      assert.equal(metadata.exitCode, result.exitCode);
-      assert.equal(metadata.terminationReason, result.terminationReason);
-      assert.equal(result.terminationReason, "interrupted");
+      try {
+        await waitForMarker(verificationStartedMarker);
+        await waitForMarker(verificationPidMarker);
+        verificationPid = Number(fs.readFileSync(verificationPidMarker, "utf-8"));
+        assert.ok(Number.isInteger(verificationPid) && verificationPid > 0);
+        controller.abort();
+        const settledResult = await resultSettlement;
+        if (settledResult.status === "rejected") throw settledResult.error;
+        const result = settledResult.result;
+
+        await reapVerification();
+        await waitForMarker(verificationCleanupMarker);
+        assert.equal(fs.readFileSync(verificationCleanupMarker, "utf-8"), String(verificationPid));
+        assert.throws(
+          () => process.kill(verificationPid!, 0),
+          (error: unknown) => {
+            return (error as NodeJS.ErrnoException).code === "ESRCH";
+          },
+        );
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.interrupted, true);
+        assert.equal(result.error, undefined);
+        assert.equal(result.progress.status, "completed");
+        assert.equal(result.progress.error, undefined);
+        assert.equal(result.progress.activityState, undefined);
+        assert.equal(result.acceptance?.status, "skipped");
+        assert.equal(result.acceptance?.runtimeChecks?.[0]?.id, "paused");
+        assert.equal(result.acceptance?.verifyRuns?.[0]?.status, undefined);
+        assert.equal(result.finalOutput, "Interrupted. Waiting for explicit next action.");
+        assert.ok(result.artifactPaths?.outputPath);
+        const artifactText = fs.readFileSync(result.artifactPaths.outputPath, "utf-8");
+        assert.equal(
+          artifactText,
+          [
+            "done",
+            "",
+            "---",
+            "Validation evidence (from acceptance report):",
+            "",
+            "  [passed] npm test — passed",
+            "---",
+          ].join("\n"),
+        );
+        assert.ok(result.artifactPaths?.metadataPath);
+        const metadata = JSON.parse(
+          fs.readFileSync(result.artifactPaths.metadataPath, "utf-8"),
+        ) as {
+          exitCode?: number;
+          error?: string;
+          terminationReason?: string;
+        };
+        // Acceptance interruption happens after the initial child finalization; the
+        // metadata must agree with the final returned result, not the pre-acceptance snapshot.
+        assert.equal(metadata.exitCode, result.exitCode);
+        assert.equal(metadata.error, result.error);
+        assert.equal(metadata.terminationReason, result.terminationReason);
+        assert.equal(result.terminationReason, "interrupted");
+      } finally {
+        controller.abort();
+        await resultSettlement;
+        await reapVerification().catch(() => undefined);
+      }
     });
 
     it("soft-interrupts the current turn and returns a paused result", async () => {

--- a/extensions/subagents/test/unit/acceptance.test.ts
+++ b/extensions/subagents/test/unit/acceptance.test.ts
@@ -952,6 +952,42 @@ describe("acceptance gates", () => {
     ]);
   });
 
+  it("preserves exact criteria validation error order before later sections", () => {
+    assert.deepEqual(
+      validateAcceptanceInput(
+        {
+          criteria: [
+            null,
+            {
+              unsupported: true,
+              id: " ",
+              must: "",
+              evidence: ["bogus"],
+              severity: "unexpected",
+            },
+            123,
+          ],
+          evidence: ["bogus"],
+          verify: [{ unsupported: true }],
+        },
+        "custom.acceptance",
+      ),
+      [
+        "custom.acceptance.criteria[0] must be a string or an object.",
+        "custom.acceptance.criteria[1].unsupported is not supported.",
+        "custom.acceptance.criteria[1].id is required.",
+        "custom.acceptance.criteria[1].must is required.",
+        "custom.acceptance.criteria[1].evidence[0] is not a supported evidence kind.",
+        "custom.acceptance.criteria[1].severity must be required or recommended.",
+        "custom.acceptance.criteria[2] must be a string or an object.",
+        "custom.acceptance.evidence[0] is not a supported evidence kind.",
+        "custom.acceptance.verify[0].unsupported is not supported.",
+        "custom.acceptance.verify[0].id is required.",
+        "custom.acceptance.verify[0].command is required.",
+      ],
+    );
+  });
+
   it("validates invalid disable and verify shapes", () => {
     assert.deepEqual(validateAcceptanceInput({ level: "none" }), [
       "acceptance.reason is required when level is none.",
@@ -967,9 +1003,15 @@ describe("acceptance gates", () => {
     );
     assert.deepEqual(validateAcceptanceInput(false), []);
     assert.deepEqual(validateAcceptanceInput("checked"), []);
+    assert.deepEqual(validateAcceptanceInput({ criteria: "ship the fix" }), [
+      "acceptance.criteria must be an array.",
+    ]);
     assert.deepEqual(
       validateAcceptanceInput({
-        criteria: ["ship the fix"],
+        criteria: [
+          "ship the fix",
+          { id: "criterion-2", must: "ship the second fix", evidence: ["changed-files"] },
+        ],
         review: false,
         stopRules: ["stay scoped"],
       }),

--- a/extensions/subagents/test/unit/async-interrupt-action.test.ts
+++ b/extensions/subagents/test/unit/async-interrupt-action.test.ts
@@ -64,6 +64,68 @@ function createRunningAsync(
   return asyncDir;
 }
 
+type InterruptLifecycleState =
+  | "paused"
+  | "continued"
+  | "cancelled"
+  | "running"
+  | "failed"
+  | "complete";
+
+function writeInterruptStatus(
+  runId: string,
+  state: InterruptLifecycleState,
+  projectMarker = false,
+): string {
+  const asyncDir = path.join(ASYNC_DIR, runId);
+  const sessionFile = path.join(asyncDir, "worker.jsonl");
+  const now = Date.now();
+  const pause = { kind: "awaiting_supervisor" as const };
+  const cancel = { summary: "Cancelled by test.", cancelledAt: now };
+  fs.mkdirSync(asyncDir, { recursive: true });
+  fs.writeFileSync(sessionFile, "", "utf-8");
+  writeJson(path.join(asyncDir, "status.json"), {
+    runId,
+    mode: "single",
+    state,
+    sessionId: "session",
+    cwd: os.tmpdir(),
+    startedAt: 100,
+    lastUpdate: now,
+    ...(state === "running" ? { pid: 12345 } : {}),
+    ...(state === "paused" ? { pause } : {}),
+    ...(state === "cancelled" ? { cancel } : {}),
+    ...(projectMarker ? { projectAgents: [] } : {}),
+    steps: [
+      {
+        agent: "worker",
+        status: state,
+        startedAt: 100,
+        sessionFile,
+        ...(state === "paused" ? { pause } : {}),
+        ...(state === "cancelled" ? { cancel } : {}),
+      },
+    ],
+  });
+  return asyncDir;
+}
+
+function createMissingStatusDirectory(runId: string): string {
+  const asyncDir = path.join(ASYNC_DIR, runId);
+  fs.mkdirSync(asyncDir, { recursive: true });
+  return asyncDir;
+}
+
+function rememberCompletedForeground(state: SubagentState, runId: string): void {
+  state.foregroundRuns!.set(runId, {
+    runId,
+    mode: "single",
+    cwd: os.tmpdir(),
+    updatedAt: 100,
+    children: [{ agent: "worker", index: 0, status: "completed" }],
+  });
+}
+
 function cleanup(runId: string, asyncDir: string): void {
   fs.rmSync(asyncDir, { recursive: true, force: true });
   fs.rmSync(path.join(RESULTS_DIR, `${runId}.json`), { force: true });
@@ -504,6 +566,108 @@ describe("async interrupt action", () => {
         );
       }
       assert.equal(fs.existsSync(steerRequestsDir(asyncDir)), false);
+    } finally {
+      cleanup(runId, asyncDir);
+    }
+  });
+
+  it("keeps persisted interrupt cancellation semantics across foreground and async routes", async () => {
+    const states = [
+      "paused",
+      "continued",
+      "cancelled",
+      "running",
+      "failed",
+      "complete",
+      "missing",
+    ] as const;
+    let caseNumber = 0;
+    for (const route of ["foreground", "async"] as const) {
+      for (const persistedState of states) {
+        const state = createState();
+        const runId = `interrupt-${route}-${persistedState}-${Date.now().toString(36)}-${caseNumber++}`;
+        if (route === "foreground") rememberCompletedForeground(state, runId);
+        const asyncDir =
+          persistedState === "missing"
+            ? createMissingStatusDirectory(runId)
+            : writeInterruptStatus(runId, persistedState);
+        const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+        try {
+          const result = await executorWithKill(state, (pid, signal) => {
+            kills.push({ pid, signal });
+            return true;
+          }).execute(
+            "interrupt",
+            { action: "interrupt", id: runId },
+            new AbortController().signal,
+            undefined,
+            ctx(),
+          );
+
+          if (persistedState === "paused" || persistedState === "cancelled") {
+            assert.equal(result.isError, undefined, `${route}/${persistedState}`);
+            assert.match(
+              text(result),
+              persistedState === "paused" ? /Cancelled paused foreground run/ : /already cancelled/,
+            );
+          } else if (persistedState === "continued") {
+            assert.equal(result.isError, true, `${route}/${persistedState}`);
+            assert.match(text(result), /already continued/);
+          } else if (route === "async" && persistedState === "running") {
+            assert.equal(result.isError, undefined);
+            assert.match(text(result), new RegExp(`Interrupt requested for async run ${runId}`));
+            assert.deepEqual(kills, [
+              { pid: 12345, signal: 0 },
+              { pid: 12345, signal: process.platform === "win32" ? "SIGBREAK" : "SIGUSR2" },
+            ]);
+          } else {
+            assert.equal(result.isError, true, `${route}/${persistedState}`);
+            assert.match(
+              text(result),
+              route === "foreground"
+                ? /No interrupt-capable run found in this session/
+                : /No running async run with an interrupt-capable pid/,
+            );
+            assert.deepEqual(kills, []);
+          }
+          assert.equal(
+            fs.existsSync(path.join(asyncDir, "control", "interrupt.json")),
+            route === "async" && persistedState === "running",
+          );
+        } finally {
+          cleanup(runId, asyncDir);
+        }
+      }
+    }
+  });
+
+  it("rejects an unauthorized project interrupt before cancellation or interrupt request", async () => {
+    const state = createState();
+    const runId = `interrupt-project-marker-${Date.now().toString(36)}`;
+    const asyncDir = writeInterruptStatus(runId, "paused", true);
+    const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+    try {
+      const result = await executorWithKill(state, (pid, signal) => {
+        kills.push({ pid, signal });
+        return true;
+      }).execute(
+        "interrupt",
+        { action: "interrupt", id: runId },
+        new AbortController().signal,
+        undefined,
+        ctx(),
+      );
+
+      assert.equal(result.isError, true);
+      assert.match(
+        text(result),
+        /persisted run carries a project-agent marker, but its process-private reference is unavailable/,
+      );
+      assert.deepEqual(kills, []);
+      assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
+      const persisted = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+      assert.equal(persisted.state, "paused");
+      assert.equal(persisted.cancel, undefined);
     } finally {
       cleanup(runId, asyncDir);
     }


### PR DESCRIPTION
## Summary

Ratchet Oxlint's repository-wide classic complexity ceiling from 80 to 70 while retaining the 2,000-line physical limit. Extract six narrow, behavior-preserving helpers across acceptance validation, interrupt routing, resume diagnostics, checkpoint projection, foreground acceptance settlement, and failed supervisor-pause normalization.

Generated runtime mirrors continue to suppress only complexity; authoritative production and tests remain covered. The measured repository maximum is 69.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
npm run check:runtime
npm run lint
npm run format:check
git diff --check
git status --short --untracked-files=all
test ! -e false
```

- Unit: 1653/1653
- Integration: 647/647
- E2E: 1/1
- Generated runtime outputs: 224 fresh
- Formatting: 601 files
- Complexity audit: 822 files total; 224 generated and 598 authoritative; maximum 69

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/refactor/complexity-max-70-current/install.sh | bash -s -- --ref refactor/complexity-max-70-current --track ref
```
