### PR TITLE
Preserve acceptance reports with unknown statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to The Last Harness will be documented in this file.
 - Switching an isolated profile from a local TLH package source back to a canonical source now removes only local registrations confirmed by a valid TLH `package.json` manifest.
 - Installer backup cleanup now rejects impossible calendar days and skips disappearing or unreadable cleanup candidates without aborting the install.
 - Async subagent idle recovery now clears current health in foreground/background widgets without masking durable warnings or sibling health, while preserving episode-aware notice delivery and legacy status compatibility.
+- Acceptance reports now normalize unrecognized criterion status strings to `not-satisfied` with evidence, preserving partial-result reports while still rejecting malformed criterion fields.
 
 ## [0.40.0] - 2026-09-06
 

--- a/extensions/subagents/src/runs/shared/acceptance.js
+++ b/extensions/subagents/src/runs/shared/acceptance.js
@@ -29,6 +29,11 @@ const VALID_EVIDENCE = new Set([
     "review-findings",
     "manual-notes",
 ]);
+const VALID_CRITERION_STATUSES = new Set([
+    "satisfied",
+    "not-satisfied",
+    "not-applicable",
+]);
 const ACCEPTANCE_CONFIG_KEYS = new Set([
     "level",
     "criteria",
@@ -521,6 +526,9 @@ export function formatAcceptancePrompt(acceptance) {
             : ["- Return the requested result."]),
         "",
         `Required evidence: ${acceptance.evidence.join(", ") || "none"}`,
+        "",
+        'Each criteriaSatisfied[].status must be one of "satisfied", "not-satisfied", or "not-applicable".',
+        'Partial results must use "not-satisfied" with evidence; do not invent a separate partial status.',
     ];
     if (acceptance.verify.length > 0) {
         lines.push("", "Runtime verification commands configured by parent:");
@@ -792,6 +800,13 @@ function describeValidationValue(value) {
 function pushTypeError(errors, pathLabel, expected, value) {
     errors.push(`${pathLabel}: expected ${expected}; got ${describeValidationValue(value)}`);
 }
+function normalizeAcceptanceCriterionStatus(value) {
+    if (typeof value !== "string")
+        return undefined;
+    return VALID_CRITERION_STATUSES.has(value)
+        ? value
+        : "not-satisfied";
+}
 function validateStringArrayField(errors, value, pathLabel) {
     if (!Array.isArray(value)) {
         pushTypeError(errors, pathLabel, "string[]", value);
@@ -825,12 +840,13 @@ function validateAcceptanceReport(value, pathLabel = "") {
         return { errors };
     }
     const report = value;
-    if (report.criteriaSatisfied !== undefined) {
-        if (!Array.isArray(report.criteriaSatisfied)) {
-            pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", report.criteriaSatisfied);
+    const criteriaSatisfied = report.criteriaSatisfied;
+    if (criteriaSatisfied !== undefined) {
+        if (!Array.isArray(criteriaSatisfied)) {
+            pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", criteriaSatisfied);
         }
         else {
-            for (const [index, item] of report.criteriaSatisfied.entries()) {
+            for (const [index, item] of criteriaSatisfied.entries()) {
                 const itemPath = `${pathFor(pathLabel, "criteriaSatisfied")}[${index}]`;
                 if (!item || typeof item !== "object" || Array.isArray(item)) {
                     pushTypeError(errors, itemPath, "object", item);
@@ -839,10 +855,13 @@ function validateAcceptanceReport(value, pathLabel = "") {
                 const criterion = item;
                 if (criterion.id !== undefined && typeof criterion.id !== "string")
                     pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
-                if (criterion.status !== "satisfied" &&
-                    criterion.status !== "not-satisfied" &&
-                    criterion.status !== "not-applicable") {
-                    pushTypeError(errors, `${itemPath}.status`, 'one of "satisfied", "not-satisfied", "not-applicable"', criterion.status);
+                const status = criterion.status;
+                const normalizedStatus = normalizeAcceptanceCriterionStatus(status);
+                if (normalizedStatus === undefined) {
+                    pushTypeError(errors, `${itemPath}.status`, 'one of "satisfied", "not-satisfied", "not-applicable"', status);
+                }
+                else if (normalizedStatus !== status) {
+                    criterion.status = normalizedStatus;
                 }
                 if (typeof criterion.evidence !== "string" || !criterion.evidence.trim())
                     pushTypeError(errors, `${itemPath}.evidence`, "non-empty string", criterion.evidence);

--- a/extensions/subagents/src/runs/shared/acceptance.ts
+++ b/extensions/subagents/src/runs/shared/acceptance.ts
@@ -50,6 +50,14 @@ const VALID_EVIDENCE = new Set<AcceptanceEvidenceKind>([
   "review-findings",
   "manual-notes",
 ]);
+type AcceptanceCriterionStatus = NonNullable<
+  AcceptanceReport["criteriaSatisfied"]
+>[number]["status"];
+const VALID_CRITERION_STATUSES = new Set<AcceptanceCriterionStatus>([
+  "satisfied",
+  "not-satisfied",
+  "not-applicable",
+]);
 const ACCEPTANCE_CONFIG_KEYS = new Set([
   "level",
   "criteria",
@@ -676,6 +684,9 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): st
       : ["- Return the requested result."]),
     "",
     `Required evidence: ${acceptance.evidence.join(", ") || "none"}`,
+    "",
+    'Each criteriaSatisfied[].status must be one of "satisfied", "not-satisfied", or "not-applicable".',
+    'Partial results must use "not-satisfied" with evidence; do not invent a separate partial status.',
   ];
   if (acceptance.verify.length > 0) {
     lines.push("", "Runtime verification commands configured by parent:");
@@ -1032,6 +1043,13 @@ function pushTypeError(
   errors.push(`${pathLabel}: expected ${expected}; got ${describeValidationValue(value)}`);
 }
 
+function normalizeAcceptanceCriterionStatus(value: unknown): AcceptanceCriterionStatus | undefined {
+  if (typeof value !== "string") return undefined;
+  return VALID_CRITERION_STATUSES.has(value as AcceptanceCriterionStatus)
+    ? (value as AcceptanceCriterionStatus)
+    : "not-satisfied";
+}
+
 function validateStringArrayField(errors: string[], value: unknown, pathLabel: string): void {
   if (!Array.isArray(value)) {
     pushTypeError(errors, pathLabel, "string[]", value);
@@ -1072,36 +1090,33 @@ function validateAcceptanceReport(
     pushTypeError(errors, pathLabel || "acceptance-report", "object", value);
     return { errors };
   }
-  const report = value as AcceptanceReport;
-  if (report.criteriaSatisfied !== undefined) {
-    if (!Array.isArray(report.criteriaSatisfied)) {
-      pushTypeError(
-        errors,
-        pathFor(pathLabel, "criteriaSatisfied"),
-        "array",
-        report.criteriaSatisfied,
-      );
+  const report = value as Record<string, unknown>;
+  const criteriaSatisfied = report.criteriaSatisfied;
+  if (criteriaSatisfied !== undefined) {
+    if (!Array.isArray(criteriaSatisfied)) {
+      pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", criteriaSatisfied);
     } else {
-      for (const [index, item] of report.criteriaSatisfied.entries()) {
+      for (const [index, item] of criteriaSatisfied.entries()) {
         const itemPath = `${pathFor(pathLabel, "criteriaSatisfied")}[${index}]`;
         if (!item || typeof item !== "object" || Array.isArray(item)) {
           pushTypeError(errors, itemPath, "object", item);
           continue;
         }
-        const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
+        const criterion = item as Record<string, unknown>;
         if (criterion.id !== undefined && typeof criterion.id !== "string")
           pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
-        if (
-          criterion.status !== "satisfied" &&
-          criterion.status !== "not-satisfied" &&
-          criterion.status !== "not-applicable"
-        ) {
+        const status = criterion.status;
+        const normalizedStatus = normalizeAcceptanceCriterionStatus(status);
+        if (normalizedStatus === undefined) {
           pushTypeError(
             errors,
             `${itemPath}.status`,
             'one of "satisfied", "not-satisfied", "not-applicable"',
-            criterion.status,
+            status,
           );
+        } else if (normalizedStatus !== status) {
+          // Keep extension fields intact while recovering unknown string statuses.
+          criterion.status = normalizedStatus;
         }
         if (typeof criterion.evidence !== "string" || !criterion.evidence.trim())
           pushTypeError(errors, `${itemPath}.evidence`, "non-empty string", criterion.evidence);
@@ -1160,9 +1175,10 @@ function validateAcceptanceReport(
   if (report.notes !== undefined && typeof report.notes !== "string")
     pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
   if (errors.length > 0) return { errors };
+  // All consumed fields are validated above; retain unknown report and criterion fields.
+  const normalizedReport = normalizeAcceptanceReportStringArrays(report as AcceptanceReport);
   // Empty string-array entries are not evidence. Normalize them before the
   // field-presence check so a report containing only blank entries is rejected.
-  const normalizedReport = normalizeAcceptanceReportStringArrays(report);
   const hasReportField =
     normalizedReport.criteriaSatisfied !== undefined ||
     normalizedReport.changedFiles !== undefined ||

--- a/extensions/subagents/test/unit/acceptance.test.ts
+++ b/extensions/subagents/test/unit/acceptance.test.ts
@@ -364,6 +364,8 @@ describe("acceptance gates", () => {
     assert.match(prompt, /Patch the bug/);
     assert.match(prompt, /```acceptance-report/);
     assert.match(prompt, /array fields contain strings/);
+    assert.match(prompt, /criteriaSatisfied\[\]\.status.*satisfied.*not-satisfied.*not-applicable/);
+    assert.match(prompt, /partial results.*not-satisfied.*evidence.*partial status/i);
     assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
   });
 
@@ -502,7 +504,7 @@ describe("acceptance gates", () => {
 
     const invalidCriteriaReport = parseAndStripAcceptanceReport(
       report({
-        criteriaSatisfied: [{ id: 7, status: "done", evidence: "" }],
+        criteriaSatisfied: [{ id: 7, status: 42, evidence: "" }],
       }),
     );
     assert.equal(invalidCriteriaReport.report, undefined);
@@ -512,12 +514,54 @@ describe("acceptance gates", () => {
     );
     assert.match(
       invalidCriteriaReport.error ?? "",
-      /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"; got "done"/,
+      /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"; got number 42/,
     );
     assert.match(
       invalidCriteriaReport.error ?? "",
       /criteriaSatisfied\[0\]\.evidence: expected non-empty string; got ""/,
     );
+  });
+
+  it("normalizes unknown criterion statuses while preserving extension fields", () => {
+    const parsed = parseAndStripAcceptanceReport(
+      report({
+        futureReportField: { keep: true },
+        criteriaSatisfied: [
+          {
+            id: "criterion-1",
+            status: "partial",
+            evidence: "incomplete but useful",
+            futureCriterionField: { keep: true },
+          },
+        ],
+      }),
+    );
+
+    assert.ok(parsed.report);
+    assert.equal(parsed.report?.criteriaSatisfied?.[0]?.status, "not-satisfied");
+    assert.deepEqual((parsed.report as Record<string, unknown>).futureReportField, { keep: true });
+    assert.deepEqual(
+      (parsed.report?.criteriaSatisfied?.[0] as Record<string, unknown> | undefined)
+        ?.futureCriterionField,
+      { keep: true },
+    );
+  });
+
+  it("rejects missing and non-string criterion statuses", () => {
+    for (const criterion of [
+      { id: "criterion-1", evidence: "missing status" },
+      { id: "criterion-1", status: null, evidence: "null status" },
+      { id: "criterion-1", status: 42, evidence: "numeric status" },
+      { id: "criterion-1", status: { value: "partial" }, evidence: "object status" },
+    ]) {
+      const parsed = parseAndStripAcceptanceReport(report({ criteriaSatisfied: [criterion] }));
+      assert.equal(parsed.report, undefined, JSON.stringify(criterion));
+      assert.match(
+        parsed.error ?? "",
+        /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"/,
+        JSON.stringify(criterion),
+      );
+    }
   });
 
   it('commandsRun[].result accepts annotated strings like "failed as expected"', () => {
@@ -735,6 +779,49 @@ describe("acceptance gates", () => {
       });
 
       assert.equal(ledger.status, "rejected");
+      assert.match(
+        acceptanceFailureMessage(ledger) ?? "",
+        /Required criterion 'regression' was reported as not-satisfied/,
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("checked mode preserves unknown-status reports as not-satisfied", async () => {
+    const cwd = tempRepo();
+    try {
+      const acceptance = resolveEffectiveAcceptance({
+        agentName: "worker",
+        task: "Implement a fix",
+        explicit: {
+          level: "checked",
+          criteria: [{ id: "regression", must: "Regression is covered" }],
+        },
+      });
+      const ledger = await evaluateAcceptance({
+        acceptance,
+        output: report({
+          criteriaSatisfied: [
+            {
+              id: "regression",
+              status: "partial",
+              evidence: "implementation is incomplete",
+              futureCriterionField: "preserved",
+            },
+          ],
+        }),
+        cwd,
+      });
+
+      assert.equal(ledger.status, "rejected");
+      assert.equal(ledger.childReportParseError, undefined);
+      assert.equal(ledger.childReport?.criteriaSatisfied?.[0]?.status, "not-satisfied");
+      assert.equal(
+        (ledger.childReport?.criteriaSatisfied?.[0] as Record<string, unknown> | undefined)
+          ?.futureCriterionField,
+        "preserved",
+      );
       assert.match(
         acceptanceFailureMessage(ledger) ?? "",
         /Required criterion 'regression' was reported as not-satisfied/,


### PR DESCRIPTION
## Summary

Document the accepted `criteriaSatisfied[].status` values in the centrally injected acceptance contract and recover reports containing unknown string statuses by normalizing them fail-safe to `not-satisfied`. Missing and non-string statuses remain invalid, while structured evidence and extension fields are preserved.

Closes #621.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

```sh
npm run validate
```

Passed. Focused acceptance tests also passed 61/61, runtime generated outputs are fresh, and the full subagent unit suite passed 1656/1656 during final review.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

The change does not touch installer or profile-isolation paths.

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/acceptance-status-recovery/install.sh | bash -s -- --ref fix/acceptance-status-recovery --track ref
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Acceptance reports now recognize the standard criterion statuses: `satisfied`, `not-satisfied`, and `not-applicable`.
  - Unrecognized status strings are normalized to `not-satisfied` while preserving supporting evidence and additional report details.
  - Malformed criteria, including missing or non-string statuses, continue to be rejected.
  - Checked acceptance results now correctly treat normalized unknown statuses as unsatisfied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->