### PR TITLE
Make idle watchdog timing observation-aware

### DIFF
--- a/extensions/subagents/src/runs/background/run-control-owner.js
+++ b/extensions/subagents/src/runs/background/run-control-owner.js
@@ -14,6 +14,8 @@ import { detectContextPressureCrossing, formatContextPressureGuidance, updateCon
 import { parseAndStripAcceptanceReport } from "../shared/acceptance.js";
 import { boundSupervisorSummary } from "../shared/lifecycle-state.js";
 import { toolBudgetState } from "../shared/tool-budget.js";
+import { ACTIVITY_MONITOR_INTERVAL_MS, getActivityMonitorGap, observeActivityWindow, } from "../shared/health-transition.js";
+const MONITOR_GAP_DIAGNOSTIC_TYPE = "subagent.run.monitor_gap";
 function resolveSupervisorPauseMetadata(input) {
     if (input.toolName === "contact_supervisor" &&
         (input.toolArgs?.reason === "need_decision" || input.toolArgs?.reason === "interview_request")) {
@@ -32,19 +34,22 @@ function resolveSupervisorPauseMetadata(input) {
     return undefined;
 }
 export function createBackgroundRunControlOwner(input) {
-    const { status, id, asyncDir, overallStartTime, controlConfig, nestedRoute, appendEvent } = input;
+    const { status, id, asyncDir, overallStartTime, controlConfig, nestedRoute, appendEvent, appendDiagnosticEvent, } = input;
     const statusPayload = status.statusPayload;
     const flatSteps = status.flatSteps;
     const activeChildInterrupts = new Map();
     const activeChildTimeouts = new Map();
     const pendingStepSteers = [];
     const emittedControlEventKeys = new Set();
+    const observedIdleSince = status.initialStatusSteps.map(() => undefined);
+    const observedActivityAt = status.initialStatusSteps.map(() => undefined);
     const mutatingFailureStates = status.initialStatusSteps.map(() => createMutatingFailureState());
     const runtimeModelContexts = status.initialStatusSteps.map(() => undefined);
     const activeConfiguredModels = status.initialStatusSteps.map(() => undefined);
     const pendingToolResults = status.initialStatusSteps.map(() => undefined);
     const mutatingFailureWindowMs = 5 * 60_000;
     let activityTimer;
+    let lastMonitorTickAt;
     function registerStepInterrupt(flatIndex, interrupt) {
         if (!interrupt) {
             activeChildInterrupts.delete(flatIndex);
@@ -302,6 +307,8 @@ export function createBackgroundRunControlOwner(input) {
         if (!step)
             return;
         status.resetStepHealth(flatIndex);
+        observedIdleSince[flatIndex] = now;
+        observedActivityAt[flatIndex] = step.lastActivityAt;
         runtimeModelContexts[flatIndex] = undefined;
         activeConfiguredModels[flatIndex] = attempt.model;
         step.model = attempt.model;
@@ -322,6 +329,7 @@ export function createBackgroundRunControlOwner(input) {
         if (!step)
             return;
         const now = Date.now();
+        observedIdleSince[flatIndex] = now;
         status.transitionStepHealth(flatIndex, { type: "validated_activity" });
         if (event.type === "compaction_start") {
             status.transitionStepHealth(flatIndex, { type: "compaction_start", reason: event.reason });
@@ -520,6 +528,7 @@ export function createBackgroundRunControlOwner(input) {
         }
         syncTopLevelCurrentTool();
         step.lastActivityAt = now;
+        observedActivityAt[flatIndex] = now;
         statusPayload.lastActivityAt = now;
         statusPayload.lastUpdate = now;
         maybeEmitActiveLongRunning(flatIndex, now);
@@ -548,11 +557,28 @@ export function createBackgroundRunControlOwner(input) {
         }
         return lastActivityAt;
     }
+    function appendMonitorGapDiagnostic(now, gapMs) {
+        const line = JSON.stringify({
+            type: MONITOR_GAP_DIAGNOSTIC_TYPE,
+            ts: now,
+            runId: id,
+            gapMs,
+        });
+        if (appendDiagnosticEvent)
+            appendDiagnosticEvent(line, MONITOR_GAP_DIAGNOSTIC_TYPE);
+        else
+            appendEvent(line);
+    }
     function updateRunnerActivityState(now) {
         if (!controlConfig.enabled)
             return false;
+        const previousMonitorTickAt = lastMonitorTickAt;
+        const { gapMs: monitorGapMs, detected: monitorGapDetected } = getActivityMonitorGap(previousMonitorTickAt, now);
+        lastMonitorTickAt = now;
         let changed = false;
         let runLastActivityAt = statusPayload.lastActivityAt ?? overallStartTime;
+        if (monitorGapDetected && statusPayload.steps.some((step) => step.status === "running"))
+            appendMonitorGapDiagnostic(now, monitorGapMs);
         for (let index = 0; index < statusPayload.steps.length; index++) {
             const step = statusPayload.steps[index];
             if (step.status !== "running")
@@ -563,13 +589,24 @@ export function createBackgroundRunControlOwner(input) {
                 step.lastActivityAt = lastActivityAt;
                 changed = true;
             }
+            const observation = observeActivityWindow({
+                previousMonitorTickAt,
+                now,
+                startedAt: step.startedAt ?? overallStartTime,
+                activityAt: lastActivityAt,
+                observedIdleSince: observedIdleSince[index],
+                observedActivityAt: observedActivityAt[index],
+            });
+            observedIdleSince[index] = observation.observedIdleSince;
+            observedActivityAt[index] = observation.observedActivityAt;
+            const observedActivitySince = observation.observedIdleSince;
             const healthState = status.healthStateForStep(index);
             const idleState = healthState.compaction
                 ? undefined
                 : deriveActivityState({
                     config: controlConfig,
                     startedAt: step.startedAt ?? overallStartTime,
-                    lastActivityAt,
+                    lastActivityAt: observedActivitySince,
                     toolCallInFlight: Boolean(step.currentTool),
                     now,
                 });
@@ -586,6 +623,7 @@ export function createBackgroundRunControlOwner(input) {
                             index,
                             ts: now,
                             lastActivityAt,
+                            elapsedMs: Math.max(0, now - observedActivitySince),
                             idleEpisodeId: transition.state.idleEpisodeId,
                         }));
                     }
@@ -612,11 +650,12 @@ export function createBackgroundRunControlOwner(input) {
     function startActivityTimer() {
         if (!controlConfig.enabled)
             return;
+        lastMonitorTickAt = Date.now();
         activityTimer = setInterval(() => {
             if (statusPayload.state !== "running")
                 return;
             updateRunnerActivityState(Date.now());
-        }, 1000);
+        }, ACTIVITY_MONITOR_INTERVAL_MS);
         activityTimer.unref?.();
     }
     function disposeActivityTimer() {

--- a/extensions/subagents/src/runs/background/run-control-owner.ts
+++ b/extensions/subagents/src/runs/background/run-control-owner.ts
@@ -50,6 +50,13 @@ import { boundSupervisorSummary } from "../shared/lifecycle-state.ts";
 import { toolBudgetState } from "../shared/tool-budget.ts";
 import type { ModelAttemptStart } from "./single-step-execution.ts";
 import type { BackgroundRunStatusOwner } from "./run-status-owner.ts";
+import {
+  ACTIVITY_MONITOR_INTERVAL_MS,
+  getActivityMonitorGap,
+  observeActivityWindow,
+} from "../shared/health-transition.ts";
+
+const MONITOR_GAP_DIAGNOSTIC_TYPE = "subagent.run.monitor_gap";
 
 export interface BackgroundRunControlOwnerInput {
   status: BackgroundRunStatusOwner;
@@ -59,6 +66,7 @@ export interface BackgroundRunControlOwnerInput {
   controlConfig: ResolvedControlConfig;
   nestedRoute?: NestedRouteInfo;
   appendEvent: (line: string) => void;
+  appendDiagnosticEvent?: (line: string, droppedEventType?: string) => void;
 }
 
 export interface BackgroundRunControlOwner {
@@ -106,13 +114,31 @@ function resolveSupervisorPauseMetadata(input: {
 export function createBackgroundRunControlOwner(
   input: BackgroundRunControlOwnerInput,
 ): BackgroundRunControlOwner {
-  const { status, id, asyncDir, overallStartTime, controlConfig, nestedRoute, appendEvent } = input;
+  const {
+    status,
+    id,
+    asyncDir,
+    overallStartTime,
+    controlConfig,
+    nestedRoute,
+    appendEvent,
+    appendDiagnosticEvent,
+  } = input;
   const statusPayload = status.statusPayload;
   const flatSteps = status.flatSteps;
   const activeChildInterrupts = new Map<number, () => void>();
   const activeChildTimeouts = new Map<number, () => void>();
   const pendingStepSteers: ChildMessageRequest[] = [];
   const emittedControlEventKeys = new Set<string>();
+  // These timestamps describe what the watchdog has continuously observed, not
+  // the child's truthful activity timestamps. A delayed watchdog tick resets
+  // this observation window without rewriting lastActivityAt.
+  const observedIdleSince: Array<number | undefined> = status.initialStatusSteps.map(
+    () => undefined,
+  );
+  const observedActivityAt: Array<number | undefined> = status.initialStatusSteps.map(
+    () => undefined,
+  );
   const mutatingFailureStates = status.initialStatusSteps.map(() => createMutatingFailureState());
   // Runtime-reported identity is trusted only after exact registry validation
   // and is scoped to the currently dispatched child attempt. A fallback invokes
@@ -129,6 +155,7 @@ export function createBackgroundRunControlOwner(
   > = status.initialStatusSteps.map(() => undefined);
   const mutatingFailureWindowMs = 5 * 60_000;
   let activityTimer: NodeJS.Timeout | undefined;
+  let lastMonitorTickAt: number | undefined;
 
   function registerStepInterrupt(flatIndex: number, interrupt: (() => void) | undefined): void {
     if (!interrupt) {
@@ -402,6 +429,10 @@ export function createBackgroundRunControlOwner(
     // episode and any in-flight compaction while retaining durable causes and
     // an already-earned long-running notice.
     status.resetStepHealth(flatIndex);
+    // A fallback attempt starts a fresh observed-idle segment. Keep the
+    // previous attempt's activity timestamp intact for truthful status output.
+    observedIdleSince[flatIndex] = now;
+    observedActivityAt[flatIndex] = step.lastActivityAt;
     runtimeModelContexts[flatIndex] = undefined;
     activeConfiguredModels[flatIndex] = attempt.model;
     step.model = attempt.model;
@@ -423,6 +454,9 @@ export function createBackgroundRunControlOwner(
     const step = statusPayload.steps[flatIndex];
     if (!step) return;
     const now = Date.now();
+    // Validated child activity starts a new observed-idle window. Raw output
+    // freshness is still folded into this window by the monitor below.
+    observedIdleSince[flatIndex] = now;
     // Only validated child protocol events can recover an idle episode. The
     // compaction operation is tracked independently of tool-call state.
     status.transitionStepHealth(flatIndex, { type: "validated_activity" });
@@ -652,6 +686,7 @@ export function createBackgroundRunControlOwner(
     }
     syncTopLevelCurrentTool();
     step.lastActivityAt = now;
+    observedActivityAt[flatIndex] = now;
     statusPayload.lastActivityAt = now;
     statusPayload.lastUpdate = now;
     maybeEmitActiveLongRunning(flatIndex, now);
@@ -683,10 +718,29 @@ export function createBackgroundRunControlOwner(
     return lastActivityAt;
   }
 
+  function appendMonitorGapDiagnostic(now: number, gapMs: number): void {
+    const line = JSON.stringify({
+      type: MONITOR_GAP_DIAGNOSTIC_TYPE,
+      ts: now,
+      runId: id,
+      gapMs,
+    });
+    if (appendDiagnosticEvent) appendDiagnosticEvent(line, MONITOR_GAP_DIAGNOSTIC_TYPE);
+    else appendEvent(line);
+  }
+
   function updateRunnerActivityState(now: number): boolean {
     if (!controlConfig.enabled) return false;
+    const previousMonitorTickAt = lastMonitorTickAt;
+    const { gapMs: monitorGapMs, detected: monitorGapDetected } = getActivityMonitorGap(
+      previousMonitorTickAt,
+      now,
+    );
+    lastMonitorTickAt = now;
     let changed = false;
     let runLastActivityAt = statusPayload.lastActivityAt ?? overallStartTime;
+    if (monitorGapDetected && statusPayload.steps.some((step) => step.status === "running"))
+      appendMonitorGapDiagnostic(now, monitorGapMs);
     for (let index = 0; index < statusPayload.steps.length; index++) {
       const step = statusPayload.steps[index]!;
       if (step.status !== "running") continue;
@@ -696,13 +750,24 @@ export function createBackgroundRunControlOwner(
         step.lastActivityAt = lastActivityAt;
         changed = true;
       }
+      const observation = observeActivityWindow({
+        previousMonitorTickAt,
+        now,
+        startedAt: step.startedAt ?? overallStartTime,
+        activityAt: lastActivityAt,
+        observedIdleSince: observedIdleSince[index],
+        observedActivityAt: observedActivityAt[index],
+      });
+      observedIdleSince[index] = observation.observedIdleSince;
+      observedActivityAt[index] = observation.observedActivityAt;
+      const observedActivitySince = observation.observedIdleSince;
       const healthState = status.healthStateForStep(index);
       const idleState = healthState.compaction
         ? undefined
         : deriveActivityState({
             config: controlConfig,
             startedAt: step.startedAt ?? overallStartTime,
-            lastActivityAt,
+            lastActivityAt: observedActivitySince,
             toolCallInFlight: Boolean(step.currentTool),
             now,
           });
@@ -720,6 +785,7 @@ export function createBackgroundRunControlOwner(
                 index,
                 ts: now,
                 lastActivityAt,
+                elapsedMs: Math.max(0, now - observedActivitySince),
                 idleEpisodeId: transition.state.idleEpisodeId,
               }),
             );
@@ -744,10 +810,11 @@ export function createBackgroundRunControlOwner(
 
   function startActivityTimer(): void {
     if (!controlConfig.enabled) return;
+    lastMonitorTickAt = Date.now();
     activityTimer = setInterval(() => {
       if (statusPayload.state !== "running") return;
       updateRunnerActivityState(Date.now());
-    }, 1000);
+    }, ACTIVITY_MONITOR_INTERVAL_MS);
     activityTimer.unref?.();
   }
 

--- a/extensions/subagents/src/runs/background/subagent-runner.js
+++ b/extensions/subagents/src/runs/background/subagent-runner.js
@@ -508,6 +508,7 @@ async function runSubagentWithInput(config, plan) {
         controlConfig,
         nestedRoute: config.nestedRoute,
         appendEvent,
+        appendDiagnosticEvent,
     });
     const pausedOutputForIndex = (index, agent) => statusOwner.supervisorPauseRequest &&
         index === statusOwner.supervisorPauseRequest.requesterIndex

--- a/extensions/subagents/src/runs/background/subagent-runner.ts
+++ b/extensions/subagents/src/runs/background/subagent-runner.ts
@@ -698,6 +698,7 @@ async function runSubagentWithInput(
     controlConfig,
     nestedRoute: config.nestedRoute,
     appendEvent,
+    appendDiagnosticEvent,
   });
   const pausedOutputForIndex = (index: number, agent: string): string =>
     statusOwner.supervisorPauseRequest &&

--- a/extensions/subagents/src/runs/foreground/execution.js
+++ b/extensions/subagents/src/runs/foreground/execution.js
@@ -25,7 +25,7 @@ import { resolveSupervisorChannelDir } from "../../supervisor/native-supervisor-
 import { cleanupOwnedProcessGroup, skipOwnedProcessGroupCleanup, supportsOwnedProcessGroupCleanup, } from "../shared/process-group-cleanup.js";
 import { hasUsableSessionArtifact, mergeContextUsageDiagnostics, resolveEffectiveContextWindow, updateContextUsageDiagnostics, detectContextPressureCrossing, formatContextPressureGuidance, parseContextPressureCrossedThresholds, parseContextPressureProjection, } from "../../shared/context-diagnostics.js";
 import { CONFIGURED_RUN_DEADLINE_TIMEOUT_MESSAGE, applyHealthProgressProjection, clearHealthForProgress, evaluateSingleAcceptance, finalizeForegroundArtifacts, finalizeSingleAttempt, formatTimeoutMessage, prepareForegroundRunFinalization, resolveResultSessionFile, setupForegroundArtifacts, snapshotProgress, snapshotResult, transitionHealthForProgress, } from "./execution-finalization.js";
-import { createHealthTransitionState, resetHealthTransitionState, } from "../shared/health-transition.js";
+import { ACTIVITY_MONITOR_INTERVAL_MS, observeActivityWindow, createHealthTransitionState, resetHealthTransitionState, } from "../shared/health-transition.js";
 const FOREGROUND_PROCESS_CLEANUP_ERROR_MESSAGE = "Foreground pause process cleanup could not be confirmed. Status does not claim the child stopped.";
 function settleForegroundAcceptance(result, acceptance, options, interruptedAcceptance, healthState) {
     result.acceptance = acceptance;
@@ -363,6 +363,9 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
         let removeAbortListener;
         let removeInterruptListener;
         let activityTimer;
+        let lastMonitorTickAt;
+        let observedIdleSince;
+        let observedActivityAt;
         let timeoutTimer;
         let timeoutTerminationTimer;
         let timeoutHardKillTimer;
@@ -559,6 +562,7 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
                 contextPressureThreshold: input.contextPressureThreshold,
                 reason,
                 idleEpisodeId: reason === "idle" ? transition.state.idleEpisodeId : undefined,
+                elapsedMs: reason === "idle" ? Math.max(0, now - (observedIdleSince ?? now)) : undefined,
                 turns: result.usage.turns,
                 tokens: progress.tokens,
                 toolCount: progress.toolCount,
@@ -597,15 +601,27 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
             }));
             return true;
         };
-        const updateActivityState = (now) => {
+        const updateActivityState = (now, monitorTick = false) => {
             if (!controlConfig.enabled)
                 return false;
+            const observation = observeActivityWindow({
+                previousMonitorTickAt: monitorTick ? lastMonitorTickAt : undefined,
+                now,
+                startedAt: startTime,
+                activityAt: progress.lastActivityAt ?? startTime,
+                observedIdleSince,
+                observedActivityAt,
+            });
+            if (monitorTick)
+                lastMonitorTickAt = now;
+            observedIdleSince = observation.observedIdleSince;
+            observedActivityAt = observation.observedActivityAt;
             const idleState = shared.healthState.value.compaction
                 ? undefined
                 : deriveActivityState({
                     config: controlConfig,
                     startedAt: startTime,
-                    lastActivityAt: progress.lastActivityAt,
+                    lastActivityAt: observation.observedIdleSince,
                     toolCallInFlight: Boolean(progress.currentTool),
                     now,
                 });
@@ -669,6 +685,8 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
                 applyHealthTransition({ type: "compaction_end" });
             }
             progress.lastActivityAt = now;
+            observedIdleSince = now;
+            observedActivityAt = now;
             if (evt.type === "tool_execution_start") {
                 const toolArgs = evt.args ?? {};
                 let supervisorPause;
@@ -823,15 +841,16 @@ async function runSingleAttempt(runtimeCwd, agent, task, model, options, shared)
             }
         };
         if (controlConfig.enabled) {
+            lastMonitorTickAt = Date.now();
             activityTimer = setInterval(() => {
                 if (processClosed || settled)
                     return;
                 const now = Date.now();
-                if (updateActivityState(now)) {
+                if (updateActivityState(now, true)) {
                     progress.durationMs = now - startTime;
                     fireUpdate();
                 }
-            }, 1000);
+            }, ACTIVITY_MONITOR_INTERVAL_MS);
             activityTimer.unref?.();
         }
         if (attemptTimeout) {

--- a/extensions/subagents/src/runs/foreground/execution.ts
+++ b/extensions/subagents/src/runs/foreground/execution.ts
@@ -140,6 +140,8 @@ import {
   type HealthTransitionBox,
 } from "./execution-finalization.ts";
 import {
+  ACTIVITY_MONITOR_INTERVAL_MS,
+  observeActivityWindow,
   createHealthTransitionState,
   resetHealthTransitionState,
   type HealthTransitionAction,
@@ -588,6 +590,9 @@ async function runSingleAttempt(
     let removeAbortListener: (() => void) | undefined;
     let removeInterruptListener: (() => void) | undefined;
     let activityTimer: NodeJS.Timeout | undefined;
+    let lastMonitorTickAt: number | undefined;
+    let observedIdleSince: number | undefined;
+    let observedActivityAt: number | undefined;
     let timeoutTimer: DeadlineTimer | undefined;
     let timeoutTerminationTimer: NodeJS.Timeout | undefined;
     let timeoutHardKillTimer: NodeJS.Timeout | undefined;
@@ -802,6 +807,7 @@ async function runSingleAttempt(
         contextPressureThreshold: input.contextPressureThreshold,
         reason,
         idleEpisodeId: reason === "idle" ? transition.state.idleEpisodeId : undefined,
+        elapsedMs: reason === "idle" ? Math.max(0, now - (observedIdleSince ?? now)) : undefined,
         turns: result.usage.turns,
         tokens: progress.tokens,
         toolCount: progress.toolCount,
@@ -840,14 +846,25 @@ async function runSingleAttempt(
       );
       return true;
     };
-    const updateActivityState = (now: number): boolean => {
+    const updateActivityState = (now: number, monitorTick = false): boolean => {
       if (!controlConfig.enabled) return false;
+      const observation = observeActivityWindow({
+        previousMonitorTickAt: monitorTick ? lastMonitorTickAt : undefined,
+        now,
+        startedAt: startTime,
+        activityAt: progress.lastActivityAt ?? startTime,
+        observedIdleSince,
+        observedActivityAt,
+      });
+      if (monitorTick) lastMonitorTickAt = now;
+      observedIdleSince = observation.observedIdleSince;
+      observedActivityAt = observation.observedActivityAt;
       const idleState = shared.healthState.value.compaction
         ? undefined
         : deriveActivityState({
             config: controlConfig,
             startedAt: startTime,
-            lastActivityAt: progress.lastActivityAt,
+            lastActivityAt: observation.observedIdleSince,
             toolCallInFlight: Boolean(progress.currentTool),
             now,
           });
@@ -914,6 +931,10 @@ async function runSingleAttempt(
         applyHealthTransition({ type: "compaction_end" });
       }
       progress.lastActivityAt = now;
+      // Validated child activity starts a new observed-idle window without
+      // changing the truthful activity timestamp retained in progress.
+      observedIdleSince = now;
+      observedActivityAt = now;
 
       if (evt.type === "tool_execution_start") {
         const toolArgs = evt.args ?? {};
@@ -1107,14 +1128,15 @@ async function runSingleAttempt(
     };
 
     if (controlConfig.enabled) {
+      lastMonitorTickAt = Date.now();
       activityTimer = setInterval(() => {
         if (processClosed || settled) return;
         const now = Date.now();
-        if (updateActivityState(now)) {
+        if (updateActivityState(now, true)) {
           progress.durationMs = now - startTime;
           fireUpdate();
         }
-      }, 1000);
+      }, ACTIVITY_MONITOR_INTERVAL_MS);
       activityTimer.unref?.();
     }
 

--- a/extensions/subagents/src/runs/shared/health-transition.js
+++ b/extensions/subagents/src/runs/shared/health-transition.js
@@ -1,3 +1,23 @@
+export const ACTIVITY_MONITOR_INTERVAL_MS = 1_000;
+export const ACTIVITY_MONITOR_GAP_THRESHOLD_MS = ACTIVITY_MONITOR_INTERVAL_MS * 2;
+export function getActivityMonitorGap(previousMonitorTickAt, now) {
+    const gapMs = previousMonitorTickAt === undefined ? 0 : Math.max(0, now - previousMonitorTickAt);
+    return { gapMs, detected: gapMs > ACTIVITY_MONITOR_GAP_THRESHOLD_MS };
+}
+export function observeActivityWindow(input) {
+    const { detected } = getActivityMonitorGap(input.previousMonitorTickAt, input.now);
+    let observedIdleSince = input.observedIdleSince;
+    if (detected)
+        observedIdleSince = input.now;
+    else if (observedIdleSince === undefined)
+        observedIdleSince = input.startedAt;
+    else if (input.observedActivityAt !== input.activityAt)
+        observedIdleSince = input.now;
+    return {
+        observedIdleSince,
+        observedActivityAt: input.activityAt,
+    };
+}
 export const MAX_IDLE_EPISODE_ID_LENGTH = 128;
 export const MAX_HEALTH_ATTEMPT_ID_LENGTH = 96;
 const PRINTABLE_ASCII_START = 0x21;

--- a/extensions/subagents/src/runs/shared/health-transition.ts
+++ b/extensions/subagents/src/runs/shared/health-transition.ts
@@ -4,6 +4,45 @@ import type {
   DurableAttentionReason,
 } from "../../shared/types.ts";
 
+/** Watchdog cadence shared by foreground and background activity observers. */
+export const ACTIVITY_MONITOR_INTERVAL_MS = 1_000;
+export const ACTIVITY_MONITOR_GAP_THRESHOLD_MS = ACTIVITY_MONITOR_INTERVAL_MS * 2;
+
+export function getActivityMonitorGap(
+  previousMonitorTickAt: number | undefined,
+  now: number,
+): { gapMs: number; detected: boolean } {
+  const gapMs = previousMonitorTickAt === undefined ? 0 : Math.max(0, now - previousMonitorTickAt);
+  return { gapMs, detected: gapMs > ACTIVITY_MONITOR_GAP_THRESHOLD_MS };
+}
+
+/**
+ * Advance an observation window without rewriting the child's activity time.
+ * A delayed watchdog tick starts a new window; otherwise a changed activity
+ * timestamp or an uninitialized window starts observation at the current time.
+ */
+export function observeActivityWindow(input: {
+  previousMonitorTickAt?: number;
+  now: number;
+  startedAt: number;
+  activityAt: number;
+  observedIdleSince?: number;
+  observedActivityAt?: number;
+}): {
+  observedIdleSince: number;
+  observedActivityAt: number;
+} {
+  const { detected } = getActivityMonitorGap(input.previousMonitorTickAt, input.now);
+  let observedIdleSince = input.observedIdleSince;
+  if (detected) observedIdleSince = input.now;
+  else if (observedIdleSince === undefined) observedIdleSince = input.startedAt;
+  else if (input.observedActivityAt !== input.activityAt) observedIdleSince = input.now;
+  return {
+    observedIdleSince,
+    observedActivityAt: input.activityAt,
+  };
+}
+
 /** Maximum length of an episode identity carried through a control event. */
 export const MAX_IDLE_EPISODE_ID_LENGTH = 128;
 

--- a/extensions/subagents/test/integration/async-execution-health.test.ts
+++ b/extensions/subagents/test/integration/async-execution-health.test.ts
@@ -187,6 +187,141 @@ describe("async execution health", () => {
     assert.equal(finalStatus.steps?.[0]?.idleEpisodeId, undefined);
   });
 
+  it(
+    "does not charge a delayed background monitor gap as idle time",
+    { skip: process.platform === "win32" ? "SIGSTOP is unavailable on Windows" : undefined },
+    async () => {
+      const markerDir = path.join(tempDir, "async-monitor-gap-markers");
+      fs.mkdirSync(markerDir, { recursive: true });
+      const ready = path.join(markerDir, "ready");
+      const release = path.join(markerDir, "release");
+      mockPi.onCall({
+        steps: [
+          {
+            jsonl: [events.assistantMessage("quiet baseline", "mock/test-model", "tool_use")],
+            writeMarkerAfter: ready,
+          },
+          { waitForMarker: release },
+          { jsonl: [events.assistantMessage("completed")] },
+        ],
+      });
+
+      const id = `async-monitor-gap-${Date.now().toString(36)}`;
+      const asyncDir = path.join(ASYNC_DIR, id);
+      executeAsyncSingle(id, {
+        agent: "scout",
+        task: "Investigate monitor timing",
+        agentConfig: makeAgent("scout"),
+        ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: id },
+        artifactConfig: {
+          enabled: false,
+          includeInput: false,
+          includeOutput: false,
+          includeJsonl: false,
+          includeMetadata: false,
+          cleanupDays: 7,
+        },
+        shareEnabled: false,
+        sessionRoot: path.join(tempDir, "sessions"),
+        maxSubagentDepth: 2,
+        controlConfig: {
+          enabled: true,
+          needsAttentionAfterMs: 2_000,
+          activeNoticeAfterTurns: 999_999,
+          activeNoticeAfterMs: 999_999,
+          activeNoticeAfterTokens: 999_999,
+          failedToolAttemptsBeforeAttention: 3,
+          notifyOn: ["active_long_running", "needs_attention"],
+          notifyChannels: ["event", "async"],
+        },
+      });
+
+      await waitForMarker(ready);
+      const running = await waitForAsyncStatusPredicate(
+        asyncDir,
+        (status) => status.state === "running" && typeof status.pid === "number",
+        "running monitor-gap background run",
+      );
+      // Let one ordinary watchdog observation establish a baseline before
+      // suspending the runner. The child remains quiet while only the monitor
+      // is stopped, so the old wall-clock calculation emits immediately after
+      // SIGCONT whereas the observation-aware baseline does not.
+      await new Promise((resolve) => setTimeout(resolve, 1_200));
+      const runnerPid = running.pid;
+      assert.ok(typeof runnerPid === "number");
+      let resumed = false;
+      try {
+        process.kill(runnerPid, "SIGSTOP");
+        await new Promise((resolve) => setTimeout(resolve, 3_200));
+        process.kill(runnerPid, "SIGCONT");
+        resumed = true;
+
+        const afterGap = await waitForAsyncControlCondition(
+          asyncDir,
+          (_status, eventText) => {
+            const records = eventText
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => JSON.parse(line));
+            const diagnostics = records.filter(
+              (record) => record.type === "subagent.run.monitor_gap",
+            );
+            const idleControls = records.filter(
+              (record) => record.type === "subagent.control" && record.event?.reason === "idle",
+            );
+            return diagnostics.length === 1 && idleControls.length === 0;
+          },
+          scaleTestTimeout(10_000),
+        );
+        const diagnostic = afterGap.eventText
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line))
+          .find((record) => record.type === "subagent.run.monitor_gap");
+        assert.deepEqual(Object.keys(diagnostic ?? {}).sort(), ["gapMs", "runId", "ts", "type"]);
+        assert.ok(typeof diagnostic?.gapMs === "number" && diagnostic.gapMs >= 3_000);
+        assert.doesNotMatch(
+          JSON.stringify(diagnostic),
+          /quiet baseline|Investigate monitor timing/,
+        );
+
+        const idleObserved = await waitForAsyncControlCondition(
+          asyncDir,
+          (_status, eventText) => {
+            const records = eventText
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => JSON.parse(line));
+            return records.some(
+              (record) => record.type === "subagent.control" && record.event?.reason === "idle",
+            );
+          },
+          scaleTestTimeout(10_000),
+        );
+        const idleControl = idleObserved.eventText
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line))
+          .find((record) => record.type === "subagent.control" && record.event?.reason === "idle");
+        assert.ok(typeof idleControl?.event?.elapsedMs === "number");
+        assert.ok(idleControl.event.elapsedMs >= 2_000);
+        assert.ok(idleControl.event.elapsedMs <= 4_000);
+        fs.writeFileSync(release, "", "utf-8");
+      } finally {
+        if (!resumed && typeof runnerPid === "number") {
+          try {
+            process.kill(runnerPid, "SIGCONT");
+          } catch {
+            // The runner may have already exited after a test failure.
+          }
+        }
+        if (!fs.existsSync(release)) fs.writeFileSync(release, "", "utf-8");
+      }
+
+      await waitForAsyncResultFile(id);
+    },
+  );
+
   it("background compaction suppresses idle but preserves long-running and post-operation stall detection", async () => {
     for (const variant of [
       { name: "normal", reason: "manual" as const, options: {} },
@@ -893,7 +1028,12 @@ describe("async execution health", () => {
   it("resets background idle episode identity across fallback attempts", async () => {
     const markerDir = path.join(tempDir, "async-fallback-health-markers");
     fs.mkdirSync(markerDir, { recursive: true });
+    const needsAttentionAfterMs = 2_000;
     const firstRelease = path.join(markerDir, "first-release");
+    const firstAttemptErrorActivity = path.join(markerDir, "first-attempt-error-activity");
+    const firstAttemptFallbackRelease = path.join(markerDir, "first-attempt-fallback-release");
+    const fallbackAttemptStarted = path.join(markerDir, "fallback-attempt-started");
+    const fallbackAttemptRelease = path.join(markerDir, "fallback-attempt-release");
     const secondRelease = path.join(markerDir, "second-release");
     mockPi.onCall({
       exitCode: 1,
@@ -914,10 +1054,14 @@ describe("async execution health", () => {
               },
             },
           ],
+          writeMarkerAfter: firstAttemptErrorActivity,
         },
+        { waitForMarker: firstAttemptFallbackRelease },
       ],
     });
     mockPi.onCall({
+      writeMarker: fallbackAttemptStarted,
+      waitForMarker: fallbackAttemptRelease,
       steps: [
         { jsonl: [events.assistantMessage("fallback attempt", "mock/test-model", "tool_use")] },
         { waitForMarker: secondRelease },
@@ -947,7 +1091,7 @@ describe("async execution health", () => {
       maxSubagentDepth: 2,
       controlConfig: {
         enabled: true,
-        needsAttentionAfterMs: 200,
+        needsAttentionAfterMs,
         activeNoticeAfterTurns: 999_999,
         activeNoticeAfterMs: 999_999,
         activeNoticeAfterTokens: 999_999,
@@ -955,7 +1099,7 @@ describe("async execution health", () => {
         notifyChannels: ["event", "async"],
       },
     });
-    const secondObserved = await waitForAsyncControlCondition(asyncDir, (status, eventText) => {
+    await waitForAsyncControlCondition(asyncDir, (status, eventText) => {
       const idleControls = eventText
         .split("\n")
         .filter(Boolean)
@@ -967,26 +1111,65 @@ describe("async execution health", () => {
         typeof status.steps?.[0]?.idleEpisodeId === "string"
       );
     });
-    const firstIdleId = secondObserved.status.steps?.[0]?.idleEpisodeId;
-    const firstIdleControl = secondObserved.eventText
+    fs.writeFileSync(firstRelease, "", "utf-8");
+    await waitForMarker(firstAttemptErrorActivity);
+    // Keep the first attempt alive after its final validated error activity.
+    // It may earn another idle episode here; that episode must not become the
+    // fallback attempt's starting idle age.
+    await new Promise((resolve) => setTimeout(resolve, needsAttentionAfterMs + 600));
+    const attemptOneQuietEventText = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
+    const attemptOneIdleControls = attemptOneQuietEventText
       .split("\n")
       .filter(Boolean)
       .map((line) => JSON.parse(line))
-      .find((record) => record.type === "subagent.control" && record.event?.reason === "idle");
-    fs.writeFileSync(firstRelease, "", "utf-8");
-    const secondIdleObserved = await waitForAsyncControlCondition(asyncDir, (status, eventText) => {
-      const idleControls = eventText
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line))
-        .filter((record) => record.type === "subagent.control" && record.event?.reason === "idle");
-      return (
-        idleControls.length === 2 &&
-        status.steps?.[0]?.activityState === "needs_attention" &&
-        typeof status.steps?.[0]?.idleEpisodeId === "string" &&
-        status.steps?.[0]?.idleEpisodeId !== firstIdleId
-      );
-    });
+      .filter((record) => record.type === "subagent.control" && record.event?.reason === "idle");
+    assert.ok(attemptOneIdleControls.length >= 1);
+    const attemptOneIdleCount = attemptOneIdleControls.length;
+    const attemptOneIdleEpisodeIds = attemptOneIdleControls
+      .map((record) => record.event?.idleEpisodeId)
+      .filter((episodeId): episodeId is string => typeof episodeId === "string");
+    fs.writeFileSync(firstAttemptFallbackRelease, "", "utf-8");
+    await waitForMarker(fallbackAttemptStarted);
+    // The output stream is opened for every attempt. Make the quiet fallback
+    // explicitly have no fresh output so this checks the observation baseline,
+    // not the stream-open timestamp.
+    const outputPath = path.join(asyncDir, "output-0.log");
+    const staleOutputTime = new Date(Date.now() - needsAttentionAfterMs - 800);
+    fs.utimesSync(outputPath, staleOutputTime, staleOutputTime);
+    // This is intentionally shorter than a fresh threshold. Pre-fix code uses
+    // the prior attempt's old lastActivityAt and emits here; the fix starts a
+    // new observation window at fallback dispatch.
+    await new Promise((resolve) => setTimeout(resolve, needsAttentionAfterMs - 800));
+    const fallbackPauseEventText = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
+    const fallbackPauseIdleControls = fallbackPauseEventText
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((record) => record.type === "subagent.control" && record.event?.reason === "idle");
+    const fallbackPauseStatus = JSON.parse(
+      fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"),
+    ) as AsyncStatusPayload;
+    assert.equal(fallbackPauseIdleControls.length, attemptOneIdleCount);
+    assert.equal(fallbackPauseStatus.steps?.[0]?.activityState, undefined);
+    fs.writeFileSync(fallbackAttemptRelease, "", "utf-8");
+    const fallbackIdleObserved = await waitForAsyncControlCondition(
+      asyncDir,
+      (status, eventText) => {
+        const idleControls = eventText
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line))
+          .filter(
+            (record) => record.type === "subagent.control" && record.event?.reason === "idle",
+          );
+        return (
+          idleControls.length === attemptOneIdleCount + 1 &&
+          status.steps?.[0]?.activityState === "needs_attention" &&
+          typeof status.steps?.[0]?.idleEpisodeId === "string" &&
+          !attemptOneIdleEpisodeIds.includes(status.steps?.[0]?.idleEpisodeId)
+        );
+      },
+    );
     fs.writeFileSync(secondRelease, "", "utf-8");
     const resultPath = await waitForAsyncResultFile(id);
     const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
@@ -997,11 +1180,10 @@ describe("async execution health", () => {
       .map((line) => JSON.parse(line))
       .filter((record) => record.type === "subagent.control" && record.event?.reason === "idle");
     assert.equal(payload.success, true);
-    assert.equal(idleControls.length, 2);
-    assert.notEqual(idleControls[0]?.event?.idleEpisodeId, idleControls[1]?.event?.idleEpisodeId);
-    assert.notEqual(
-      firstIdleControl?.event?.idleEpisodeId,
-      secondIdleObserved.status.steps?.[0]?.idleEpisodeId,
-    );
+    assert.equal(idleControls.length, attemptOneIdleCount + 1);
+    const fallbackIdleEpisodeId = fallbackIdleObserved.status.steps?.[0]?.idleEpisodeId;
+    if (typeof fallbackIdleEpisodeId !== "string") assert.fail("fallback idle episode is missing");
+    assert.equal(idleControls.at(-1)?.event?.idleEpisodeId, fallbackIdleEpisodeId);
+    assert.ok(!attemptOneIdleEpisodeIds.includes(fallbackIdleEpisodeId));
   });
 });

--- a/extensions/subagents/test/integration/foreground-execution-health.test.ts
+++ b/extensions/subagents/test/integration/foreground-execution-health.test.ts
@@ -1,0 +1,144 @@
+/** Deterministic foreground watchdog health regressions. */
+
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  createMockPi,
+  createTempDir,
+  events,
+  makeAgent,
+  removeTempDir,
+} from "../support/helpers.ts";
+import type { MockPi } from "../support/helpers.ts";
+import { scaleTestTimeout } from "../support/scale-timeout.ts";
+import {
+  available,
+  mockAssistantMessage,
+  runSync,
+  type RunSyncResult,
+} from "../support/single-execution-fixtures.ts";
+import { ACTIVITY_MONITOR_GAP_THRESHOLD_MS } from "../../src/runs/shared/health-transition.ts";
+
+type ControlEvent = NonNullable<RunSyncResult["controlEvents"]>[number];
+
+const IDLE_CONTROL_CONFIG = {
+  enabled: true,
+  needsAttentionAfterMs: 200,
+  activeNoticeAfterMs: 999_999,
+  activeNoticeAfterTurns: 999_999,
+  activeNoticeAfterTokens: 999_999,
+  notifyOn: ["active_long_running", "needs_attention"],
+} as const;
+
+describe(
+  "foreground execution health",
+  { skip: !available ? "pi packages not available" : undefined },
+  () => {
+    let tempDir: string;
+    let mockPi: MockPi;
+
+    before(() => {
+      mockPi = createMockPi();
+      mockPi.install();
+    });
+
+    after(() => {
+      mockPi.uninstall();
+    });
+
+    beforeEach(() => {
+      tempDir = createTempDir();
+      mockPi.reset();
+    });
+
+    afterEach(() => {
+      removeTempDir(tempDir);
+    });
+
+    it("does not charge a delayed foreground monitor tick as idle time", async () => {
+      const release = path.join(tempDir, "foreground-monitor-gap-release");
+      mockPi.onCall({
+        steps: [
+          { jsonl: [mockAssistantMessage("quiet baseline", "tool_use")] },
+          { waitForMarker: release },
+          { jsonl: [events.assistantMessage("completed after the monitor gap")] },
+        ],
+      });
+      const controlEvents: ControlEvent[] = [];
+      let blocked = false;
+      const safetyRelease = setTimeout(() => {
+        if (!fs.existsSync(release)) fs.writeFileSync(release, "", "utf-8");
+      }, scaleTestTimeout(10_000));
+      safetyRelease.unref?.();
+      try {
+        const result = await runSync(
+          tempDir,
+          [makeAgent("scout", { completionGuard: false })],
+          "scout",
+          "Investigate monitor timing",
+          {
+            runId: "foreground-monitor-gap",
+            controlConfig: IDLE_CONTROL_CONFIG,
+            onControlEvent: (event: ControlEvent) => controlEvents.push(event),
+            onUpdate: () => {
+              if (blocked) return;
+              blocked = true;
+              const blocker = new Int32Array(new SharedArrayBuffer(4));
+              Atomics.wait(blocker, 0, 0, ACTIVITY_MONITOR_GAP_THRESHOLD_MS + 500);
+              setTimeout(() => {
+                if (!fs.existsSync(release)) fs.writeFileSync(release, "", "utf-8");
+              }, 500);
+            },
+          },
+        );
+        assert.equal(result.exitCode, 0);
+        assert.equal(blocked, true);
+        assert.equal(
+          controlEvents.find((event) => event.reason === "idle"),
+          undefined,
+        );
+        assert.equal(
+          result.controlEvents?.find((event) => event.reason === "idle"),
+          undefined,
+        );
+      } finally {
+        clearTimeout(safetyRelease);
+        if (!fs.existsSync(release)) fs.writeFileSync(release, "", "utf-8");
+      }
+    });
+
+    it("emits idle attention after continuously observed foreground silence", async () => {
+      const release = path.join(tempDir, "foreground-genuine-idle-release");
+      mockPi.onCall({
+        steps: [
+          { jsonl: [mockAssistantMessage("quiet baseline", "tool_use")] },
+          { waitForMarker: release },
+          { jsonl: [events.assistantMessage("completed after genuine idle")] },
+        ],
+      });
+      const controlEvents: ControlEvent[] = [];
+      const result = await runSync(
+        tempDir,
+        [makeAgent("scout", { completionGuard: false })],
+        "scout",
+        "Investigate genuine idle timing",
+        {
+          runId: "foreground-genuine-idle",
+          controlConfig: IDLE_CONTROL_CONFIG,
+          onControlEvent: (event: ControlEvent) => {
+            controlEvents.push(event);
+            if (event.reason === "idle" && !fs.existsSync(release))
+              fs.writeFileSync(release, "", "utf-8");
+          },
+        },
+      );
+      const idleEvents = controlEvents.filter((event) => event.reason === "idle");
+      assert.equal(result.exitCode, 0);
+      assert.equal(idleEvents.length, 1);
+      assert.equal(idleEvents[0]?.type, "needs_attention");
+      assert.ok((idleEvents[0]?.elapsedMs ?? 0) >= 200);
+    });
+  },
+);

--- a/extensions/subagents/test/integration/single-execution-basic.test.ts
+++ b/extensions/subagents/test/integration/single-execution-basic.test.ts
@@ -39,7 +39,6 @@ import {
   type RunSyncResult,
 } from "../support/single-execution-fixtures.ts";
 import type { ContextUsageDiagnostics } from "../../src/shared/types.ts";
-
 describe(
   "single sync execution",
   { skip: !available ? "pi packages not available" : undefined },

--- a/extensions/subagents/test/support/single-execution-fixtures.ts
+++ b/extensions/subagents/test/support/single-execution-fixtures.ts
@@ -93,6 +93,7 @@ export interface RunSyncResult {
     contextPressureThreshold?: string;
     turns?: number;
     tokens?: number;
+    elapsedMs?: number;
     currentPath?: string;
     recentFailureSummary?: string;
   }>;


### PR DESCRIPTION
## Summary

- make foreground and background idle watchdogs count only continuously observed quiet time
- re-baseline background fallback attempts without rewriting truthful child activity timestamps
- record privacy-safe async monitor-gap diagnostics and add deterministic regressions

Fixes #620.

## Change type

- [ ] Installer / wrapper
- [x] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [ ] Other

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: passed after rebasing onto current `origin/main` (unit 1658/1658, integration 654/654, e2e 1/1; typecheck, generated-runtime freshness, lint, formatting, shell checks, installer smoke, and package dry-run passed).

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/fix/620-idle-observation-gaps/install.sh | bash -s -- --ref fix/620-idle-observation-gaps --track ref
```
