### PR TITLE
Remove prompt wording assertions

### DIFF
--- a/tests/the-last-harness-attribution.test.mjs
+++ b/tests/the-last-harness-attribution.test.mjs
@@ -81,10 +81,6 @@ test("commit attribution prompt helper only renders when enabled", () => {
     buildTlhCommitAttributionPrompt(resolveTlhCommitAttribution(undefined)) ?? "",
     /Co-authored-by: The Last Harness <hi@thelastharness\.com>/,
   );
-  assert.match(
-    buildTlhCommitAttributionPrompt(resolveTlhCommitAttribution(undefined)) ?? "",
-    /blank line/,
-  );
 });
 
 test("git commit attribution guard blocks only obvious unattributed inline commit commands", () => {

--- a/tests/the-last-harness-experimental.test.mjs
+++ b/tests/the-last-harness-experimental.test.mjs
@@ -232,26 +232,6 @@ test("ci failure investigation prompt injection stays default-off and only enabl
     buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
     /## TLH Experimental Feature: ci-failure-investigation/,
   );
-  assert.match(
-    buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
-    /overrides the default post-PR monitor-and-ask-only step/i,
-  );
-  assert.match(
-    buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
-    /You may do a read-only investigation before asking the user whether to proceed/i,
-  );
-  assert.match(
-    buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
-    /Do not edit files, commit, push, rerun jobs, change the PR/i,
-  );
-  assert.match(
-    buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
-    /edits, commits, pushes, reruns, PR changes, or other follow-up changes/i,
-  );
-  assert.match(
-    buildPrimaryExperimentalPrompt({ name: "architect" }, enabledConfig) ?? "",
-    /ask for explicit user approval/i,
-  );
   assert.equal(buildPrimaryExperimentalPrompt({ name: "rush" }, enabledConfig), undefined);
   assert.equal(buildPrimaryExperimentalPrompt({ name: "product" }, enabledConfig), undefined);
   assert.equal(buildPrimaryExperimentalPrompt({ name: "bug-hunter" }, enabledConfig), undefined);

--- a/tests/the-last-harness-extension-static.test.mjs
+++ b/tests/the-last-harness-extension-static.test.mjs
@@ -5,13 +5,12 @@ import test from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const {
-  buildChildSubagentSystemPrompt,
-  buildTlhSystemPrompt,
-  loadPrimaryAgents,
-  loadSubagentMetadata,
-} = await jiti.import("../extensions/the-last-harness/prompts.ts");
+const { buildTlhSystemPrompt, loadPrimaryAgents, loadSubagentMetadata } = await jiti.import(
+  "../extensions/the-last-harness/prompts.ts",
+);
 const { buildReviewHtml } = await jiti.import("../extensions/annotate-git-diff/ui.ts");
+
+const USER_SCOPE_MARKER = /agentScope.*"user"/;
 
 function extractJsonStringAssignment(html, assignmentName) {
   const escapedName = assignmentName.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
@@ -200,25 +199,17 @@ test("annotate-git-diff review HTML inlines Monaco assets without file:// URLs i
   }
 });
 
-test("primary and child prompts do not include disabled-ticket fallback guidance", () => {
+test("primary prompt exposes stable minor-agent delegation markers", () => {
   const primaryAgents = loadPrimaryAgents();
   const rush = primaryAgents.get("rush");
   assert.ok(rush, "Rush primary prompt should load");
 
   const primaryPrompt = buildTlhSystemPrompt(rush, loadSubagentMetadata(), true);
-  const childPrompt = buildChildSubagentSystemPrompt();
 
   assert.match(primaryPrompt, /## TLH Allowed Minor Subagents/);
   assert.match(primaryPrompt, /action: "list"`\/`"get"`\/`"resume"/);
-  assert.match(primaryPrompt, /omit `agentScope` or use `"user"`/);
-  assert.match(primaryPrompt, /TLH minor agents are isolated to the user scope/);
+  assert.match(primaryPrompt, USER_SCOPE_MARKER);
   assert.match(primaryPrompt, /- contrarian:/i);
-
-  for (const prompt of [primaryPrompt, childPrompt]) {
-    assert.doesNotMatch(prompt, /## TLH Ticket Integration Disabled/);
-    assert.doesNotMatch(prompt, /non-ticket/i);
-    assert.doesNotMatch(prompt, /ticket integration is disabled/i);
-  }
 });
 
 test("allowed-subagents prompt scopes embedded guidance to architect regardless of settings", () => {
@@ -229,47 +220,33 @@ test("allowed-subagents prompt scopes embedded guidance to architect regardless 
   const bugHunter = primaryAgents.get("bug-hunter");
   const subagents = loadSubagentMetadata();
 
-  const embeddedClause = /embedded\.<slug>.*agent.*explicitly names or asks/s;
-  const projectNaturalLanguageClause =
-    /project agents are intentionally omitted.*list.*get.*user asks for the `xyz` project subagent.*`embedded\.xyz`.*exception.*management output omits it/is;
-  const closingRule = /Do not delegate outside this bundled TLH minor-agent list\./;
-  const managementGuidance = /TLH minor agents are isolated to the user scope/;
+  const embeddedTargetMarker = /embedded\.<slug>/;
+  const embeddedProjectAgentMarker = /embedded\.xyz/;
+  const projectAgentPathMarker = /\.tlh\/agents\/custom\/<UPPERCASE-SLUG>\.md/;
   const sectionHeader = /## TLH Allowed Minor Subagents/;
+  const reviewHandoffHeader = /## \/review handoff/;
 
   const architectPrompt = buildTlhSystemPrompt(architect, subagents, true);
   assert.match(architectPrompt, sectionHeader);
-  assert.match(architectPrompt, managementGuidance);
-  assert.match(architectPrompt, embeddedClause);
-  assert.match(architectPrompt, projectNaturalLanguageClause);
-  assert.doesNotMatch(architectPrompt, closingRule);
+  assert.match(architectPrompt, embeddedTargetMarker);
+  assert.match(architectPrompt, embeddedProjectAgentMarker);
+  assert.match(architectPrompt, projectAgentPathMarker);
+  assert.match(architectPrompt, USER_SCOPE_MARKER);
 
   for (const primary of [rush, product, bugHunter]) {
     const label = primary?.name ?? "unknown";
     const prompt = buildTlhSystemPrompt(primary, subagents, true);
     assert.match(prompt, sectionHeader, `${label}: section header present`);
-    assert.match(prompt, managementGuidance, `${label}: management guidance present`);
-    assert.doesNotMatch(prompt, embeddedClause, `${label}: no embedded clause`);
-    assert.match(prompt, closingRule, `${label}: closing rule present`);
-    assert.doesNotMatch(prompt, /## \/review handoff/, `${label}: no review handoff`);
+    assert.doesNotMatch(prompt, embeddedTargetMarker, `${label}: no embedded guidance`);
+    assert.doesNotMatch(prompt, reviewHandoffHeader, `${label}: no review handoff`);
   }
 
   const disabledPrompt = buildTlhSystemPrompt(undefined, subagents, false);
   assert.match(disabledPrompt, sectionHeader, "disabled: section header present");
-  assert.match(disabledPrompt, managementGuidance, "disabled: management guidance present");
-  assert.match(disabledPrompt, embeddedClause, "disabled: embedded guidance present");
-  assert.match(disabledPrompt, /\.tlh\/agents\/custom\/<UPPERCASE-SLUG>\.md/);
-  assert.match(disabledPrompt, /## \/review handoff/);
-  assert.match(disabledPrompt, /`code-reviewer` subagent in a \*\*fresh \(isolated\) context\*\*/);
-  assert.match(disabledPrompt, /passing the full envelope contents as the task input/);
-  assert.match(disabledPrompt, /present a concise digested summary with your own assessment/);
+  assert.match(disabledPrompt, embeddedTargetMarker, "disabled: embedded guidance present");
+  assert.doesNotMatch(disabledPrompt, embeddedProjectAgentMarker);
+  assert.match(disabledPrompt, projectAgentPathMarker);
+  assert.match(disabledPrompt, USER_SCOPE_MARKER);
+  assert.match(disabledPrompt, /## \/review handoff[\s\S]*code-reviewer/);
   assert.doesNotMatch(disabledPrompt, /You are the TLH architect/);
-  assert.doesNotMatch(
-    disabledPrompt,
-    /Do not delegate outside this bundled TLH minor-agent list\./,
-  );
-  assert.doesNotMatch(
-    disabledPrompt,
-    /clarify the requested outcome.*create and maintain.*ticket plan/is,
-  );
-  assert.doesNotMatch(disabledPrompt, /After approval:/);
 });

--- a/tests/the-last-harness-primary-agent-runtime-prompt-guidance.test.mjs
+++ b/tests/the-last-harness-primary-agent-runtime-prompt-guidance.test.mjs
@@ -28,6 +28,9 @@ const jiti = createJiti(import.meta.url);
 const { formatProjectAgentGuidance } = await jiti.import(
   "../extensions/the-last-harness/prompts.ts",
 );
+const { buildPrimaryExperimentalPrompt, buildChildExperimentalPrompt } = await jiti.import(
+  "../extensions/the-last-harness/experimental.ts",
+);
 const {
   CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
   default: registerSubagentPromptRuntime,
@@ -418,7 +421,7 @@ test("root hook relocates only a terminal child boundary", () => {
     [quotedPrompt, rootRuntimeBlock, CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS].join("\n\n"),
   );
   assert.equal(
-    (rewritten.match(/You are a child subagent, not the parent orchestrator\./g) ?? []).length,
+    rewritten.split(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS).length - 1,
     2,
     "quoted and runtime-owned boundaries must both survive",
   );
@@ -431,7 +434,7 @@ test("root hook keeps its no-boundary append-only behavior", () => {
     [CHILD_SUBAGENT_ROOT_RUNTIME_OPEN, content, CHILD_SUBAGENT_ROOT_RUNTIME_CLOSE].join("\n");
   const rewritten = appendBeforeChildSubagentBoundary(prompt, "root child additions");
   assert.equal(rewritten, [prompt, rootRuntimeBlock("root child additions")].join("\n\n"));
-  assert.doesNotMatch(rewritten, /You are a child subagent, not the parent orchestrator\./);
+  assert.equal(rewritten.includes(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), false);
 
   const replaced = appendBeforeChildSubagentBoundary(rewritten, "updated root additions");
   assert.equal(replaced, [prompt, rootRuntimeBlock("updated root additions")].join("\n\n"));
@@ -439,7 +442,7 @@ test("root hook keeps its no-boundary append-only behavior", () => {
 
   const cleared = appendBeforeChildSubagentBoundary(replaced, "");
   assert.equal(cleared, prompt);
-  assert.doesNotMatch(cleared, /You are a child subagent, not the parent orchestrator\./);
+  assert.equal(cleared.includes(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), false);
 });
 
 test("malformed and duplicate-owner reserved-marker base text remains intact", () => {
@@ -476,7 +479,7 @@ test("malformed and duplicate-owner reserved-marker base text remains intact", (
 test("marked root and explicit content replace when their text changes", () => {
   const options = { inheritProjectContext: true, inheritSkills: true };
   const rootOnly = appendBeforeChildSubagentBoundary("base prompt", "root version one");
-  assert.doesNotMatch(rootOnly, /You are a child subagent, not the parent orchestrator\./);
+  assert.equal(rootOnly.includes(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), false);
   const first = rewriteSubagentPrompt(rootOnly, options, "guidance version one");
   assert.match(first, /root version one/);
   assert.ok(first.endsWith(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS));
@@ -494,10 +497,7 @@ test("marked root and explicit content replace when their text changes", () => {
     (second.match(new RegExp(CHILD_SUBAGENT_EXPLICIT_RUNTIME_OPEN, "g")) ?? []).length,
     1,
   );
-  assert.equal(
-    (second.match(/You are a child subagent, not the parent orchestrator\./g) ?? []).length,
-    1,
-  );
+  assert.equal(second.split(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS).length - 1, 1);
   assert.equal(
     rewriteSubagentPrompt(
       appendBeforeChildSubagentBoundary(second, "root version two"),
@@ -657,7 +657,7 @@ test("child hook composition is idempotent in either registration order", async 
           `${label}: child boundary must remain terminal`,
         );
         assert.equal(
-          (onePass.match(/You are a child subagent, not the parent orchestrator\./g) ?? []).length,
+          onePass.split(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS).length - 1,
           2,
           `${label}: quoted and authoritative child boundaries must both survive`,
         );
@@ -896,13 +896,18 @@ test("disabled primary mode keeps neutral TLH delegation guidance without the ar
   const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 
   await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
+    const primaryAgents = selectablePrimaryAgents();
+    primaryAgents.set(
+      "architect",
+      createPrimaryPrompt("architect", { systemPrompt: "architect persona sentinel" }),
+    );
     const { beforeAgentStart } = registerRuntimeHarness({
-      primaryAgents: selectablePrimaryAgents(),
+      primaryAgents,
       subagentMetadata: [
-        { name: "developer", description: "Implements exactly one approved task at a time." },
+        { name: "developer", description: "developer description sentinel" },
         {
           name: "test-runner",
-          description: "Executes exact ordered shell/MCP final-validation steps without editing.",
+          description: "test-runner description sentinel",
         },
         contrarianMetadata(),
       ],
@@ -924,22 +929,10 @@ test("disabled primary mode keeps neutral TLH delegation guidance without the ar
 
     assert.match(disabledPrompt.systemPrompt, /## The Last Harness Defaults/);
     assert.match(disabledPrompt.systemPrompt, /## TLH Allowed Minor Subagents/);
-    assert.match(
-      disabledPrompt.systemPrompt,
-      /- developer: Implements exactly one approved task at a time\./,
-    );
-    assert.match(
-      disabledPrompt.systemPrompt,
-      /- test-runner: Executes exact ordered shell\/MCP final-validation steps without editing\./,
-    );
-    assert.match(disabledPrompt.systemPrompt, /Trusted `embedded\.<slug>` agents/);
-    assert.doesNotMatch(disabledPrompt.systemPrompt, /You are the TLH architect/);
+    assert.match(disabledPrompt.systemPrompt, /- developer: developer description sentinel/);
+    assert.match(disabledPrompt.systemPrompt, /- test-runner: test-runner description sentinel/);
+    assert.doesNotMatch(disabledPrompt.systemPrompt, /architect persona sentinel/);
     assert.doesNotMatch(disabledPrompt.systemPrompt, /## TLH Experimental Feature:/);
-    assert.doesNotMatch(
-      disabledPrompt.systemPrompt,
-      /final-validation ticket.*depends on all implementation tickets/i,
-    );
-    assert.doesNotMatch(disabledPrompt.systemPrompt, /architect-only/i);
   });
 });
 
@@ -957,8 +950,6 @@ test("before_agent_start adds TLH commit attribution guidance only when enabled"
       enabledPrompt.systemPrompt,
       /Co-authored-by: The Last Harness <hi@thelastharness\.com>/,
     );
-    assert.match(enabledPrompt.systemPrompt, /blank line/);
-
     writeFileSync(
       join(fixture.agent, "settings.json"),
       `${JSON.stringify({ tlh: { attribution: { commit: false } } }, null, 2)}\n`,
@@ -971,33 +962,18 @@ test("before_agent_start adds TLH commit attribution guidance only when enabled"
   });
 });
 
-test("before_agent_start includes permanent architect final-validation guidance and ignores stale tlh.experimental settings", async (t) => {
+test("before_agent_start keeps the architect prompt when stale tlh.experimental settings are present", async (t) => {
   const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
 
   await withEnv({ HOME: fixture.home, PI_CODING_AGENT_DIR: fixture.agent }, async () => {
-    const { beforeAgentStart } = registerRuntimeHarness();
-    const assertValidationWorkflow = (systemPrompt) => {
-      assert.match(systemPrompt, /final-validation ticket.*depends on all implementation tickets/i);
-      assert.match(systemPrompt, /implementation-ticket validation narrow and ticket-scoped/i);
-      assert.match(
-        systemPrompt,
-        /Every final-validation ticket must list the exact ordered validation steps that `test-runner` must execute/i,
-      );
-      assert.match(
-        systemPrompt,
-        /complete shell command.*exact adapter-shaped input for the generic `mcp` gateway.*only the fields required by the selected status, discovery, search, connect, or call operation.*`server`, `tool`, and `args` are optional overall.*JSON string for tool calls/i,
-      );
-      assert.match(
-        systemPrompt,
-        /VALIDATING\.md.*otherwise use repo-discovered validation checks/i,
-      );
-      assert.match(systemPrompt, /implementation tickets go to `developer`/i);
-      assert.match(systemPrompt, /final-validation tickets go to `test-runner`/i);
-      assert.match(
-        systemPrompt,
-        /Do not send a final-validation ticket to `developer`, and do not send an implementation ticket to `test-runner`/i,
-      );
-      assert.match(systemPrompt, /Make any validation deferral explicit in the ticket text/i);
+    const primaryAgents = selectablePrimaryAgents();
+    primaryAgents.set(
+      "architect",
+      createPrimaryPrompt("architect", { systemPrompt: "architect prompt sentinel" }),
+    );
+    const { beforeAgentStart } = registerRuntimeHarness({ primaryAgents });
+    const assertArchitectPrompt = (systemPrompt) => {
+      assert.match(systemPrompt, /architect prompt sentinel/);
       assert.doesNotMatch(systemPrompt, /## TLH Experimental Feature:/);
     };
 
@@ -1005,7 +981,7 @@ test("before_agent_start includes permanent architect final-validation guidance 
       { systemPrompt: "base prompt" },
       createToolCallContext([], undefined, { cwd: fixture.cwd }),
     );
-    assertValidationWorkflow(defaultPrompt.systemPrompt);
+    assertArchitectPrompt(defaultPrompt.systemPrompt);
 
     for (const experimental of [
       { enabledFeatures: true },
@@ -1021,7 +997,7 @@ test("before_agent_start includes permanent architect final-validation guidance 
         { systemPrompt: "base prompt" },
         createToolCallContext([], undefined, { cwd: fixture.cwd }),
       );
-      assertValidationWorkflow(prompt.systemPrompt);
+      assertArchitectPrompt(prompt.systemPrompt);
     }
   });
 });
@@ -1042,16 +1018,6 @@ test("before_agent_start gates delta follow-up review guidance behind isolated T
       defaultPrompt.systemPrompt,
       /## TLH Experimental Feature: delta-follow-up-reviews/,
     );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /default the follow-up `code-reviewer` request to the delta since the last reviewed checkpoint/i,
-    );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /prior findings.*git range or checkpoint.*changed-file list/i,
-    );
-    assert.doesNotMatch(defaultPrompt.systemPrompt, /targeted wider review or full re-review/i);
-
     for (const enabledFeatures of [true, [123]]) {
       writeFileSync(
         join(fixture.agent, "settings.json"),
@@ -1065,16 +1031,12 @@ test("before_agent_start gates delta follow-up review guidance behind isolated T
         malformedPrompt.systemPrompt,
         /## TLH Experimental Feature: delta-follow-up-reviews/,
       );
-      assert.doesNotMatch(
-        malformedPrompt.systemPrompt,
-        /default the follow-up `code-reviewer` request to the delta since the last reviewed checkpoint/i,
-      );
-      assert.doesNotMatch(malformedPrompt.systemPrompt, /targeted wider review or full re-review/i);
     }
 
+    const deltaConfig = { enabledFeatures: [DELTA_FOLLOW_UP_REVIEWS_FEATURE] };
     writeFileSync(
       join(fixture.agent, "settings.json"),
-      `${JSON.stringify({ tlh: { experimental: { enabledFeatures: [DELTA_FOLLOW_UP_REVIEWS_FEATURE] } } }, null, 2)}\n`,
+      `${JSON.stringify({ tlh: { experimental: deltaConfig } }, null, 2)}\n`,
     );
     const enabledPrompt = await beforeAgentStart(
       { systemPrompt: "base prompt" },
@@ -1084,15 +1046,12 @@ test("before_agent_start gates delta follow-up review guidance behind isolated T
       enabledPrompt.systemPrompt,
       /## TLH Experimental Feature: delta-follow-up-reviews/,
     );
-    assert.match(
-      enabledPrompt.systemPrompt,
-      /default the follow-up `code-reviewer` request to the delta since the last reviewed checkpoint/i,
+    const architectExperimentalPrompt = buildPrimaryExperimentalPrompt(
+      { name: "architect" },
+      deltaConfig,
     );
-    assert.match(
-      enabledPrompt.systemPrompt,
-      /prior findings.*git range or checkpoint.*changed-file list/i,
-    );
-    assert.match(enabledPrompt.systemPrompt, /targeted wider review or full re-review/i);
+    assert.ok(architectExperimentalPrompt);
+    assert.ok(enabledPrompt.systemPrompt.includes(architectExperimentalPrompt));
   });
 });
 
@@ -1112,11 +1071,6 @@ test("before_agent_start gates ci failure investigation guidance behind isolated
       defaultPrompt.systemPrompt,
       /## TLH Experimental Feature: ci-failure-investigation/,
     );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /read-only investigation before asking the user whether to proceed/i,
-    );
-
     for (const enabledFeatures of [true, [123]]) {
       writeFileSync(
         join(fixture.agent, "settings.json"),
@@ -1129,10 +1083,6 @@ test("before_agent_start gates ci failure investigation guidance behind isolated
       assert.doesNotMatch(
         malformedPrompt.systemPrompt,
         /## TLH Experimental Feature: ci-failure-investigation/,
-      );
-      assert.doesNotMatch(
-        malformedPrompt.systemPrompt,
-        /read-only investigation before asking the user whether to proceed/i,
       );
     }
 
@@ -1148,28 +1098,6 @@ test("before_agent_start gates ci failure investigation guidance behind isolated
       architectPrompt.systemPrompt,
       /## TLH Experimental Feature: ci-failure-investigation/,
     );
-    assert.match(
-      architectPrompt.systemPrompt,
-      /This TLH experiment is enabled for the architect primary agent/i,
-    );
-    assert.match(
-      architectPrompt.systemPrompt,
-      /overrides the default post-PR monitor-and-ask-only step/i,
-    );
-    assert.match(
-      architectPrompt.systemPrompt,
-      /read-only investigation before asking the user whether to proceed/i,
-    );
-    assert.match(
-      architectPrompt.systemPrompt,
-      /Do not edit files, commit, push, rerun jobs, change the PR/i,
-    );
-    assert.match(
-      architectPrompt.systemPrompt,
-      /edits, commits, pushes, reruns, PR changes, or other follow-up changes/i,
-    );
-    assert.match(architectPrompt.systemPrompt, /ask for explicit user approval/i);
-
     writeFileSync(
       join(fixture.agent, "settings.json"),
       `${JSON.stringify(
@@ -1190,15 +1118,6 @@ test("before_agent_start gates ci failure investigation guidance behind isolated
     assert.doesNotMatch(
       rushPrompt.systemPrompt,
       /## TLH Experimental Feature: ci-failure-investigation/,
-    );
-    assert.doesNotMatch(rushPrompt.systemPrompt, /This TLH experiment is enabled for TLH Rush/i);
-    assert.doesNotMatch(
-      rushPrompt.systemPrompt,
-      /read-only investigation before asking the user whether to proceed/i,
-    );
-    assert.doesNotMatch(
-      rushPrompt.systemPrompt,
-      /summarize the failure and likely cause, then ask the user whether to proceed/i,
     );
   });
 });
@@ -1223,11 +1142,6 @@ test("before_agent_start ci-failure-investigation guidance stays per-turn: enabl
       offPrompt.systemPrompt,
       /## TLH Experimental Feature: ci-failure-investigation/,
     );
-    assert.doesNotMatch(
-      offPrompt.systemPrompt,
-      /read-only investigation before asking the user whether to proceed/i,
-    );
-
     // Enable the feature mid-session.
     writeFileSync(
       join(fixture.agent, "settings.json"),
@@ -1238,17 +1152,13 @@ test("before_agent_start ci-failure-investigation guidance stays per-turn: enabl
     // because prompt-only experimental features read settings fresh every turn.
     const onPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, ctx);
     assert.match(onPrompt.systemPrompt, /## TLH Experimental Feature: ci-failure-investigation/);
-    assert.match(
-      onPrompt.systemPrompt,
-      /read-only investigation before asking the user whether to proceed/i,
-    );
   });
 });
 
 test("before_agent_start includes contrarian guidance by default and ignores stale contrarian experimental settings", async (t) => {
   const fixture = createIsolatedProfileFixture("tlh-primary-runtime-test-", { cwd: true, test: t });
   const subagentMetadata = [
-    { name: "developer", description: "Implements exactly one approved task at a time." },
+    { name: "developer", description: "developer description sentinel" },
     contrarianMetadata(),
   ];
 
@@ -1270,14 +1180,8 @@ test("before_agent_start includes contrarian guidance by default and ignores sta
     );
     const defaultPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, architectCtx);
     assert.doesNotMatch(defaultPrompt.systemPrompt, /## TLH Experimental Feature: contrarian/);
-    assert.match(
-      defaultPrompt.systemPrompt,
-      /- contrarian: Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case\./i,
-    );
-    assert.match(
-      defaultPrompt.systemPrompt,
-      /developer: Implements exactly one approved task at a time\./i,
-    );
+    assert.match(defaultPrompt.systemPrompt, /- contrarian:/i);
+    assert.match(defaultPrompt.systemPrompt, /developer:/i);
 
     writeFileSync(
       join(fixture.agent, "settings.json"),
@@ -1285,14 +1189,8 @@ test("before_agent_start includes contrarian guidance by default and ignores sta
     );
     const malformedPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, architectCtx);
     assert.doesNotMatch(malformedPrompt.systemPrompt, /## TLH Experimental Feature: contrarian/);
-    assert.match(
-      malformedPrompt.systemPrompt,
-      /- contrarian: Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case\./i,
-    );
-    assert.match(
-      malformedPrompt.systemPrompt,
-      /developer: Implements exactly one approved task at a time\./i,
-    );
+    assert.match(malformedPrompt.systemPrompt, /- contrarian:/i);
+    assert.match(malformedPrompt.systemPrompt, /developer:/i);
 
     writeFileSync(
       join(fixture.agent, "settings.json"),
@@ -1300,10 +1198,7 @@ test("before_agent_start includes contrarian guidance by default and ignores sta
     );
     const legacyFlagPrompt = await beforeAgentStart({ systemPrompt: "base prompt" }, architectCtx);
     assert.doesNotMatch(legacyFlagPrompt.systemPrompt, /## TLH Experimental Feature: contrarian/);
-    assert.match(
-      legacyFlagPrompt.systemPrompt,
-      /- contrarian: Stress-tests plans, designs, and conclusions by steelmanning the strongest opposing case\./i,
-    );
+    assert.match(legacyFlagPrompt.systemPrompt, /- contrarian:/i);
   });
 });
 
@@ -1337,8 +1232,6 @@ test("child mode keeps parent-only controls disabled while applying commit attri
       enabledPrompt.systemPrompt,
       /Co-authored-by: The Last Harness <hi@thelastharness\.com>/,
     );
-    assert.match(enabledPrompt.systemPrompt, /blank line/);
-
     const blockedCommit = await toolCall(
       { toolName: "bash", input: { command: 'git commit -m "ship it"' } },
       createToolCallContext([], undefined, { cwd: fixture.cwd }),
@@ -1397,19 +1290,6 @@ test("child mode gates delta follow-up review guidance to enabled code-reviewer 
       defaultPrompt.systemPrompt,
       /## TLH Experimental Feature: delta-follow-up-reviews/,
     );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /expect prior findings plus an exact delta baseline/i,
-    );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /default to the requested delta and prior findings/i,
-    );
-    assert.doesNotMatch(
-      defaultPrompt.systemPrompt,
-      /requested delta cannot be validated safely without wider context/i,
-    );
-
     for (const enabledFeatures of [true, [123]]) {
       writeFileSync(
         join(fixture.agent, "settings.json"),
@@ -1423,23 +1303,12 @@ test("child mode gates delta follow-up review guidance to enabled code-reviewer 
         malformedPrompt.systemPrompt,
         /## TLH Experimental Feature: delta-follow-up-reviews/,
       );
-      assert.doesNotMatch(
-        malformedPrompt.systemPrompt,
-        /expect prior findings plus an exact delta baseline/i,
-      );
-      assert.doesNotMatch(
-        malformedPrompt.systemPrompt,
-        /default to the requested delta and prior findings/i,
-      );
-      assert.doesNotMatch(
-        malformedPrompt.systemPrompt,
-        /requested delta cannot be validated safely without wider context/i,
-      );
     }
 
+    const deltaConfig = { enabledFeatures: [DELTA_FOLLOW_UP_REVIEWS_FEATURE] };
     writeFileSync(
       join(fixture.agent, "settings.json"),
-      `${JSON.stringify({ tlh: { experimental: { enabledFeatures: [DELTA_FOLLOW_UP_REVIEWS_FEATURE] } } }, null, 2)}\n`,
+      `${JSON.stringify({ tlh: { experimental: deltaConfig } }, null, 2)}\n`,
     );
     const enabledPrompt = await codeReviewerBeforeAgentStart(
       { systemPrompt: "base prompt" },
@@ -1449,13 +1318,12 @@ test("child mode gates delta follow-up review guidance to enabled code-reviewer 
       enabledPrompt.systemPrompt,
       /## TLH Experimental Feature: delta-follow-up-reviews/,
     );
-    assert.match(enabledPrompt.systemPrompt, /expect prior findings plus an exact delta baseline/i);
-    assert.match(enabledPrompt.systemPrompt, /default to the requested delta and prior findings/i);
-    assert.match(
-      enabledPrompt.systemPrompt,
-      /requested delta cannot be validated safely without wider context/i,
+    const codeReviewerExperimentalPrompt = buildChildExperimentalPrompt(
+      "code-reviewer",
+      deltaConfig,
     );
-
+    assert.ok(codeReviewerExperimentalPrompt);
+    assert.ok(enabledPrompt.systemPrompt.includes(codeReviewerExperimentalPrompt));
     const developerPi = createPiHarness();
     registerTlhPrimaryAgentRuntime(developerPi, {
       env: { PI_SUBAGENT_CHILD: "1", PI_SUBAGENT_CHILD_AGENT: "developer" },
@@ -1471,18 +1339,6 @@ test("child mode gates delta follow-up review guidance to enabled code-reviewer 
     assert.doesNotMatch(
       developerPrompt.systemPrompt,
       /## TLH Experimental Feature: delta-follow-up-reviews/,
-    );
-    assert.doesNotMatch(
-      developerPrompt.systemPrompt,
-      /expect prior findings plus an exact delta baseline/i,
-    );
-    assert.doesNotMatch(
-      developerPrompt.systemPrompt,
-      /default to the requested delta and prior findings/i,
-    );
-    assert.doesNotMatch(
-      developerPrompt.systemPrompt,
-      /requested delta cannot be validated safely without wider context/i,
     );
   });
 });

--- a/tests/tlh-subagent-safety.test.mjs
+++ b/tests/tlh-subagent-safety.test.mjs
@@ -219,20 +219,8 @@ test("validateSubagentToolInput allows opaque resume and blocks unsafe scopes", 
   assert.equal(allowedDeveloperResume.agentScope, "user");
 });
 
-test("validateSubagentToolInput uses generic primary-agent wording", () => {
-  const reasons = [
-    validateSubagentToolInput(null),
-    validateSubagentToolInput({ action: "delete" }),
-    validateSubagentToolInput({ agent: "developer" }),
-  ].filter(Boolean);
-
-  for (const reason of reasons) {
-    assert.match(reason, /TLH primary(?:-agent| agents)/);
-    assert.doesNotMatch(reason, /TLH architect/);
-  }
-});
-
 test("validateSubagentToolInput rejects disallowed agents", () => {
+  assert.ok(validateSubagentToolInput(null));
   assert.match(
     validateSubagentToolInput({ agent: "architect" }),
     /Disallowed target\(s\): architect/,


### PR DESCRIPTION
## Summary

- remove tests and assertions that only pin mutable primary/subagent prompt prose
- retain structural prompt composition, role/settings gating, safety boundaries, privacy, and runtime guard coverage
- replace brittle prose checks with production constants, protocol markers, or test-supplied sentinels where behavioral coverage is required

## Change type

- [ ] Installer / wrapper
- [ ] Extension / skill / prompt / theme
- [ ] Docs
- [ ] CI / release
- [ ] Pin PR (update a `config/default-extensions.json` fork tag)
- [x] Other: test maintenance

## Validation

**Standard validation (most changes):**

```sh
npm run validate
```

Result: PASS (exit status 0).

Focused validation across the five changed test files: 85 tests passed.

## Pre-review checklist

- [x] Change preserves isolation and installer safety invariants:
  - never mutates `~/.pi/agent` (the user's normal Pi configuration)
  - all installer-created Pi commands set `PI_CODING_AGENT_DIR` to the isolated profile directory
  - settings merges are conservative: append missing packages, respect opt-outs, preserve existing isolated-user values, back up before writes
  - does not clobber unmanaged wrapper files without an explicit `--force`
- [x] Relevant tests or smoke checks pass
- [x] Docs and `CHANGELOG.md` updated where a user-visible change warrants it (not warranted: test-only cleanup)
- [x] Diff contains no secrets, local paths, or unintended generated files

---

## Install this branch

```sh
curl -fsSL https://raw.githubusercontent.com/diegopetrucci/the-last-harness/test/remove-prompt-wording-assertions/install.sh | bash -s -- --ref test/remove-prompt-wording-assertions --track ref
```
